### PR TITLE
[MM-15977] Enhance mattermost version change behavior

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: mattermost-operator
       containers:
         - name: mattermost-operator
-          image: mattermost/mattermost-operator:latest
+          image: mattermost/mattermost-operator:test
           command:
           - mattermost-operator
           imagePullPolicy: IfNotPresent

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -107,3 +107,14 @@ rules:
   - "*"
   verbs:
   - "*"
+- apiGroups:
+  - "batch"
+  resources:
+  - jobs
+  verbs:
+  - get
+  - create
+  - list
+  - delete
+  - watch
+  - update

--- a/docs/mattermost-operator/mattermost-operator.yaml
+++ b/docs/mattermost-operator/mattermost-operator.yaml
@@ -61,6 +61,10 @@ spec:
               type: object
             databaseType:
               properties:
+                dbStorageSize:
+                  description: Defines the storage size for the database. ie 50Gi
+                  pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                  type: string
                 externalDatabaseSecret:
                   description: If the user want to use an external DB. This can be
                     inside the same k8s cluster or outside like AWS RDS.
@@ -87,6 +91,7 @@ spec:
             minioStorageSize:
               description: MinioStorageSize defines the storage size for minio. ie
                 50Gi
+              pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
               type: string
             nodeSelector:
               additionalProperties:
@@ -252,6 +257,17 @@ rules:
   - "*"
   verbs:
   - "*"
+- apiGroups:
+  - "batch"
+  resources:
+  - jobs
+  verbs:
+  - get
+  - create
+  - list
+  - delete
+  - watch
+  - update
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -283,7 +299,7 @@ spec:
       serviceAccountName: mattermost-operator
       containers:
         - name: mattermost-operator
-          image: mattermost/mattermost-operator:latest
+          image: mattermost/mattermost-operator:test
           command:
           - mattermost-operator
           imagePullPolicy: IfNotPresent

--- a/pkg/controller/clusterinstallation/mattermost_test.go
+++ b/pkg/controller/clusterinstallation/mattermost_test.go
@@ -11,6 +11,7 @@ import (
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	logmo "github.com/mattermost/mattermost-operator/pkg/log"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,6 +100,19 @@ func TestCheckMattermost(t *testing.T) {
 	})
 
 	t.Run("deployment", func(t *testing.T) {
+		updateName := "mattermost-image-update-check"
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      updateName,
+				Namespace: ci.GetNamespace(),
+			},
+			Status: batchv1.JobStatus{
+				Succeeded: 1,
+			},
+		}
+		err := r.client.Create(context.TODO(), job)
+		require.NoError(t, err)
+
 		err = r.checkMattermostDeployment(ci, logger)
 		assert.NoError(t, err)
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -38,8 +38,7 @@ func (l *infoLogger) Info(msg string, keysAndVals ...interface{}) {
 
 func (l *logrusLogger) Error(err error, msg string, keysAndVals ...interface{}) {
 	fields := parseFields(l.l, l.name, keysAndVals)
-	fields["err.ctx"] = msg
-	l.l.WithFields(fields).Error(prependName(l.name, err.Error()))
+	l.l.WithFields(fields).WithError(err).Error(prependName(l.name, msg))
 }
 
 // TODO


### PR DESCRIPTION
This change includes improvements to the ability of the operator
to move between mattermost versions. The operator will now run
a job of the requested image version in order to perform any
database migrations that may be required. If those complete
successfully then the deployment will be updated to use the new
mattermost image as well.

This change also improves logging and corrects an issue with `e2e`
tests not running the correct operator image.

Fixes https://mattermost.atlassian.net/browse/MM-15977