### PR TITLE
[MM-16031] Add liveness probe to mattermost deployment

### DIFF
--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -323,6 +323,17 @@ func (mattermost *ClusterInstallation) GenerateDeployment(dbUser, dbPassword str
 									Name:          "app",
 								},
 							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/api/v4/system/ping",
+										Port: intstr.FromInt(8065),
+									},
+								},
+								InitialDelaySeconds: 10,
+								PeriodSeconds:       5,
+								FailureThreshold:    6,
+							},
 							LivenessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
 									HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -323,6 +323,17 @@ func (mattermost *ClusterInstallation) GenerateDeployment(dbUser, dbPassword str
 									Name:          "app",
 								},
 							},
+							LivenessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/api/v4/system/ping",
+										Port: intstr.FromInt(8065),
+									},
+								},
+								InitialDelaySeconds: 10,
+								PeriodSeconds:       10,
+								FailureThreshold:    3,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
This probe checks that the `/api/v4/system/ping` endpoint is alive
and responding.

Fixes https://mattermost.atlassian.net/browse/MM-16031

Note: in the future we probably want to add header checks which will allow us to also confirm that arbitrary values are correct: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request