### PR TITLE
fixing the error message to the correct phase

### DIFF
--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -36,7 +36,7 @@ func (r *ReconcileClusterInstallation) checkClusterInstallation(mattermost *matt
 
 	for _, pod := range pods.Items {
 		if pod.Status.Phase != v1.PodRunning || pod.DeletionTimestamp != nil {
-			return nil, fmt.Errorf("mattermost pod %q is terminating", pod.Name)
+			return nil, fmt.Errorf("mattermost pod %q is %q", pod.Name, pod.Status.Phase)
 		}
 		if len(pod.Spec.Containers) == 0 {
 			return nil, fmt.Errorf("mattermost pod %q has no containers", pod.Name)


### PR DESCRIPTION
when scaling up or down or any other updates the error message that was using is not 100% correct because depends on the state and the `terminating ` is not correct.

Example, when scaling up it creates a new pod but the error shows terminating which is not true.

logs when the change is applied:
```
time="2019-05-17T08:42:18Z" level=error msg="[opr.kubebuilder.controller] mattermost pod \"test-579cc784d5-9htf4\" is \"Pending\"" controller=clusterinstallation err.ctx="Reconciler error" request=default/test
time="2019-05-17T08:42:23Z" level=info msg="[opr.clusterinstallation.controller] Reconciling ClusterInstallation" Request.Name=test Request.Namespace=default
```

this is a smal change to make more clear the message.