### PR TITLE
refactor external database to use an existing secret

### DIFF
--- a/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
+++ b/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
@@ -39,7 +39,7 @@ spec:
               type: object
             databaseType:
               properties:
-                externalDatabase:
+                externalDatabaseSecret:
                   description: If the user want to use an external DB. This can be
                     inside the same k8s cluster or outside like AWS RDS.
                   type: string

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -33,7 +33,7 @@ type DatabaseType struct {
 	Type string `json:"type,omitempty"`
 	// If the user want to use an external DB.
 	// This can be inside the same k8s cluster or outside like AWS RDS.
-	ExternalDatabase string `json:"externalDatabase,omitempty"`
+	ExternalDatabaseSecret string `json:"externalDatabaseSecret,omitempty"`
 }
 
 // ClusterInstallationStatus defines the observed state of ClusterInstallation

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -135,11 +135,10 @@ func (mattermost *ClusterInstallation) GenerateDeployment(dbUser, dbPassword str
 	}
 
 	if externalDB {
-		secretName := fmt.Sprintf("%s-externalDB", mattermost.Name)
 		envVarDB.ValueFrom = &corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
-					Name: secretName,
+					Name: mattermost.Spec.DatabaseType.ExternalDatabaseSecret,
 				},
 				Key: "externalDB",
 			},

--- a/pkg/controller/clusterinstallation/controller.go
+++ b/pkg/controller/clusterinstallation/controller.go
@@ -2,7 +2,6 @@ package clusterinstallation
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -124,43 +123,34 @@ func (r *ReconcileClusterInstallation) Reconcile(request reconcile.Request) (rec
 		return reconcile.Result{}, err
 	}
 
-	if mattermost.Spec.DatabaseType.ExternalDatabase != "" {
-		reqLogger.Info("Reconciling ClusterInstallation External Database secret")
-		secretName := fmt.Sprintf("%s-externalDB", mattermost.Name)
-		err = r.checkMattermostSecret(secretName, "externalDB", mattermost.Spec.DatabaseType.ExternalDatabase, mattermost, reqLogger)
+	switch mattermost.Spec.DatabaseType.Type {
+	case "mysql":
+		reqLogger.Info("Reconciling ClusterInstallation MySQL service account")
+		err = r.checkMySQLServiceAccount(mattermost, reqLogger)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-	} else {
-		switch mattermost.Spec.DatabaseType.Type {
-		case "mysql":
-			reqLogger.Info("Reconciling ClusterInstallation MySQL service account")
-			err = r.checkMySQLServiceAccount(mattermost, reqLogger)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
 
-			reqLogger.Info("Reconciling ClusterInstallation MySQL role binding")
-			err = r.checkMySQLRoleBinding(mattermost, reqLogger)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-
-			reqLogger.Info("Reconciling ClusterInstallation MySQL")
-			err = r.checkMySQLDeployment(mattermost, reqLogger)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-		case "postgres":
-			reqLogger.Info("Reconciling ClusterInstallation Postgres")
-			err = r.checkDBPostgresDeployment(mattermost, reqLogger)
-			if err != nil {
-				return reconcile.Result{}, err
-			}
-		case "default":
-			errInvalid := errors.NewInvalid(mattermostv1alpha1.SchemeGroupVersion.WithKind("ClusterInstallation").GroupKind(), "Database type invalid", nil)
-			return reconcile.Result{}, errInvalid
+		reqLogger.Info("Reconciling ClusterInstallation MySQL role binding")
+		err = r.checkMySQLRoleBinding(mattermost, reqLogger)
+		if err != nil {
+			return reconcile.Result{}, err
 		}
+
+		reqLogger.Info("Reconciling ClusterInstallation MySQL")
+		err = r.checkMySQLDeployment(mattermost, reqLogger)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	case "postgres":
+		reqLogger.Info("Reconciling ClusterInstallation Postgres")
+		err = r.checkDBPostgresDeployment(mattermost, reqLogger)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	case "default":
+		errInvalid := errors.NewInvalid(mattermostv1alpha1.SchemeGroupVersion.WithKind("ClusterInstallation").GroupKind(), "Database type invalid", nil)
+		return reconcile.Result{}, errInvalid
 	}
 
 	err = r.checkMinioDeployment(mattermost, reqLogger)

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -37,14 +37,14 @@ func (r *ReconcileClusterInstallation) checkMattermostDeployment(mattermost *mat
 	externalDB := false
 	dbPassword := ""
 	dbUser := ""
-	var err error
 	if mattermost.Spec.DatabaseType.ExternalDatabaseSecret != "" {
 		err := r.checkSecret(mattermost.Spec.DatabaseType.ExternalDatabaseSecret, mattermost.Namespace)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Error getting the external database secret.")
 		}
 		externalDB = true
 	} else {
+		var err error
 		dbPassword, err = r.getMySQLSecrets(mattermost, reqLogger)
 		if err != nil {
 			return errors.Wrap(err, "Error getting the database password.")

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -38,7 +38,11 @@ func (r *ReconcileClusterInstallation) checkMattermostDeployment(mattermost *mat
 	dbPassword := ""
 	dbUser := ""
 	var err error
-	if mattermost.Spec.DatabaseType.ExternalDatabase != "" {
+	if mattermost.Spec.DatabaseType.ExternalDatabaseSecret != "" {
+		err := r.checkSecret(mattermost.Spec.DatabaseType.ExternalDatabaseSecret, mattermost.Namespace)
+		if err != nil {
+			return err
+		}
 		externalDB = true
 	} else {
 		dbPassword, err = r.getMySQLSecrets(mattermost, reqLogger)

--- a/pkg/controller/clusterinstallation/secrets.go
+++ b/pkg/controller/clusterinstallation/secrets.go
@@ -1,11 +1,25 @@
 package clusterinstallation
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 )
 
 func (r *ReconcileClusterInstallation) checkMattermostSecret(secretName, keyName, data string, mattermost *mattermostv1alpha1.ClusterInstallation, reqLogger logr.Logger) error {
 	return r.createSecretIfNotExists(mattermost, mattermost.GenerateSecret(secretName, keyName, data), reqLogger)
+}
+
+func (r *ReconcileClusterInstallation) checkSecret(secretName, namespace string) error {
+	foundSecret := &corev1.Secret{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: namespace}, foundSecret)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/controller/clusterinstallation/secrets.go
+++ b/pkg/controller/clusterinstallation/secrets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -18,7 +19,7 @@ func (r *ReconcileClusterInstallation) checkSecret(secretName, namespace string)
 	foundSecret := &corev1.Secret{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: namespace}, foundSecret)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error getting secret")
 	}
 
 	return nil


### PR DESCRIPTION
After the implementation https://mattermost.atlassian.net/browse/MM-14982, I think a bit more and looked other operators.

and when you need to set some external information the user is responsible to create the configmap or the secret.
In our case make sense to have a secret instead of setting the DNS (which contains passwords/user) directly in the manifest.