### PR TITLE
[MM-15372] Enhanced state and upgrade support

### DIFF
--- a/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
+++ b/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
@@ -80,6 +80,9 @@ spec:
             Not included when requesting from the apiserver, only from the Mattermost
             Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
+            image:
+              description: The image running on the pods in the Mattermost instance
+              type: string
             replicas:
               description: Total number of non-terminated pods targeted by this Mattermost
                 deployment (their labels match the selector).

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -51,13 +51,16 @@ type DatabaseType struct {
 // RunningState is the state of the Mattermost instance
 type RunningState string
 
+// Running States:
+// Two types of instance running states are implemented: reconciling and stable.
+// If any changes are being made on the mattermost instance, the state will be
+// set to reconciling. If the reconcile loop reaches the end without requeuing
+// then the state will be set to stable.
 const (
-	// Creating is the state when the Mattermost instance is being created
-	Creating RunningState = "creating"
-	// Upgrading is the state when the Mattermost instance is being upgraded
-	Upgrading RunningState = "upgrading"
-	// Running is the state when the Mattermost instance is fully running
-	Running RunningState = "running"
+	// Reconciling is the state when the Mattermost instance is being updated
+	Reconciling RunningState = "reconciling"
+	// Stable is the state when the Mattermost instance is fully running
+	Stable RunningState = "stable"
 )
 
 // ClusterInstallationStatus defines the observed state of ClusterInstallation
@@ -72,6 +75,9 @@ type ClusterInstallationStatus struct {
 	// The version currently running in the Mattermost instance
 	// +optional
 	Version string `json:"version,omitempty"`
+	// The image running on the pods in the Mattermost instance
+	// +optional
+	Image string `json:"image,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -231,11 +231,11 @@ func (mattermost *ClusterInstallation) GenerateDeployment(dbUser, dbPassword str
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &mattermost.Spec.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{ClusterLabel: mattermost.Name},
+				MatchLabels: LabelsForClusterInstallation(mattermost.Name),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{ClusterLabel: mattermost.Name},
+					Labels: LabelsForClusterInstallation(mattermost.Name),
 				},
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{
@@ -279,4 +279,10 @@ func (mattermost *ClusterInstallation) GenerateSecret(secretName string, values 
 		},
 		Data: values,
 	}
+}
+
+// LabelsForClusterInstallation returns the labels for selecting the resources
+// belonging to the given mattermost clusterinstallation name.
+func LabelsForClusterInstallation(name string) map[string]string {
+	return map[string]string{"app": "mattermost", ClusterLabel: name}
 }

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -1,8 +1,15 @@
 package clusterinstallation
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 )
@@ -57,5 +64,67 @@ func (r *ReconcileClusterInstallation) checkMattermostDeployment(mattermost *mat
 		return errors.Wrap(err, "Error getting the minio service.")
 	}
 
-	return r.createDeploymentIfNotExists(mattermost, mattermost.GenerateDeployment(dbUser, dbPassword, externalDB, minioService), reqLogger)
+	deployment := mattermost.GenerateDeployment(dbUser, dbPassword, externalDB, minioService)
+	// TODO: Figure out why it's common to ignore errors here
+	_ = controllerutil.SetControllerReference(mattermost, deployment, r.scheme)
+	err = r.createDeploymentIfNotExists(mattermost, deployment, reqLogger)
+	if err != nil {
+		return err
+	}
+
+	foundDeployment := &appsv1.Deployment{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, foundDeployment)
+	if err != nil {
+		reqLogger.Error(err, "Failed to get mattermost deployment")
+		return err
+	}
+
+	err = r.updateMattermostDeployment(mattermost, foundDeployment, reqLogger)
+	if err != nil {
+		reqLogger.Error(err, "Failed to update mattermost deployment")
+		return err
+	}
+
+	return nil
+}
+
+// updateMattermostDeployment checks if the deployment should be updated.
+// If an update is required then the deployment spec is set to:
+// - roll forward version
+// - keep active MattermostInstallation available by setting maxUnavailable=N-1
+func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermostv1alpha1.ClusterInstallation, d *appsv1.Deployment, reqLogger logr.Logger) error {
+	var update bool
+
+	// Ensure deployment replicas is the same as the spec
+	if *d.Spec.Replicas != mi.Spec.Replicas {
+		d.Spec.Replicas = &mi.Spec.Replicas
+		update = true
+	}
+
+	// Look for mattermost container in pod spec and determine if the image
+	// needs to be updated.
+	for pos, container := range d.Spec.Template.Spec.Containers {
+		if container.Name == mi.Name {
+			image := fmt.Sprintf("%s:%s", mi.Spec.Image, mi.Spec.Version)
+			if container.Image != image {
+				container.Image = image
+				d.Spec.Template.Spec.Containers[pos] = container
+				update = true
+			}
+
+			break
+		}
+
+		// If we got here, something went wrong
+		return fmt.Errorf("Unable to find mattermost container in deployment")
+	}
+
+	if update {
+		mu := intstr.FromInt(int(mi.Spec.Replicas - 1))
+		d.Spec.Strategy.RollingUpdate.MaxUnavailable = &mu
+		reqLogger.Info("Updating deployment", "name", d.Name)
+		return r.client.Update(context.TODO(), d)
+	}
+
+	return nil
 }

--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -1,0 +1,77 @@
+package clusterinstallation
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// checkClusterInstallation checks the health and correctness of the k8s
+// objects that make up a MattermostInstallation.
+//
+// NOTE: this is a vital health check. Every reconciliation loop should run this
+// check at the very end to ensure that everything in the installation is as it
+// should be. Over time, more types of checks should be added here as needed.
+func (r *ReconcileClusterInstallation) checkClusterInstallation(mattermost *mattermostv1alpha1.ClusterInstallation) (*mattermostv1alpha1.ClusterInstallationStatus, error) {
+	pods := &v1.PodList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+	}
+	sel := mattermostv1alpha1.LabelsForClusterInstallation(mattermost.Name)
+	opts := &client.ListOptions{LabelSelector: labels.SelectorFromSet(sel)}
+
+	err := r.client.List(context.TODO(), opts, pods)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != v1.PodRunning || pod.DeletionTimestamp != nil {
+			return nil, fmt.Errorf("mattermost pod %q is terminating", pod.Name)
+		}
+		if len(pod.Spec.Containers) == 0 {
+			return nil, fmt.Errorf("mattermost pod %q has no containers", pod.Name)
+		}
+		expectedImage := fmt.Sprintf("%s:%s", mattermost.Spec.Image, mattermost.Spec.Version)
+		if pod.Spec.Containers[0].Image != expectedImage {
+			return nil, fmt.Errorf("mattermost pod %q is running incorrect version", pod.Name)
+		}
+	}
+
+	if int32(len(pods.Items)) != mattermost.Spec.Replicas {
+		return nil, fmt.Errorf("found %d pods, but wanted %d", len(pods.Items), mattermost.Spec.Replicas)
+	}
+
+	return &mattermostv1alpha1.ClusterInstallationStatus{
+		State:    mattermostv1alpha1.Stable,
+		Image:    mattermost.Spec.Image,
+		Version:  mattermost.Spec.Version,
+		Replicas: mattermost.Spec.Replicas,
+	}, nil
+}
+
+func (r *ReconcileClusterInstallation) updateStatus(mattermost *mattermostv1alpha1.ClusterInstallation, status mattermostv1alpha1.ClusterInstallationStatus, reqLogger logr.Logger) error {
+	if !reflect.DeepEqual(mattermost.Status, status) {
+		reqLogger.Info(fmt.Sprintf("Updating status"),
+			"Old", fmt.Sprintf("%+v", mattermost.Status),
+			"New", fmt.Sprintf("%+v", status),
+		)
+		mattermost.Status = status
+		err := r.client.Status().Update(context.TODO(), mattermost)
+		if err != nil {
+			reqLogger.Error(err, "failed to update the clusterinstallation status")
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This change introduces the following:
 - Full 'reconciling' and 'stable' state support
 - Final health and validity checks for the mattermost installation
   k8s objects
 - Initial upgrade support for mattermost versions
 - Support for updating deployment replica count
 - Minor logging bug fixes

Initial support for https://mattermost.atlassian.net/browse/MM-15372

Other Notes:
This should be considered initial mattermost upgrade support. While the swapping out of images works, I sporadically ran into issues with DB connectivity that should be looked into further.

Regardless, the improved state support in this PR will start to give us confidence that our installations are actually running correctly instead of just creating the k8s objects and crossing our fingers.