### PR TITLE
add service type loadbalancer

### DIFF
--- a/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
+++ b/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
@@ -16,6 +16,10 @@ spec:
     description: Version of Mattermost
     name: Version
     type: string
+  - JSONPath: .status.endpoint
+    description: Endpoint
+    name: Endpoint
+    type: string
   group: mattermost.com
   names:
     kind: ClusterInstallation
@@ -91,6 +95,12 @@ spec:
                 a ClusterInstallation resource
               format: int32
               type: integer
+            serviceAnnotations:
+              additionalProperties:
+                type: string
+              type: object
+            useServiceLoadBalancer:
+              type: boolean
             version:
               description: Version defines the ClusterInstallation Docker image version.
               type: string
@@ -102,6 +112,9 @@ spec:
             Not included when requesting from the apiserver, only from the Mattermost
             Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status'
           properties:
+            endpoint:
+              description: The endpoint to access the Mattermost instance
+              type: string
             image:
               description: The image running on the pods in the Mattermost instance
               type: string

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -41,6 +41,12 @@ type ClusterInstallationSpec struct {
 
 	// +optional
 	ElasticSearch ElasticSearch `json:"elasticSearch,omitempty"`
+
+	// +optional
+	UseServiceLoadBalancer bool `json:"useServiceLoadBalancer,omitempty"`
+
+	// +optional
+	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 }
 
 // DatabaseType defines the Database configuration for a ClusterInstallation
@@ -90,6 +96,9 @@ type ClusterInstallationStatus struct {
 	// The image running on the pods in the Mattermost instance
 	// +optional
 	Image string `json:"image,omitempty"`
+	// The endpoint to access the Mattermost instance
+	// +optional
+	Endpoint string `json:"endpoint,omitempty"`
 }
 
 // +genclient
@@ -102,6 +111,7 @@ type ClusterInstallationStatus struct {
 // +kubebuilder:printcolumn:priority=0,name="State",type=string,JSONPath=".status.state",description="State of Mattermost"
 // +kubebuilder:printcolumn:priority=0,name="Image",type=string,JSONPath=".status.image",description="Image of Mattermost"
 // +kubebuilder:printcolumn:priority=0,name="Version",type=string,JSONPath=".status.version",description="Version of Mattermost"
+// +kubebuilder:printcolumn:priority=0,name="Endpoint",type=string,JSONPath=".status.endpoint",description="Endpoint"
 type ClusterInstallation struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object’s metadata. More info:

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -60,6 +60,46 @@ func (mattermost *ClusterInstallation) SetDefaults() error {
 
 // GenerateService returns the service for Mattermost
 func (mattermost *ClusterInstallation) GenerateService() *corev1.Service {
+	svcAnnotations := map[string]string{
+		"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+	}
+	if mattermost.Spec.UseServiceLoadBalancer {
+		for k, v := range mattermost.Spec.ServiceAnnotations {
+			svcAnnotations[k] = v
+		}
+		return &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:    ClusterInstallationLabels(mattermost.Name),
+				Name:      mattermost.Name,
+				Namespace: mattermost.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(mattermost, schema.GroupVersionKind{
+						Group:   SchemeGroupVersion.Group,
+						Version: SchemeGroupVersion.Version,
+						Kind:    "ClusterInstallation",
+					}),
+				},
+				Annotations: svcAnnotations,
+			},
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "https",
+						Port:       433,
+						TargetPort: intstr.FromString("app"),
+					},
+					{
+						Name:       "http",
+						Port:       80,
+						TargetPort: intstr.FromString("app"),
+					},
+				},
+				Selector: ClusterInstallationLabels(mattermost.Name),
+				Type:     corev1.ServiceTypeLoadBalancer,
+			},
+		}
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels:    ClusterInstallationLabels(mattermost.Name),
@@ -72,12 +112,15 @@ func (mattermost *ClusterInstallation) GenerateService() *corev1.Service {
 					Kind:    "ClusterInstallation",
 				}),
 			},
-			Annotations: map[string]string{
-				"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-			},
+			Annotations: svcAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Ports:     []corev1.ServicePort{{Port: 8065}},
+			Ports: []corev1.ServicePort{
+				{
+					Port:       8065,
+					TargetPort: intstr.FromString("app"),
+				},
+			},
 			Selector:  ClusterInstallationLabels(mattermost.Name),
 			ClusterIP: corev1.ClusterIPNone,
 		},
