### PR TITLE
[MM-15110 | MM-15111] Migrate operator from zap to logrus logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1367,6 +1367,8 @@
     "github.com/operator-framework/operator-sdk/pkg/test/e2eutil",
     "github.com/operator-framework/operator-sdk/version",
     "github.com/oracle/mysql-operator/pkg/apis/mysql/v1alpha1",
+    "github.com/pkg/errors",
+    "github.com/sirupsen/logrus",
     "github.com/spf13/pflag",
     "github.com/stretchr/testify/assert",
     "golang.org/x/net/context",

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,135 @@
+package log
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	log "github.com/sirupsen/logrus"
+)
+
+type logrusLogger struct {
+	l *log.Entry
+	infoLogger
+}
+
+type infoLogger struct {
+	l    *log.Entry
+	name string
+}
+
+// InitLogger returns a logrus-based logger wrapped in a logr.Logger interface.
+func InitLogger() logr.Logger {
+	logger := log.NewEntry(log.New())
+	return &logrusLogger{
+		l: logger,
+		infoLogger: infoLogger{
+			l:    logger,
+			name: "",
+		},
+	}
+}
+
+func (l *infoLogger) Enabled() bool { return true }
+func (l *infoLogger) Info(msg string, keysAndVals ...interface{}) {
+	fields := parseFields(l.l, l.name, keysAndVals)
+	l.l.WithFields(fields).Info(prependName(l.name, msg))
+}
+
+func (l *logrusLogger) Error(err error, msg string, keysAndVals ...interface{}) {
+	fields := parseFields(l.l, l.name, keysAndVals)
+	fields["err.ctx"] = msg
+	l.l.WithFields(fields).Error(prependName(l.name, err.Error()))
+}
+
+// TODO
+// The commented code below works, but in practice the operator logging quickly
+// gets set to 'fatal' and stops logging normally. This requires further
+// investigation. For now, the logging levels are not changed.
+func (l *logrusLogger) V(level int) logr.InfoLogger {
+	// Compare the given int to the list of all logrus levels. If the given value
+	// is below or above the range of logrus levels then we take the lowest or
+	// highest value respectively.
+	// logLevel := log.AllLevels[0]
+	// if level > 0 && level < (len(log.AllLevels)-1) {
+	// 	logLevel = log.AllLevels[level]
+	// } else if level > (len(log.AllLevels) - 1) {
+	// 	logLevel = log.AllLevels[(len(log.AllLevels) - 1)]
+	// }
+
+	// newLogger := newLogger(l)
+	// newLogger.l.Logger.SetLevel(logLevel)
+	// return &infoLogger{
+	// 	l:    newLogger.l,
+	// 	name: l.name,
+	// }
+
+	return &infoLogger{
+		l:    l.l,
+		name: l.name,
+	}
+}
+
+func (l *logrusLogger) WithValues(keysAndValues ...interface{}) logr.Logger {
+	newFieldLogger := l.l.WithFields(parseFields(l.l, l.name, keysAndValues))
+	newLogger := newLogger(l)
+	newLogger.l = newFieldLogger
+	newLogger.infoLogger.l = newFieldLogger
+
+	return newLogger
+}
+
+func (l *logrusLogger) WithName(name string) logr.Logger {
+	newLogger := newLogger(l)
+	newLogger.name = fmt.Sprintf("%s.%s", l.name, name)
+
+	return newLogger
+}
+
+func newLogger(l *logrusLogger) *logrusLogger {
+	return &logrusLogger{
+		l: l.l,
+		infoLogger: infoLogger{
+			l:    l.l,
+			name: l.name,
+		},
+	}
+}
+
+func parseFields(le *log.Entry, name string, args []interface{}) log.Fields {
+	fields := make(map[string]interface{})
+	if len(args) == 0 {
+		return fields
+	}
+
+	for i := 0; i < len(args); {
+		// Make sure we don't have an extra key with no value.
+		if i == len(args)-1 {
+			le.Error(errors.New(
+				prependName(name, "Logging key provided with no value; skipping"),
+			), "KeyParseError")
+			break
+		}
+
+		// Process a key value pair. If the key isn't a string then ignore and
+		// skip remaining args.
+		key, value := args[i], args[i+1]
+		keyStr, isString := key.(string)
+		if !isString {
+			le.Error(errors.New(
+				prependName(name,
+					fmt.Sprintf("logging key %v is not a string; skipping remaining values", key),
+				)), "KeyParseError")
+			break
+		}
+
+		fields[keyStr] = value
+		i += 2
+	}
+
+	return fields
+}
+
+func prependName(name, msg string) string {
+	return fmt.Sprintf("[%s] %s", name, msg)
+}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,92 @@
+package log
+
+import (
+	"fmt"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+var logrus = log.NewEntry(log.New())
+var defaultLogger = &logrusLogger{
+	l: logrus,
+	infoLogger: infoLogger{
+		l:    logrus,
+		name: "default",
+	},
+}
+
+func TestNewLogger(t *testing.T) {
+	newLogger := newLogger(defaultLogger)
+	assert.Equal(t, newLogger, defaultLogger)
+
+	// Change the newLogger and make sure the original isn't modified.
+	newLogger.name = "newName"
+	assert.NotEqual(t, newLogger, defaultLogger)
+}
+
+func TestEnabled(t *testing.T) {
+	logger := InitLogger()
+	assert.True(t, logger.Enabled())
+}
+
+func TestLevel(t *testing.T) {
+	levelTests := []int{-1000, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 100, 1000}
+	for _, level := range levelTests {
+		t.Run(fmt.Sprintf("level-%d", level), func(t *testing.T) {
+			logger := InitLogger()
+			assert.NotPanics(t, func() { logger.V(level) })
+		})
+	}
+}
+
+func TestParseFields(t *testing.T) {
+	var parseTests = []struct {
+		name     string
+		args     []string
+		expected log.Fields
+	}{
+		{
+			"noArgs",
+			[]string{},
+			make(map[string]interface{}),
+		}, {
+			"oneArgs",
+			[]string{"key1"},
+			make(map[string]interface{}),
+		}, {
+			"twoArgs",
+			[]string{"key1", "val1"},
+			map[string]interface{}{
+				"key1": "val1",
+			},
+		}, {
+			"threeArgs",
+			[]string{"key1", "val1", "key2"},
+			map[string]interface{}{
+				"key1": "val1",
+			},
+		}, {
+			"fourArgs",
+			[]string{"key1", "val1", "key2", "val2"},
+			map[string]interface{}{
+				"key1": "val1",
+				"key2": "val2",
+			},
+		},
+	}
+	for _, tt := range parseTests {
+		t.Run(tt.name, func(t *testing.T) {
+			var args []interface{}
+			for _, arg := range tt.args {
+				args = append(args, arg)
+			}
+			assert.Equal(
+				t,
+				parseFields(defaultLogger.l, tt.name, args),
+				tt.expected,
+			)
+		})
+	}
+}

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -9,7 +9,7 @@ run_ct_container() {
     docker run --rm --interactive --detach --network host --name test-cont \
         --volume "$(pwd):/go/src/github.com/mattermost/mattermost-operator" \
         --workdir "/go/src/github.com/mattermost/mattermost-operator" \
-        "golang:1.12.2" \
+        "golang:1.12.4" \
         cat
     echo
 }


### PR DESCRIPTION
This change wraps the logrus logger in a `logr.Logger` interface
so that it can be used by the mattermost operator packages. The
deferred logging in these packages requires this type of interface.

https://mattermost.atlassian.net/browse/MM-15110
https://mattermost.atlassian.net/browse/MM-15111
