### PR TITLE
[MM-15595] Enhance status reporting

### DIFF
--- a/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
+++ b/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
@@ -125,12 +125,17 @@ spec:
               type: string
             replicas:
               description: Total number of non-terminated pods targeted by this Mattermost
-                deployment (their labels match the selector).
+                deployment
               format: int32
               type: integer
             state:
               description: Represents the running state of the Mattermost instance
               type: string
+            updatedReplicas:
+              description: Total number of non-terminated pods targeted by this Mattermost
+                deployment that are running with the desired image.
+              format: int32
+              type: integer
             version:
               description: The version currently running in the Mattermost instance
               type: string

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: mattermost-operator
       containers:
         - name: mattermost-operator
-          image: mattermost/mattermost-operator:latest
+          image: mattermost/mattermost-operator:test
           command:
           - mattermost-operator
           imagePullPolicy: IfNotPresent

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -91,10 +91,6 @@ type ClusterInstallationStatus struct {
 	// Represents the running state of the Mattermost instance
 	// +optional
 	State RunningState `json:"state,omitempty"`
-	// Total number of non-terminated pods targeted by this Mattermost deployment
-	// (their labels match the selector).
-	// +optional
-	Replicas int32 `json:"replicas,omitempty"`
 	// The version currently running in the Mattermost instance
 	// +optional
 	Version string `json:"version,omitempty"`
@@ -104,6 +100,13 @@ type ClusterInstallationStatus struct {
 	// The endpoint to access the Mattermost instance
 	// +optional
 	Endpoint string `json:"endpoint,omitempty"`
+	// Total number of non-terminated pods targeted by this Mattermost deployment
+	// +optional
+	Replicas int32 `json:"replicas,omitempty"`
+	// Total number of non-terminated pods targeted by this Mattermost deployment
+	// that are running with the desired image.
+	// +optional
+	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
 }
 
 // +genclient

--- a/pkg/controller/clusterinstallation/controller.go
+++ b/pkg/controller/clusterinstallation/controller.go
@@ -182,9 +182,10 @@ func (r *ReconcileClusterInstallation) Reconcile(request reconcile.Request) (rec
 	status, err := r.checkClusterInstallation(mattermost)
 	if err != nil {
 		r.setReconciling()
-		return reconcile.Result{RequeueAfter: time.Second * 5}, err
+		r.updateStatus(mattermost, status, reqLogger)
+		return reconcile.Result{RequeueAfter: time.Second * 3}, err
 	}
-	err = r.updateStatus(mattermost, *status, reqLogger)
+	err = r.updateStatus(mattermost, status, reqLogger)
 	if err != nil {
 		r.setReconciling()
 		return reconcile.Result{}, err

--- a/pkg/controller/clusterinstallation/controller_test.go
+++ b/pkg/controller/clusterinstallation/controller_test.go
@@ -74,7 +74,7 @@ func TestReconcile(t *testing.T) {
 	// not running yet.
 	res, err := r.Reconcile(req)
 	require.Error(t, err)
-	require.Equal(t, res, reconcile.Result{RequeueAfter: time.Second * 5})
+	require.Equal(t, res, reconcile.Result{RequeueAfter: time.Second * 3})
 
 	// Define the NamespacedName objects that will be used to lookup the
 	// cluster resources.


### PR DESCRIPTION
This change allows the operator to report status of cluster
installations more often during reconciliation. Also, the status
reported now includes a new value for the number of updated
replicas that are running. This can be compared against the total
number of pods targeted by the operator.

https://mattermost.atlassian.net/browse/MM-15595