@@ -277,7 +320,7 @@ func (mattermost *ClusterInstallation) GenerateDeployment(dbUser, dbPassword str
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8065,
-									Name:          mattermost.Name,
+									Name:          "app",
 								},
 							},
 						},

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.deepcopy.go
@@ -103,6 +103,13 @@ func (in *ClusterInstallationSpec) DeepCopyInto(out *ClusterInstallationSpec) {
 	}
 	out.DatabaseType = in.DatabaseType
 	out.ElasticSearch = in.ElasticSearch
+	if in.ServiceAnnotations != nil {
+		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -133,6 +133,25 @@ func schema_pkg_apis_mattermost_v1alpha1_ClusterInstallationSpec(ref common.Refe
 							Ref: ref("github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.ElasticSearch"),
 						},
 					},
+					"useServiceLoadBalancer": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
+					"serviceAnnotations": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"ingressName"},
 			},

--- a/pkg/controller/clusterinstallation/controller.go
+++ b/pkg/controller/clusterinstallation/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -181,7 +182,7 @@ func (r *ReconcileClusterInstallation) Reconcile(request reconcile.Request) (rec
 	status, err := r.checkClusterInstallation(mattermost)
 	if err != nil {
 		r.setReconciling()
-		return reconcile.Result{}, err
+		return reconcile.Result{RequeueAfter: time.Second * 5}, err
 	}
 	err = r.updateStatus(mattermost, *status, reqLogger)
 	if err != nil {

--- a/pkg/controller/clusterinstallation/controller_test.go
+++ b/pkg/controller/clusterinstallation/controller_test.go
@@ -3,6 +3,7 @@ package clusterinstallation
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost-operator/pkg/apis"
 	logmo "github.com/mattermost/mattermost-operator/pkg/log"
@@ -73,7 +74,7 @@ func TestReconcile(t *testing.T) {
 	// not running yet.
 	res, err := r.Reconcile(req)
 	require.Error(t, err)
-	require.Equal(t, res, reconcile.Result{})
+	require.Equal(t, res, reconcile.Result{RequeueAfter: time.Second * 5})
 
 	// Define the NamespacedName objects that will be used to lookup the
 	// cluster resources.

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -59,6 +59,21 @@ func (r *ReconcileClusterInstallation) checkMattermostService(mattermost *matter
 		update = true
 	}
 
+	// If we are using the loadBalancer the ClusterIp is imutable
+	// and other fields are created in the first time
+	if mattermost.Spec.UseServiceLoadBalancer {
+		service.Spec.ClusterIP = foundService.Spec.ClusterIP
+		service.Spec.ExternalTrafficPolicy = foundService.Spec.ExternalTrafficPolicy
+		service.Spec.SessionAffinity = foundService.Spec.SessionAffinity
+		for _, foundPort := range foundService.Spec.Ports {
+			for i, servicePort := range service.Spec.Ports {
+				if foundPort.Name == servicePort.Name {
+					service.Spec.Ports[i].NodePort = foundPort.NodePort
+					service.Spec.Ports[i].Protocol = foundPort.Protocol
+				}
+			}
+		}
+	}
 	if !reflect.DeepEqual(service.Spec, foundService.Spec) {
 		reqLogger.Info("Updating mattermost service spec")
 		foundService.Spec = service.Spec

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -59,7 +59,7 @@ func (r *ReconcileClusterInstallation) checkMattermostService(mattermost *matter
 		update = true
 	}
 
-	// If we are using the loadBalancer the ClusterIp is imutable
+	// If we are using the loadBalancer the ClusterIp is immutable
 	// and other fields are created in the first time
 	if mattermost.Spec.UseServiceLoadBalancer {
 		service.Spec.ClusterIP = foundService.Spec.ClusterIP

--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -69,7 +69,7 @@ func (r *ReconcileClusterInstallation) checkClusterInstallation(mattermost *matt
 			return nil, fmt.Errorf("should return just one service but returned %d", len(svc.Items))
 		}
 		if svc.Items[0].Status.LoadBalancer.Ingress == nil {
-			return nil, fmt.Errorf("waiting for the Load Balancers be active")
+			return nil, fmt.Errorf("waiting for the Load Balancers to be active")
 		}
 		if svc.Items[0].Status.LoadBalancer.Ingress[0].Hostname != "" {
 			mmEndpoint = svc.Items[0].Status.LoadBalancer.Ingress[0].Hostname

--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -9,7 +9,7 @@ import (
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,7 +23,7 @@ import (
 // check at the very end to ensure that everything in the installation is as it
 // should be. Over time, more types of checks should be added here as needed.
 func (r *ReconcileClusterInstallation) checkClusterInstallation(mattermost *mattermostv1alpha1.ClusterInstallation) (*mattermostv1alpha1.ClusterInstallationStatus, error) {
-	pods := &v1.PodList{
+	pods := &corev1.PodList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
@@ -38,7 +38,7 @@ func (r *ReconcileClusterInstallation) checkClusterInstallation(mattermost *matt
 	}
 
 	for _, pod := range pods.Items {
-		if pod.Status.Phase != v1.PodRunning || pod.DeletionTimestamp != nil {
+		if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
 			return nil, fmt.Errorf("mattermost pod %s is in state '%s'", pod.Name, pod.Status.Phase)
 		}
 		if len(pod.Spec.Containers) == 0 {
@@ -53,11 +53,52 @@ func (r *ReconcileClusterInstallation) checkClusterInstallation(mattermost *matt
 		return nil, fmt.Errorf("found %d pods, but wanted %d", len(pods.Items), mattermost.Spec.Replicas)
 	}
 
+	var mmEndpoint string
+	if mattermost.Spec.UseServiceLoadBalancer {
+		svc := &corev1.ServiceList{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1",
+			},
+		}
+		err := r.client.List(context.TODO(), opts, svc)
+		if err != nil {
+			return nil, err
+		}
+		if len(svc.Items) > 1 {
+			return nil, fmt.Errorf("should return just one service but returned %d", len(svc.Items))
+		}
+		if svc.Items[0].Status.LoadBalancer.Ingress == nil {
+			return nil, fmt.Errorf("waiting for the Load Balancers be active")
+		}
+		if svc.Items[0].Status.LoadBalancer.Ingress[0].Hostname != "" {
+			mmEndpoint = svc.Items[0].Status.LoadBalancer.Ingress[0].Hostname
+		} else if svc.Items[0].Status.LoadBalancer.Ingress[0].IP != "" {
+			mmEndpoint = svc.Items[0].Status.LoadBalancer.Ingress[0].IP
+		}
+	} else {
+		ingress := &v1beta1.IngressList{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Ingress",
+				APIVersion: "v1",
+			},
+		}
+		err := r.client.List(context.TODO(), opts, ingress)
+		if err != nil {
+			return nil, err
+		}
+		if len(ingress.Items) > 1 {
+			return nil, fmt.Errorf("should return just one ingress but returned %d", len(ingress.Items))
+		}
+		mmEndpoint = ingress.Items[0].Spec.Rules[0].Host
+	}
+
 	return &mattermostv1alpha1.ClusterInstallationStatus{
 		State:    mattermostv1alpha1.Stable,
 		Image:    mattermost.Spec.Image,
 		Version:  mattermost.Spec.Version,
 		Replicas: mattermost.Spec.Replicas,
+		Endpoint: mmEndpoint,
 	}, nil
 }
 

--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -53,7 +53,7 @@ func (r *ReconcileClusterInstallation) checkClusterInstallation(mattermost *matt
 		return nil, fmt.Errorf("found %d pods, but wanted %d", len(pods.Items), mattermost.Spec.Replicas)
 	}
 
-	var mmEndpoint string
+	mmEndpoint := "not available"
 	if mattermost.Spec.UseServiceLoadBalancer {
 		svc := &corev1.ServiceList{
 			TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
We can use Ingress (then need to install an ingress controller) or now we can use a service type Loadbalancer, it will create a loadbalancer and assign the MM pods to receive the traffic.

Also added this information in the get the installation

for example, if you have a ingress it will return the DNS name like
```bash
$ kubectl get clusterinstallation test
NAME   STATE    IMAGE                                      VERSION   ENDPOINT
test   stable   mattermost/mattermost-enterprise-edition   5.11.0    demo.cpanato.spinmint.com
```

if using the loadbalancer will return the hostname for the ELB in AWS or the IP in the case of Azure
```bash
$ kubectl get clusterinstallation test
NAME   STATE    IMAGE                                      VERSION   ENDPOINT
test   stable   mattermost/mattermost-enterprise-edition   5.11.0    52.232.125.219
```