### PR TITLE
[MM-16721] Add object matcher to check the mm deployment 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -73,6 +73,14 @@
   version = "1.0.0"
 
 [[projects]]
+  digest = "1:46dd90a1970c3922902d0e9a5cbd93fc180d53d4d6d73b1f48795600316f8376"
+  name = "github.com/banzaicloud/k8s-objectmatcher"
+  packages = ["patch"]
+  pruneopts = "NT"
+  revision = "1596e84aae2764cab454a32215e756bbbee3af5d"
+  version = "v0.1.1"
+
+[[projects]]
   branch = "master"
   digest = "1:c819830f4f5ef85874a90ac3cbcc96cd322c715f5c96fbe4722eacd3dafbaa07"
   name = "github.com/beorn7/perks"
@@ -322,6 +330,14 @@
   pruneopts = "NT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
+
+[[projects]]
+  digest = "1:cfc5b2c22306eb2edbdce2850686525aa037415d7b67bf1293db0dbd013d5723"
+  name = "github.com/goph/emperror"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "ae59d9fdc3f0c4814bc5fac2d4a68441dcff5a17"
+  version = "v0.17.1"
 
 [[projects]]
   branch = "master"
@@ -1015,6 +1031,7 @@
     "pkg/util/framer",
     "pkg/util/intstr",
     "pkg/util/json",
+    "pkg/util/jsonmergepatch",
     "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
@@ -1277,6 +1294,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/banzaicloud/k8s-objectmatcher/patch",
     "github.com/go-logr/logr",
     "github.com/go-openapi/spec",
     "github.com/minio/minio-operator/pkg/apis/miniocontroller/v1beta1",

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -376,6 +376,10 @@ func (mattermost *ClusterInstallation) GenerateDeployment(dbUser, dbPassword str
 	envVars = append(envVars, envVarGeneral...)
 
 	revHistoryLimit := int32(5)
+	maxUnavailable := intstr.FromInt(int(mattermost.Spec.Replicas - 1))
+	if mattermost.Spec.Replicas == 1 {
+		maxUnavailable = intstr.FromInt(1)
+	}
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -394,7 +398,7 @@ func (mattermost *ClusterInstallation) GenerateDeployment(dbUser, dbPassword str
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateDeployment{
-					MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+					MaxUnavailable: &maxUnavailable,
 				},
 			},
 			RevisionHistoryLimit: &revHistoryLimit,

--- a/pkg/controller/clusterinstallation/controller_test.go
+++ b/pkg/controller/clusterinstallation/controller_test.go
@@ -38,6 +38,7 @@ func TestReconcile(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ciName,
 			Namespace: ciNamespace,
+			UID:       types.UID("test"),
 		},
 		Spec: mattermostv1alpha1.ClusterInstallationSpec{
 			Replicas:    replicas,

--- a/pkg/controller/clusterinstallation/create_resources.go
+++ b/pkg/controller/clusterinstallation/create_resources.go
@@ -3,6 +3,7 @@ package clusterinstallation
 import (
 	"context"
 
+	objectMatcher "github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -23,6 +24,13 @@ type Object interface {
 
 // createResource creates the provided resource and sets the owner
 func (r *ReconcileClusterInstallation) createResource(owner v1.Object, resource Object, reqLogger logr.Logger) error {
+	// adding the last applied annotation to use the object matcher later
+	// see: https://github.com/banzaicloud/k8s-objectmatcher
+	errMatcher := objectMatcher.DefaultAnnotator.SetLastAppliedAnnotation(resource)
+	if errMatcher != nil {
+		reqLogger.Error(errMatcher, "Error applying the annotation in the resource")
+		return errMatcher
+	}
 	err := r.client.Create(context.TODO(), resource)
 	if err != nil {
 		reqLogger.Error(err, "Error creating resource")

--- a/pkg/controller/clusterinstallation/create_resources.go
+++ b/pkg/controller/clusterinstallation/create_resources.go
@@ -26,12 +26,12 @@ type Object interface {
 func (r *ReconcileClusterInstallation) createResource(owner v1.Object, resource Object, reqLogger logr.Logger) error {
 	// adding the last applied annotation to use the object matcher later
 	// see: https://github.com/banzaicloud/k8s-objectmatcher
-	errMatcher := objectMatcher.DefaultAnnotator.SetLastAppliedAnnotation(resource)
-	if errMatcher != nil {
-		reqLogger.Error(errMatcher, "Error applying the annotation in the resource")
-		return errMatcher
+	err := objectMatcher.DefaultAnnotator.SetLastAppliedAnnotation(resource)
+	if err != nil {
+		reqLogger.Error(err, "Error applying the annotation in the resource")
+		return err
 	}
-	err := r.client.Create(context.TODO(), resource)
+	err = r.client.Create(context.TODO(), resource)
 	if err != nil {
 		reqLogger.Error(err, "Error creating resource")
 		return err

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"time"
 
+	objectMatcher "github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -15,7 +16,6 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 )
@@ -192,24 +192,20 @@ func (r *ReconcileClusterInstallation) checkMattermostDeployment(mattermost *mat
 // If an update is required then the deployment spec is set to:
 // - roll forward version
 // - keep active MattermostInstallation available by setting maxUnavailable=N-1
-func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermostv1alpha1.ClusterInstallation, original, d *appsv1.Deployment, reqLogger logr.Logger) error {
+func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermostv1alpha1.ClusterInstallation, modified, original *appsv1.Deployment, reqLogger logr.Logger) error {
 	var update bool
 
 	// Look for mattermost container in pod spec and determine if the image
 	// needs to be updated.
 	image := mi.GetImageName()
-	for pos, container := range d.Spec.Template.Spec.Containers {
+	for _, container := range original.Spec.Template.Spec.Containers {
 		if container.Name == mi.Name {
 			if container.Image != image {
-				reqLogger.Info("Updating mattermost deployment pod image")
-				container.Image = image
-				d.Spec.Template.Spec.Containers[pos] = container
+				reqLogger.Info("Current image is not the same as the requested, will upgrade the Mattermost installation")
 				update = true
 			}
-
 			break
 		}
-
 		// If we got here, something went wrong
 		return fmt.Errorf("Unable to find mattermost container in deployment")
 	}
@@ -288,28 +284,19 @@ func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermost
 		}
 	}
 
-	// Ensure deployment replicas is the same as the spec
-	if *d.Spec.Replicas != mi.Spec.Replicas {
-		reqLogger.Info("Updating mattermost deployment replica count")
-		d.Spec.Replicas = &mi.Spec.Replicas
-		update = true
+	patchResult, err := objectMatcher.DefaultPatchMaker.Calculate(original, modified)
+	if err != nil {
+		reqLogger.Error(err, "Error checking the difference in the deployment")
+		return err
 	}
 
-	updatedLabels := ensureLabels(mattermostv1alpha1.ClusterInstallationLabels(mi.Name), d.Labels)
-	if !reflect.DeepEqual(updatedLabels, d.Labels) {
-		reqLogger.Info("Updating mattermost deployment labels")
-		update = true
-		d.Labels = updatedLabels
-	}
-
-	if update {
-		mu := intstr.FromInt(int(mi.Spec.Replicas - 1))
-		if d.Spec.Strategy.RollingUpdate == nil {
-			d.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{}
+	if !patchResult.IsEmpty() {
+		errMatcher := objectMatcher.DefaultAnnotator.SetLastAppliedAnnotation(modified)
+		if errMatcher != nil {
+			reqLogger.Error(errMatcher, "Error applying the annotation in the deployment")
+			return errMatcher
 		}
-		d.Spec.Strategy.RollingUpdate.MaxUnavailable = &mu
-
-		return r.client.Update(context.TODO(), d)
+		return r.client.Update(context.TODO(), modified)
 	}
 
 	return nil

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -192,7 +192,7 @@ func (r *ReconcileClusterInstallation) checkMattermostDeployment(mattermost *mat
 // If an update is required then the deployment spec is set to:
 // - roll forward version
 // - keep active MattermostInstallation available by setting maxUnavailable=N-1
-func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermostv1alpha1.ClusterInstallation, modified, original *appsv1.Deployment, reqLogger logr.Logger) error {
+func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermostv1alpha1.ClusterInstallation, new, original *appsv1.Deployment, reqLogger logr.Logger) error {
 	var update bool
 
 	// Look for mattermost container in pod spec and determine if the image
@@ -284,19 +284,19 @@ func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermost
 		}
 	}
 
-	patchResult, err := objectMatcher.DefaultPatchMaker.Calculate(original, modified)
+	patchResult, err := objectMatcher.DefaultPatchMaker.Calculate(original, new)
 	if err != nil {
 		reqLogger.Error(err, "Error checking the difference in the deployment")
 		return err
 	}
 
 	if !patchResult.IsEmpty() {
-		errMatcher := objectMatcher.DefaultAnnotator.SetLastAppliedAnnotation(modified)
-		if errMatcher != nil {
-			reqLogger.Error(errMatcher, "Error applying the annotation in the deployment")
-			return errMatcher
+		err := objectMatcher.DefaultAnnotator.SetLastAppliedAnnotation(new)
+		if err != nil {
+			reqLogger.Error(err, "Error applying the annotation in the deployment")
+			return err
 		}
-		return r.client.Update(context.TODO(), modified)
+		return r.client.Update(context.TODO(), new)
 	}
 
 	return nil

--- a/pkg/controller/clusterinstallation/mattermost_test.go
+++ b/pkg/controller/clusterinstallation/mattermost_test.go
@@ -34,6 +34,7 @@ func TestCheckMattermost(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ciName,
 			Namespace: ciNamespace,
+			UID:       types.UID("test"),
 		},
 		Spec: mattermostv1alpha1.ClusterInstallationSpec{
 			Replicas:    replicas,

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/LICENSE
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/NOTICE
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/NOTICE
@@ -1,0 +1,6 @@
+Copyright © 2019 Banzai Cloud
+
+Portions of this software were developed in the Kubernetes project: https://github.com/kubernetes/kubernetes
+
+The source file patch/annotation.go is based on https://github.com/kubernetes/kubernetes/blob/3d0c961d57bb90c112a0ee2f5ccdcb5c8570ad32/pkg/kubectl/apply.go
+The source file patch/deletenull.go is based on https://github.com/kubernetes/kubernetes/blob/433b448e8d42da70df5d50f4ce667bcb36aeeec2/staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch/patch.go

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/clusterrole.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/clusterrole.go
@@ -1,0 +1,63 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type clusterRoleMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewClusterRoleMatcher(objectMatcher ObjectMatcher) *clusterRoleMatcher {
+	return &clusterRoleMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two rbacv1.ClusterRole objects
+func (m clusterRoleMatcher) Match(old, new *rbacv1.ClusterRole) (bool, error) {
+	type ClusterRole struct {
+		ObjectMeta
+		Rules []rbacv1.PolicyRule `json:"rules"`
+	}
+
+	oldData, err := json.Marshal(ClusterRole{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Rules:      old.Rules,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := ClusterRole{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Rules:      new.Rules,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/clusterrolebinding.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/clusterrolebinding.go
@@ -1,0 +1,72 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kubernetesrbacv1 "k8s.io/kubernetes/pkg/apis/rbac/v1"
+)
+
+type clusterRoleBindingMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewClusterRoleBindingMatcher(objectMatcher ObjectMatcher) *clusterRoleBindingMatcher {
+	return &clusterRoleBindingMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two rbacv1.ClusterRoleBinding objects
+func (m clusterRoleBindingMatcher) Match(oldOrig, newOrig *rbacv1.ClusterRoleBinding) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	kubernetesrbacv1.SetObjectDefaults_ClusterRoleBinding(new)
+
+	type ClusterRoleBinding struct {
+		ObjectMeta
+		Subjects []rbacv1.Subject `json:"subjects,omitempty"`
+		RoleRef  rbacv1.RoleRef   `json:"roleRef"`
+	}
+
+	oldData, err := json.Marshal(ClusterRoleBinding{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Subjects:   old.Subjects,
+		RoleRef:    old.RoleRef,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := ClusterRoleBinding{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Subjects:   new.Subjects,
+		RoleRef:    new.RoleRef,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/configmap.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/configmap.go
@@ -1,0 +1,72 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+)
+
+type configMapMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewConfigMapMatcher(objectMatcher ObjectMatcher) *configMapMatcher {
+	return &configMapMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two corev1.ConfigMap objects
+func (m configMapMatcher) Match(oldOrig, newOrig *corev1.ConfigMap) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	v1.SetObjectDefaults_ConfigMap(new)
+
+	type ConfigMap struct {
+		ObjectMeta
+		Data       map[string]string `json:"data"`
+		BinaryData map[string][]byte `json:"binaryData"`
+	}
+
+	oldData, err := json.Marshal(ConfigMap{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Data:       old.Data,
+		BinaryData: old.BinaryData,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newConfigMap := ConfigMap{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Data:       new.Data,
+		BinaryData: new.BinaryData,
+	}
+	newData, err := json.Marshal(newConfigMap)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newConfigMap)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/crd.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/crd.go
@@ -1,0 +1,75 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	extensionsobj "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+type crdMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewCRDMatcher(objectMatcher ObjectMatcher) *crdMatcher {
+	return &crdMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two extensionsobj.CustomResourceDefinition objects
+func (m crdMatcher) Match(oldOrig, newOrig *extensionsobj.CustomResourceDefinition) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	extensionsobj.SetObjectDefaults_CustomResourceDefinition(new)
+
+	if old.Spec.AdditionalPrinterColumns == nil && newOrig.Spec.AdditionalPrinterColumns == nil {
+		new.Spec.AdditionalPrinterColumns = nil
+	}
+	if old.Spec.Versions == nil && newOrig.Spec.Versions == nil {
+		new.Spec.Versions = nil
+	}
+
+	type CRD struct {
+		ObjectMeta
+		Spec extensionsobj.CustomResourceDefinitionSpec
+	}
+
+	oldData, err := json.Marshal(CRD{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := CRD{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/daemonset.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/daemonset.go
@@ -1,0 +1,69 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/kubernetes/pkg/apis/apps/v1"
+)
+
+type daemonSetMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewDaemonSetMatcher(objectMatcher ObjectMatcher) *daemonSetMatcher {
+	return &daemonSetMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two appsv1.ClusterDaemonSet objects
+func (m daemonSetMatcher) Match(oldOrig, newOrig *appsv1.DaemonSet) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	v1.SetObjectDefaults_DaemonSet(new)
+
+	type DaemonSet struct {
+		ObjectMeta
+		Spec appsv1.DaemonSetSpec
+	}
+
+	oldData, err := json.Marshal(DaemonSet{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := DaemonSet{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/deployment.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/deployment.go
@@ -1,0 +1,72 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/kubernetes/pkg/apis/apps/v1"
+)
+
+type deploymentMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewDeploymentMatcher(objectMatcher ObjectMatcher) *deploymentMatcher {
+	return &deploymentMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two appsv1.Deployment objects
+func (m deploymentMatcher) Match(oldOrig, newOrig *appsv1.Deployment) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	v1.SetObjectDefaults_Deployment(new)
+
+	type Deployment struct {
+		ObjectMeta
+		Spec appsv1.DeploymentSpec
+	}
+
+	delete(old.ObjectMeta.Annotations, "deployment.kubernetes.io/revision")
+	delete(old.ObjectMeta.Annotations, "control-plane.alpha.kubernetes.io/leader")
+
+	oldData, err := json.Marshal(Deployment{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := Deployment{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/hpa.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/hpa.go
@@ -1,0 +1,69 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	autoscalev2beta1 "k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/kubernetes/pkg/apis/autoscaling/v2beta1"
+)
+
+type horizontalPodAutoscalerMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewHorizontalPodAutoscalerMatcher(objectMatcher ObjectMatcher) *horizontalPodAutoscalerMatcher {
+	return &horizontalPodAutoscalerMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two autoscalev2beta1.HorizontalPodAutoscaler objects
+func (m horizontalPodAutoscalerMatcher) Match(oldOrig, newOrig *autoscalev2beta1.HorizontalPodAutoscaler) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	v2beta1.SetObjectDefaults_HorizontalPodAutoscaler(new)
+
+	type HorizontalPodAutoscaler struct {
+		ObjectMeta
+		Spec autoscalev2beta1.HorizontalPodAutoscalerSpec
+	}
+
+	oldData, err := json.Marshal(HorizontalPodAutoscaler{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := HorizontalPodAutoscaler{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/mutatingwebhook.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/mutatingwebhook.go
@@ -1,0 +1,112 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/kubernetes/pkg/apis/admissionregistration/v1beta1"
+)
+
+type mutatingWebhookConfigurationMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewMutatingWebhookConfigurationMatcher(objectMatcher ObjectMatcher) *mutatingWebhookConfigurationMatcher {
+	return &mutatingWebhookConfigurationMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two admissionv1beta1.MutatingWebhookConfiguration objects
+func (m mutatingWebhookConfigurationMatcher) Match(oldOrig, newOrig *admissionv1beta1.MutatingWebhookConfiguration) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	v1beta1.SetObjectDefaults_MutatingWebhookConfiguration(new)
+
+	nullUnsupportedFields(old.Webhooks, newOrig.Webhooks, new.Webhooks)
+
+	type MutatingWebhookConfiguration struct {
+		ObjectMeta
+		Webhooks []admissionv1beta1.Webhook `json:"webhooks,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	}
+
+	old.Webhooks = nullCABundleConditionally(old.Webhooks, new.Webhooks)
+
+	oldData, err := json.Marshal(MutatingWebhookConfiguration{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Webhooks:   old.Webhooks,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+
+	newObject := MutatingWebhookConfiguration{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Webhooks:   new.Webhooks,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}
+
+// nullUnsupportedFields nils specific fields that were not yet present in previous apiserver versions
+func nullUnsupportedFields(oldWebhooks, newWebhooks []admissionv1beta1.Webhook, newWebhooksWithDefaults []admissionv1beta1.Webhook) {
+	for i, wh := range oldWebhooks {
+		nwh := getWebhookByName(wh.Name, newWebhooks)
+		owh := getWebhookByName(wh.Name, oldWebhooks)
+		if nwh != nil && owh != nil {
+			if nwh.SideEffects == nil && owh.SideEffects == nil {
+				newWebhooksWithDefaults[i].SideEffects = nil
+			}
+		}
+	}
+}
+
+// nullCABundleConditionally nils ClientConfig.CABundle value in the old object if it is nil in the new to avoid conflict
+func nullCABundleConditionally(oldWebhooks, newWebhooks []admissionv1beta1.Webhook) []admissionv1beta1.Webhook {
+	for i, wh := range oldWebhooks {
+		nwh := getWebhookByName(wh.Name, newWebhooks)
+		if nwh == nil || nwh.ClientConfig.CABundle != nil {
+			continue
+		}
+		wh.ClientConfig.CABundle = nil
+		oldWebhooks[i] = wh
+	}
+
+	return oldWebhooks
+}
+
+// getWebhookByName gets webhook from webhooks by its name
+func getWebhookByName(name string, webhooks []admissionv1beta1.Webhook) *admissionv1beta1.Webhook {
+	for _, webhook := range webhooks {
+		if webhook.Name == name {
+			return &webhook
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/node.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/node.go
@@ -1,0 +1,71 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	v1 "k8s.io/api/core/v1"
+	kubernetescorev1 "k8s.io/kubernetes/pkg/apis/core/v1"
+)
+
+type nodeMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewNodeMatcher(objectMatcher ObjectMatcher) *nodeMatcher {
+	return &nodeMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+func (m nodeMatcher) Match(oldOrig, newOrig *v1.Node) (bool, error) {
+
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	kubernetescorev1.SetObjectDefaults_Node(new)
+
+	type Node struct {
+		ObjectMeta
+		Spec v1.NodeSpec
+	}
+
+	oldData, err := json.Marshal(Node{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+
+	newObject := Node{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/objectmatch.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/objectmatch.go
@@ -1,0 +1,340 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+	"reflect"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/go-logr/logr"
+	"github.com/goph/emperror"
+	"github.com/pkg/errors"
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalev2beta1 "k8s.io/api/autoscaling/v2beta1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	extensionsobj "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+type ObjectMatcher interface {
+	Match(old, new interface{}) (bool, error)
+	GetObjectMeta(objectMeta metav1.ObjectMeta) ObjectMeta
+	MatchJSON(old, new []byte, obj interface{}) (bool, error)
+}
+
+type objectMatcher struct {
+	logger logr.Logger
+}
+
+func New(logger logr.Logger) ObjectMatcher {
+	return &objectMatcher{
+		logger: logger,
+	}
+}
+
+func (om *objectMatcher) Match(old, new interface{}) (bool, error) {
+	if reflect.TypeOf(old) != reflect.TypeOf(new) {
+		return false, emperror.With(errors.New("old and new object types mismatch"), "oldType", reflect.TypeOf(old), "newType", reflect.TypeOf(new))
+	}
+
+	switch old.(type) {
+	default:
+		return false, nil
+	case *unstructured.Unstructured:
+		oldObject := old.(*unstructured.Unstructured)
+		newObject := new.(*unstructured.Unstructured)
+
+		m := NewUnstructuredMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *corev1.ServiceAccount:
+		oldObject := old.(*corev1.ServiceAccount)
+		newObject := new.(*corev1.ServiceAccount)
+
+		m := NewServiceAccountMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *rbacv1.ClusterRole:
+		oldObject := old.(*rbacv1.ClusterRole)
+		newObject := new.(*rbacv1.ClusterRole)
+
+		m := NewClusterRoleMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *rbacv1.ClusterRoleBinding:
+		oldObject := old.(*rbacv1.ClusterRoleBinding)
+		newObject := new.(*rbacv1.ClusterRoleBinding)
+
+		m := NewClusterRoleBindingMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *appsv1.Deployment:
+		oldObject := old.(*appsv1.Deployment)
+		newObject := new.(*appsv1.Deployment)
+
+		m := NewDeploymentMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *corev1.Service:
+		oldObject := old.(*corev1.Service)
+		newObject := new.(*corev1.Service)
+
+		m := NewServiceMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *corev1.Pod:
+		oldObject := old.(*corev1.Pod)
+		newObject := new.(*corev1.Pod)
+
+		m := NewPodMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *corev1.PersistentVolumeClaim:
+		oldObject := old.(*corev1.PersistentVolumeClaim)
+		newObject := new.(*corev1.PersistentVolumeClaim)
+
+		m := NewPvcMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *corev1.ConfigMap:
+		oldObject := old.(*corev1.ConfigMap)
+		newObject := new.(*corev1.ConfigMap)
+
+		m := NewConfigMapMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *extensionsobj.CustomResourceDefinition:
+		oldObject := old.(*extensionsobj.CustomResourceDefinition)
+		newObject := new.(*extensionsobj.CustomResourceDefinition)
+
+		m := NewCRDMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *autoscalev2beta1.HorizontalPodAutoscaler:
+		oldObject := old.(*autoscalev2beta1.HorizontalPodAutoscaler)
+		newObject := new.(*autoscalev2beta1.HorizontalPodAutoscaler)
+
+		m := NewHorizontalPodAutoscalerMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *admissionv1beta1.MutatingWebhookConfiguration:
+		oldObject := old.(*admissionv1beta1.MutatingWebhookConfiguration)
+		newObject := new.(*admissionv1beta1.MutatingWebhookConfiguration)
+
+		m := NewMutatingWebhookConfigurationMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *policyv1beta1.PodDisruptionBudget:
+		oldObject := old.(*policyv1beta1.PodDisruptionBudget)
+		newObject := new.(*policyv1beta1.PodDisruptionBudget)
+
+		m := NewPodDisruptionBudgetMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *appsv1.DaemonSet:
+		oldObject := old.(*appsv1.DaemonSet)
+		newObject := new.(*appsv1.DaemonSet)
+
+		m := NewDaemonSetMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *rbacv1.Role:
+		oldObject := old.(*rbacv1.Role)
+		newObject := new.(*rbacv1.Role)
+
+		m := NewRoleMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *rbacv1.RoleBinding:
+		oldObject := old.(*rbacv1.RoleBinding)
+		newObject := new.(*rbacv1.RoleBinding)
+
+		m := NewRoleBindingMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	case *corev1.Node:
+		oldObject := old.(*corev1.Node)
+		newObject := new.(*corev1.Node)
+
+		m := NewNodeMatcher(om)
+		ok, err := m.Match(oldObject, newObject)
+		if err != nil {
+			return false, errors.WithStack(err)
+		}
+		return ok, nil
+	}
+}
+
+type ObjectMeta struct {
+	Labels          map[string]string       `json:"labels,omitempty"`
+	Annotations     map[string]string       `json:"annotations,omitempty"`
+	OwnerReferences []metav1.OwnerReference `json:"ownerReferences,omitempty"`
+}
+
+func (om *objectMatcher) GetObjectMeta(objectMeta metav1.ObjectMeta) ObjectMeta {
+	if len(objectMeta.Annotations) == 0 {
+		objectMeta.Annotations = make(map[string]string)
+	}
+
+	if len(objectMeta.Labels) == 0 {
+		objectMeta.Labels = make(map[string]string)
+	}
+
+	return ObjectMeta{
+		Labels:          objectMeta.Labels,
+		Annotations:     objectMeta.Annotations,
+		OwnerReferences: objectMeta.OwnerReferences,
+	}
+}
+
+func (om *objectMatcher) MatchJSON(old, new []byte, obj interface{}) (bool, error) {
+	var patch []byte
+	var err error
+
+	_, unstructed := obj.(*unstructured.Unstructured)
+	if unstructed {
+		patch, err = jsonpatch.CreateMergePatch(old, new)
+		if err != nil {
+			return false, emperror.Wrap(err, "could not create json merge patch")
+		}
+	} else {
+		patch, err = strategicpatch.CreateTwoWayMergePatch(old, new, obj)
+		if err != nil {
+			return false, emperror.Wrap(err, "could not create two way merge patch")
+		}
+	}
+
+	patch, _, err = om.deleteNullInJsonPatch(patch)
+	if err != nil {
+		return false, emperror.Wrap(err, "could not remove nil values from json merge patch")
+	}
+
+	if string(patch) == "{}" {
+		return true, nil
+	}
+
+	om.logger.V(1).Info("objects differs", "diff", string(patch), "old", string(old), "new", string(new))
+
+	return false, nil
+}
+
+func (om *objectMatcher) deleteNullInJsonPatch(patch []byte) ([]byte, map[string]interface{}, error) {
+	var patchMap map[string]interface{}
+
+	err := json.Unmarshal(patch, &patchMap)
+	if err != nil {
+		return nil, nil, emperror.Wrap(err, "could not unmarshal json patch")
+	}
+
+	filteredMap, err := om.deleteNullInObj(patchMap)
+	if err != nil {
+		return nil, nil, emperror.Wrap(err, "could not delete null values from patch map")
+	}
+
+	o, err := json.Marshal(filteredMap)
+	if err != nil {
+		return nil, nil, emperror.Wrap(err, "could not marshal filtered patch map")
+	}
+
+	return o, filteredMap, err
+}
+
+func (om *objectMatcher) deleteNullInObj(m map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	filteredMap := make(map[string]interface{})
+
+	for key, val := range m {
+		if val == nil {
+			continue
+		}
+
+		switch typedVal := val.(type) {
+		default:
+			return nil, errors.Errorf("unknown type: %v", reflect.TypeOf(typedVal))
+		case []interface{}, string, float64, bool, int64, nil:
+			filteredMap[key] = val
+		case map[string]interface{}:
+			if len(typedVal) == 0 {
+				filteredMap[key] = typedVal
+				continue
+			}
+
+			var filteredSubMap map[string]interface{}
+			filteredSubMap, err = om.deleteNullInObj(typedVal)
+			if err != nil {
+				return nil, emperror.Wrap(err, "could not delete null values from filtered sub map")
+			}
+
+			if len(filteredSubMap) != 0 {
+				filteredMap[key] = filteredSubMap
+			}
+		}
+	}
+	return filteredMap, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/patch/annotation.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/patch/annotation.go
@@ -1,0 +1,149 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch
+
+import (
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const LastAppliedConfig = "banzaicloud.com/last-applied"
+
+var DefaultAnnotator = NewAnnotator(LastAppliedConfig)
+
+type Annotator struct {
+	metadataAccessor meta.MetadataAccessor
+	key              string
+}
+
+func NewAnnotator(key string) *Annotator {
+	return &Annotator{
+		key:              key,
+		metadataAccessor: meta.NewAccessor(),
+	}
+}
+
+// GetOriginalConfiguration retrieves the original configuration of the object
+// from the annotation, or nil if no annotation was found.
+func (a *Annotator) GetOriginalConfiguration(obj runtime.Object) ([]byte, error) {
+	annots, err := a.metadataAccessor.Annotations(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annots == nil {
+		return nil, nil
+	}
+
+	original, ok := annots[a.key]
+	if !ok {
+		return nil, nil
+	}
+
+	return []byte(original), nil
+}
+
+// SetOriginalConfiguration sets the original configuration of the object
+// as the annotation on the object for later use in computing a three way patch.
+func (a *Annotator) SetOriginalConfiguration(obj runtime.Object, original []byte) error {
+	if len(original) < 1 {
+		return nil
+	}
+
+	annots, err := a.metadataAccessor.Annotations(obj)
+	if err != nil {
+		return err
+	}
+
+	if annots == nil {
+		annots = map[string]string{}
+	}
+
+	annots[a.key] = string(original)
+	return a.metadataAccessor.SetAnnotations(obj, annots)
+}
+
+// GetModifiedConfiguration retrieves the modified configuration of the object.
+// If annotate is true, it embeds the result as an annotation in the modified
+// configuration. If an object was read from the command input, it will use that
+// version of the object. Otherwise, it will use the version from the server.
+func (a *Annotator) GetModifiedConfiguration(obj runtime.Object, annotate bool) ([]byte, error) {
+	// First serialize the object without the annotation to prevent recursion,
+	// then add that serialization to it as the annotation and serialize it again.
+	var modified []byte
+
+	// Otherwise, use the server side version of the object.
+	// Get the current annotations from the object.
+	annots, err := a.metadataAccessor.Annotations(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annots == nil {
+		annots = map[string]string{}
+	}
+
+	original := annots[a.key]
+	delete(annots, a.key)
+	if err := a.metadataAccessor.SetAnnotations(obj, annots); err != nil {
+		return nil, err
+	}
+
+	// Do not include an empty annotation map
+	if len(annots) == 0 {
+		a.metadataAccessor.SetAnnotations(obj, nil)
+	}
+	modified, err = json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if annotate {
+		annots[a.key] = string(modified)
+		if err := a.metadataAccessor.SetAnnotations(obj, annots); err != nil {
+			return nil, err
+		}
+
+		modified, err = json.Marshal(obj)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Restore the object to its original condition.
+	annots[a.key] = original
+	if err := a.metadataAccessor.SetAnnotations(obj, annots); err != nil {
+		return nil, err
+	}
+
+	return modified, nil
+}
+
+// SetLastAppliedAnnotation gets the modified configuration of the object,
+// without embedding it again, and then sets it on the object as the annotation.
+func (a *Annotator) SetLastAppliedAnnotation(obj runtime.Object) error {
+	modified, err := a.GetModifiedConfiguration(obj, false)
+	if err != nil {
+		return err
+	}
+	// Remove nulls from json
+	modifiedWithoutNulls, _, err := DeleteNullInJson(modified)
+	if err != nil {
+		return err
+	}
+	return a.SetOriginalConfiguration(obj, modifiedWithoutNulls)
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/patch/deletenull.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/patch/deletenull.go
@@ -1,0 +1,133 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/goph/emperror"
+	"github.com/pkg/errors"
+)
+
+func DeleteNullInJson(jsonBytes []byte) ([]byte, map[string]interface{}, error) {
+	var patchMap map[string]interface{}
+
+	err := json.Unmarshal(jsonBytes, &patchMap)
+	if err != nil {
+		return nil, nil, emperror.Wrap(err, "could not unmarshal json patch")
+	}
+
+	filteredMap, err := deleteNullInObj(patchMap)
+	if err != nil {
+		return nil, nil, emperror.Wrap(err, "could not delete null values from patch map")
+	}
+
+	o, err := json.Marshal(filteredMap)
+	if err != nil {
+		return nil, nil, emperror.Wrap(err, "could not marshal filtered patch map")
+	}
+
+	return o, filteredMap, err
+}
+
+func deleteNullInObj(m map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	filteredMap := make(map[string]interface{})
+
+	for key, val := range m {
+		if val == nil || isZero(reflect.ValueOf(val)) {
+			continue
+		}
+		switch typedVal := val.(type) {
+		default:
+			return nil, errors.Errorf("unknown type: %v", reflect.TypeOf(typedVal))
+		case []interface{}:
+			slice, err := deleteNullInSlice(typedVal)
+			if err != nil {
+				return nil, errors.Errorf("could not delete null values from subslice")
+			}
+			filteredMap[key] = slice
+		case string, float64, bool, int64, nil:
+			filteredMap[key] = val
+		case map[string]interface{}:
+			if len(typedVal) == 0 {
+				filteredMap[key] = typedVal
+				continue
+			}
+
+			var filteredSubMap map[string]interface{}
+			filteredSubMap, err = deleteNullInObj(typedVal)
+			if err != nil {
+				return nil, emperror.Wrap(err, "could not delete null values from filtered sub map")
+			}
+
+			if len(filteredSubMap) != 0 {
+				filteredMap[key] = filteredSubMap
+			}
+		}
+	}
+	return filteredMap, nil
+}
+
+func deleteNullInSlice(m []interface{}) ([]interface{}, error) {
+	filteredSlice := make([]interface{}, len(m))
+	for key, val := range m {
+		if val == nil {
+			continue
+		}
+		switch typedVal := val.(type) {
+		default:
+			return nil, errors.Errorf("unknown type: %v", reflect.TypeOf(typedVal))
+		case []interface{}:
+			filteredSubSlice, err := deleteNullInSlice(typedVal)
+			if err != nil {
+				return nil, errors.Errorf("could not delete null values from subslice")
+			}
+			filteredSlice[key] = filteredSubSlice
+		case string, float64, bool, int64, nil:
+			filteredSlice[key] = val
+		case map[string]interface{}:
+			filteredMap, err := deleteNullInObj(typedVal)
+			if err != nil {
+				return nil, emperror.Wrap(err, "could not delete null values from filtered sub map")
+			}
+			filteredSlice[key] = filteredMap
+		}
+	}
+	return filteredSlice, nil
+}
+
+func isZero(v reflect.Value) bool {
+	switch v.Kind() {
+	default:
+		z := reflect.Zero(v.Type())
+		return v.Interface() == z.Interface()
+	case reflect.Func, reflect.Map, reflect.Slice:
+		return v.IsNil()
+	case reflect.Array:
+		z := true
+		for i := 0; i < v.Len(); i++ {
+			z = z && isZero(v.Index(i))
+		}
+		return z
+	case reflect.Struct:
+		z := true
+		for i := 0; i < v.NumField(); i++ {
+			z = z && isZero(v.Field(i))
+		}
+		return z
+	}
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/patch/patch.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/patch/patch.go
@@ -1,0 +1,113 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/goph/emperror"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+var DefaultPatchMaker = NewPatchMaker(DefaultAnnotator)
+
+type PatchMaker struct {
+	annotator *Annotator
+}
+
+func NewPatchMaker(annotator *Annotator) *PatchMaker {
+	return &PatchMaker{
+		annotator: annotator,
+	}
+}
+
+func (p *PatchMaker) Calculate(currentObject, modifiedObject runtime.Object) (*PatchResult, error) {
+	current, err := json.Marshal(currentObject)
+	if err != nil {
+		return nil, emperror.Wrap(err, "Failed to convert current object to byte sequence")
+	}
+
+	modified, err := json.Marshal(modifiedObject)
+	if err != nil {
+		return nil, emperror.Wrap(err, "Failed to convert current object to byte sequence")
+	}
+
+	modified, _, err = DeleteNullInJson(modified)
+	if err != nil {
+		return nil, emperror.Wrap(err, "Failed to delete null from modified object")
+	}
+
+	original, err := p.annotator.GetOriginalConfiguration(currentObject)
+	if err != nil {
+		return nil, emperror.Wrap(err, "Failed to get original configuration")
+	}
+
+	var patch []byte
+
+	switch currentObject.(type) {
+	default:
+		lookupPatchMeta, err := strategicpatch.NewPatchMetaFromStruct(modifiedObject)
+		if err != nil {
+			return nil, emperror.WrapWith(err, "Failed to lookup patch meta", "current object", currentObject)
+		}
+		patch, err = strategicpatch.CreateThreeWayMergePatch(original, modified, current, lookupPatchMeta, true)
+		if err != nil {
+			return nil, emperror.Wrap(err, "Failed to generate strategic merge patch")
+		}
+		// $setElementOrder can make it hard to decide whether there is an actual diff or not.
+		// In cases like that trying to apply the patch locally on current will make it clear.
+		if string(patch) != "{}" {
+			patchCurrent, err := strategicpatch.StrategicMergePatch(current, patch, modifiedObject)
+			if err != nil {
+				return nil, emperror.Wrap(err, "Failed to apply patch again to check for an actual diff")
+			}
+			patch, err = strategicpatch.CreateTwoWayMergePatch(current, patchCurrent, modifiedObject)
+			if err != nil {
+				return nil, emperror.Wrap(err, "Failed to create patch again to check for an actual diff")
+			}
+		}
+	case *unstructured.Unstructured:
+		patch, err = jsonmergepatch.CreateThreeWayJSONMergePatch(original, modified, current)
+		if err != nil {
+			return nil, emperror.Wrap(err, "Failed to generate merge patch")
+		}
+	}
+
+	return &PatchResult{
+		Patch:    patch,
+		Current:  current,
+		Modified: modified,
+		Original: original,
+	}, nil
+}
+
+type PatchResult struct {
+	Patch    []byte
+	Current  []byte
+	Modified []byte
+	Original []byte
+}
+
+func (p *PatchResult) IsEmpty() bool {
+	return string(p.Patch) == "{}"
+}
+
+func (p *PatchResult) String() string {
+	return fmt.Sprintf("\nPatch: %s \nCurrent: %s\nModified: %s\nOriginal: %s\n", p.Patch, p.Current, p.Modified, p.Original)
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/pdb.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/pdb.go
@@ -1,0 +1,63 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+)
+
+type podDisruptionBudgetMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewPodDisruptionBudgetMatcher(objectMatcher ObjectMatcher) *podDisruptionBudgetMatcher {
+	return &podDisruptionBudgetMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two autoscalev2beta1.HorizontalPodAutoscaler objects
+func (m podDisruptionBudgetMatcher) Match(old, new *policyv1beta1.PodDisruptionBudget) (bool, error) {
+	type PodDisruptionBudgetMatcher struct {
+		ObjectMeta
+		Spec policyv1beta1.PodDisruptionBudgetSpec
+	}
+
+	oldData, err := json.Marshal(PodDisruptionBudgetMatcher{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := PodDisruptionBudgetMatcher{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/pod.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/pod.go
@@ -1,0 +1,109 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+	"strings"
+
+	v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+
+	"github.com/goph/emperror"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type podMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewPodMatcher(objectMatcher ObjectMatcher) *podMatcher {
+	return &podMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two corev1.Pod objects
+func (m podMatcher) Match(oldOrig, newOrig *corev1.Pod) (bool, error) {
+	old := oldOrig.DeepCopy()
+
+	new := newOrig.DeepCopy()
+	v1.SetObjectDefaults_Pod(new)
+
+	type Pod struct {
+		ObjectMeta
+		Spec corev1.PodSpec
+	}
+
+	generatedTokenName := ""
+	tmpVolume := []corev1.Volume{}
+	for _, volume := range old.Spec.Volumes {
+		if !strings.HasPrefix(volume.Name, old.Spec.ServiceAccountName+"-token-") {
+			tmpVolume = append(tmpVolume, volume)
+		} else {
+			generatedTokenName = volume.Name
+		}
+	}
+	old.Spec.Volumes = tmpVolume
+
+	tmpInitContainers := []corev1.Container{}
+	for _, initContainer := range old.Spec.InitContainers {
+		tmpVolumeMounts := []corev1.VolumeMount{}
+		for _, volumeMount := range initContainer.VolumeMounts {
+			if volumeMount.Name != generatedTokenName {
+				tmpVolumeMounts = append(tmpVolumeMounts, volumeMount)
+			}
+		}
+		initContainer.VolumeMounts = tmpVolumeMounts
+		tmpInitContainers = append(tmpInitContainers, initContainer)
+	}
+	old.Spec.InitContainers = tmpInitContainers
+
+	tmpContainers := []corev1.Container{}
+	for _, container := range old.Spec.Containers {
+		tmpVolumeMounts := []corev1.VolumeMount{}
+		for _, volumeMount := range container.VolumeMounts {
+			if volumeMount.Name != generatedTokenName {
+				tmpVolumeMounts = append(tmpVolumeMounts, volumeMount)
+			}
+		}
+		container.VolumeMounts = tmpVolumeMounts
+		tmpContainers = append(tmpContainers, container)
+	}
+	old.Spec.Containers = tmpContainers
+
+	oldData, err := json.Marshal(Pod{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := Pod{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/pvc.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/pvc.go
@@ -1,0 +1,80 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+)
+
+type pvcMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewPvcMatcher(objectMatcher ObjectMatcher) *pvcMatcher {
+	return &pvcMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two corev1.PersistentVolumeClaim objects
+func (m pvcMatcher) Match(oldOrig, newOrig *corev1.PersistentVolumeClaim) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	v1.SetObjectDefaults_PersistentVolumeClaim(new)
+
+	type Pvc struct {
+		ObjectMeta
+		Spec corev1.PersistentVolumeClaimSpec
+	}
+
+	if old.Spec.VolumeMode == nil && newOrig.Spec.VolumeMode == nil {
+		new.Spec.VolumeMode = nil
+	}
+
+	delete(new.ObjectMeta.Annotations, "volume.beta.kubernetes.io/storage-provisioner")
+	delete(new.ObjectMeta.Annotations, "pv.kubernetes.io/bind-completed")
+	delete(new.ObjectMeta.Annotations, "pv.kubernetes.io/bound-by-controller")
+
+	old.Spec.VolumeName = new.Spec.VolumeName
+
+	oldData, err := json.Marshal(Pvc{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := Pvc{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/role.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/role.go
@@ -1,0 +1,66 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+type roleMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewRoleMatcher(objectMatcher ObjectMatcher) *roleMatcher {
+	return &roleMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two rbacv1.ClusterRole objects
+func (m roleMatcher) Match(oldOrig, newOrig *rbacv1.Role) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	type Role struct {
+		ObjectMeta
+		Rules []rbacv1.PolicyRule `json:"rules"`
+	}
+
+	oldData, err := json.Marshal(Role{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Rules:      old.Rules,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := Role{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Rules:      new.Rules,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/rolebinding.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/rolebinding.go
@@ -1,0 +1,72 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	rbacv1 "k8s.io/api/rbac/v1"
+	v1 "k8s.io/kubernetes/pkg/apis/rbac/v1"
+)
+
+type roleBindingMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewRoleBindingMatcher(objectMatcher ObjectMatcher) *roleBindingMatcher {
+	return &roleBindingMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two rbacv1.RoleBinding objects
+func (m roleBindingMatcher) Match(oldOrig, newOrig *rbacv1.RoleBinding) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	v1.SetObjectDefaults_RoleBinding(new)
+
+	type RoleBinding struct {
+		ObjectMeta
+		Subjects []rbacv1.Subject `json:"subjects,omitempty"`
+		RoleRef  rbacv1.RoleRef   `json:"roleRef"`
+	}
+
+	oldData, err := json.Marshal(RoleBinding{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Subjects:   old.Subjects,
+		RoleRef:    old.RoleRef,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := RoleBinding{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Subjects:   new.Subjects,
+		RoleRef:    new.RoleRef,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/service.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/service.go
@@ -1,0 +1,86 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/kubernetes/pkg/apis/core/v1"
+)
+
+type serviceMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewServiceMatcher(objectMatcher ObjectMatcher) *serviceMatcher {
+	return &serviceMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two corev1.Service objects
+func (m serviceMatcher) Match(oldOrig, newOrig *corev1.Service) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	v1.SetObjectDefaults_Service(new)
+
+	type Service struct {
+		ObjectMeta
+		Spec corev1.ServiceSpec
+	}
+
+	// NodePort can be a generated value, avoid the diff by removing it if so
+	tmpPorts := []corev1.ServicePort{}
+	for i, port := range old.Spec.Ports {
+		if len(newOrig.Spec.Ports) > i && newOrig.Spec.Ports[i].NodePort == 0 && port.NodePort > 0 {
+			port.NodePort = 0
+			tmpPorts = append(tmpPorts, corev1.ServicePort{
+				Name:       port.Name,
+				Protocol:   port.Protocol,
+				Port:       port.Port,
+				TargetPort: port.TargetPort,
+			})
+		} else {
+			tmpPorts = append(tmpPorts, port)
+		}
+	}
+	old.Spec.Ports = tmpPorts
+
+	oldData, err := json.Marshal(Service{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+		Spec:       old.Spec,
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := Service{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+		Spec:       new.Spec,
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/serviceaccount.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/serviceaccount.go
@@ -1,0 +1,63 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type serviceAccountMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewServiceAccountMatcher(objectMatcher ObjectMatcher) *serviceAccountMatcher {
+	return &serviceAccountMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two corev1.ServiceAccount objects
+func (m serviceAccountMatcher) Match(oldOrig, newOrig *corev1.ServiceAccount) (bool, error) {
+	old := oldOrig.DeepCopy()
+	new := newOrig.DeepCopy()
+
+	type ServiceAccount struct {
+		ObjectMeta
+	}
+
+	oldData, err := json.Marshal(ServiceAccount{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(old.ObjectMeta),
+	})
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.Name)
+	}
+	newObject := ServiceAccount{
+		ObjectMeta: m.objectMatcher.GetObjectMeta(new.ObjectMeta),
+	}
+	newData, err := json.Marshal(newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.Name)
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, newObject)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.Name)
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/unstructured.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/unstructured.go
@@ -1,0 +1,51 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package objectmatch
+
+import (
+	"encoding/json"
+
+	"github.com/goph/emperror"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type unstructuredMatcher struct {
+	objectMatcher ObjectMatcher
+}
+
+func NewUnstructuredMatcher(objectMatcher ObjectMatcher) *unstructuredMatcher {
+	return &unstructuredMatcher{
+		objectMatcher: objectMatcher,
+	}
+}
+
+// Match compares two unstructured.Unstructured objects
+func (m unstructuredMatcher) Match(old, new *unstructured.Unstructured) (bool, error) {
+	oldData, err := json.Marshal(old)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal old object", "name", old.GetName())
+	}
+	newData, err := json.Marshal(new)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not marshal new object", "name", new.GetName())
+	}
+
+	matched, err := m.objectMatcher.MatchJSON(oldData, newData, new)
+	if err != nil {
+		return false, emperror.WrapWith(err, "could not match objects", "name", new.GetName())
+	}
+
+	return matched, nil
+}

--- a/vendor/github.com/goph/emperror/LICENSE
+++ b/vendor/github.com/goph/emperror/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 Márk Sági-Kazár <mark.sagikazar@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/goph/emperror/cause.go
+++ b/vendor/github.com/goph/emperror/cause.go
@@ -1,0 +1,26 @@
+package emperror
+
+// ForEachCause loops through an error chain and calls a function for each of them,
+// starting with the topmost one.
+//
+// The function can return false to break the loop before it ends.
+func ForEachCause(err error, fn func(err error) bool) {
+	// causer is the interface defined in github.com/pkg/errors for specifying a parent error.
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		continueLoop := fn(err)
+		if !continueLoop {
+			break
+		}
+
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+
+		err = cause.Cause()
+	}
+}

--- a/vendor/github.com/goph/emperror/context.go
+++ b/vendor/github.com/goph/emperror/context.go
@@ -1,0 +1,104 @@
+package emperror
+
+import (
+	"fmt"
+	"io"
+)
+
+// The implementation bellow is heavily influenced by go-kit's log context.
+
+// With returns a new error with keyvals context appended to it.
+// If the wrapped error is already a contextual error created by With
+// keyvals is appended to the existing context, but a new error is returned.
+func With(err error, keyvals ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	if len(keyvals) == 0 {
+		return err
+	}
+
+	var kvs []interface{}
+
+	// extract context from previous error
+	if c, ok := err.(*withContext); ok {
+		err = c.err
+
+		kvs = append(kvs, c.keyvals...)
+
+		if len(kvs)%2 != 0 {
+			kvs = append(kvs, nil)
+		}
+	}
+
+	kvs = append(kvs, keyvals...)
+
+	if len(kvs)%2 != 0 {
+		kvs = append(kvs, nil)
+	}
+
+	// Limiting the capacity of the stored keyvals ensures that a new
+	// backing array is created if the slice must grow in With.
+	// Using the extra capacity without copying risks a data race.
+	return &withContext{
+		err:     err,
+		keyvals: kvs[:len(kvs):len(kvs)],
+	}
+}
+
+// Context extracts the context key-value pairs from an error (or error chain).
+func Context(err error) []interface{} {
+	type contextor interface {
+		Context() []interface{}
+	}
+
+	var kvs []interface{}
+
+	ForEachCause(err, func(err error) bool {
+		if cerr, ok := err.(contextor); ok {
+			kvs = append(cerr.Context(), kvs...)
+		}
+
+		return true
+	})
+
+	return kvs
+}
+
+// withContext annotates an error with context.
+type withContext struct {
+	err     error
+	keyvals []interface{}
+}
+
+func (w *withContext) Error() string {
+	return w.err.Error()
+}
+
+// Context returns the appended keyvals.
+func (w *withContext) Context() []interface{} {
+	return w.keyvals
+}
+
+func (w *withContext) Cause() error {
+	return w.err
+}
+
+func (w *withContext) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = fmt.Fprintf(s, "%+v", w.Cause())
+			return
+		}
+
+		fallthrough
+
+	case 's':
+		_, _ = io.WriteString(s, w.Error())
+
+	case 'q':
+		_, _ = fmt.Fprintf(s, "%q", w.Error())
+	}
+}

--- a/vendor/github.com/goph/emperror/emperror.go
+++ b/vendor/github.com/goph/emperror/emperror.go
@@ -1,0 +1,2 @@
+// Package emperror provides error handling solutions and tools for libraries and applications.
+package emperror

--- a/vendor/github.com/goph/emperror/handler.go
+++ b/vendor/github.com/goph/emperror/handler.go
@@ -1,0 +1,9 @@
+package emperror
+
+// Handler is responsible for handling an error.
+//
+// This interface allows libraries to decouple from logging and error handling solutions.
+type Handler interface {
+	// Handle takes care of unhandled errors.
+	Handle(err error)
+}

--- a/vendor/github.com/goph/emperror/handler/airbrakehandler/handler.go
+++ b/vendor/github.com/goph/emperror/handler/airbrakehandler/handler.go
@@ -1,0 +1,71 @@
+// Package airbrakehandler provides Airbrake/Errbit integration.
+package airbrakehandler
+
+import (
+	"github.com/airbrake/gobrake"
+
+	"github.com/goph/emperror"
+	"github.com/goph/emperror/httperr"
+	"github.com/goph/emperror/internal/keyvals"
+)
+
+// Handler is responsible for sending errors to Airbrake/Errbit.
+type Handler struct {
+	notifier *gobrake.Notifier
+
+	sendSynchronously bool
+}
+
+// New creates a new handler.
+func New(projectID int64, projectKey string) *Handler {
+	return NewFromNotifier(gobrake.NewNotifier(projectID, projectKey))
+}
+
+// NewSync creates a new handler that sends errors synchronously.
+func NewSync(projectID int64, projectKey string) *Handler {
+	handler := New(projectID, projectKey)
+
+	handler.sendSynchronously = true
+
+	return handler
+}
+
+// NewFromNotifier creates a new handler from a notifier instance.
+func NewFromNotifier(notifier *gobrake.Notifier) *Handler {
+	handler := &Handler{
+		notifier: notifier,
+	}
+
+	return handler
+}
+
+// NewSyncFromNotifier creates a new handler from a notifier instance that sends errors synchronously.
+func NewSyncFromNotifier(notifier *gobrake.Notifier) *Handler {
+	handler := NewFromNotifier(notifier)
+
+	handler.sendSynchronously = true
+
+	return handler
+}
+
+// Handle sends the error to Airbrake/Errbit.
+func (h *Handler) Handle(err error) {
+	// Get HTTP request (if any)
+	req, _ := httperr.HTTPRequest(err)
+
+	notice := h.notifier.Notice(emperror.ExposeStackTrace(err), req, 1)
+
+	// Extract context from the error and attach it to the notice
+	notice.Params = keyvals.ToMap(emperror.Context(err))
+
+	if h.sendSynchronously {
+		_, _ = h.notifier.SendNotice(notice)
+	} else {
+		h.notifier.SendNoticeAsync(notice)
+	}
+}
+
+// Close closes the underlying notifier and waits for asynchronous reports to finish.
+func (h *Handler) Close() error {
+	return h.notifier.Close()
+}

--- a/vendor/github.com/goph/emperror/handler/bugsnaghandler/error.go
+++ b/vendor/github.com/goph/emperror/handler/bugsnaghandler/error.go
@@ -1,0 +1,47 @@
+package bugsnaghandler
+
+import (
+	berrors "github.com/bugsnag/bugsnag-go/errors"
+	"github.com/pkg/errors"
+)
+
+type stackTracer interface {
+	Error() string
+	StackTrace() errors.StackTrace
+}
+
+type errorWithStackFrames struct {
+	err stackTracer
+}
+
+// newErrorWithStackFrames returns a new error implementing the
+// github.com/bugsnag/bugsnag-go/errors.ErrorWithStackFrames interface.
+func newErrorWithStackFrames(err stackTracer) *errorWithStackFrames {
+	return &errorWithStackFrames{err}
+}
+
+// Error implements the error interface.
+func (e *errorWithStackFrames) Error() string {
+	return e.err.Error()
+}
+
+// Cause implements the github.com/pkg/errors.causer interface.
+func (e *errorWithStackFrames) Cause() error {
+	return e.err
+}
+
+// StackTrace implements the github.com/pkg/errors.stackTracer interface.
+func (e *errorWithStackFrames) StackTrace() errors.StackTrace {
+	return e.err.StackTrace()
+}
+
+func (e *errorWithStackFrames) StackFrames() []berrors.StackFrame {
+	stackTrace := e.err.StackTrace()
+	stackFrames := make([]berrors.StackFrame, len(stackTrace))
+
+	for i, frame := range stackTrace {
+		stackFrames[i] = berrors.NewStackFrame(uintptr(frame))
+	}
+
+	return stackFrames
+}

--- a/vendor/github.com/goph/emperror/handler/bugsnaghandler/handler.go
+++ b/vendor/github.com/goph/emperror/handler/bugsnaghandler/handler.go
@@ -1,0 +1,58 @@
+// Package bugsnaghandler provides Bugsnag integration.
+package bugsnaghandler
+
+import (
+	"reflect"
+
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/pkg/errors"
+
+	"github.com/goph/emperror"
+	"github.com/goph/emperror/internal/keyvals"
+)
+
+// Handler is responsible for sending errors to Bugsnag.
+type Handler struct {
+	notifier *bugsnag.Notifier
+}
+
+// New creates a new handler.
+func New(apiKey string) *Handler {
+	return NewFromNotifier(bugsnag.New(bugsnag.Configuration{
+		APIKey: apiKey,
+	}))
+}
+
+// NewFromNotifier creates a new handler from an existing notifier instance.
+func NewFromNotifier(notifier *bugsnag.Notifier) *Handler {
+	return &Handler{
+		notifier: notifier,
+	}
+}
+
+// Handle sends the error to Bugsnag.
+func (h *Handler) Handle(err error) {
+	// Expose the stackTracer interface on the outer error (if there is stack trace in the error)
+	// Convert error with stack trace to an internal error type
+	if e, ok := emperror.ExposeStackTrace(err).(stackTracer); ok {
+		err = newErrorWithStackFrames(e)
+	}
+
+	var rawData []interface{}
+
+	if cause := errors.Cause(err); cause != nil {
+		if name := reflect.TypeOf(cause).String(); len(name) > 0 {
+			errorClass := bugsnag.ErrorClass{Name: name}
+
+			rawData = append(rawData, errorClass)
+		}
+	}
+
+	if ctx := emperror.Context(err); len(ctx) > 0 {
+		rawData = append(rawData, bugsnag.MetaData{
+			"Params": keyvals.ToMap(ctx),
+		})
+	}
+
+	_ = h.notifier.Notify(err, rawData...)
+}

--- a/vendor/github.com/goph/emperror/handler/logrushandler/handler.go
+++ b/vendor/github.com/goph/emperror/handler/logrushandler/handler.go
@@ -1,0 +1,43 @@
+// Package logrushandler provides Logrus integration.
+package logrushandler
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/goph/emperror"
+	"github.com/goph/emperror/internal/keyvals"
+)
+
+// Handler logs errors using Logrus.
+type Handler struct {
+	logger logrus.FieldLogger
+}
+
+// New creates a new handler.
+func New(logger logrus.FieldLogger) *Handler {
+	return &Handler{
+		logger: logger,
+	}
+}
+
+// Handle logs an error.
+func (h *Handler) Handle(err error) {
+	logger := h.logger
+
+	// Extract context from the error and attach it to the log
+	if kvs := emperror.Context(err); len(kvs) > 0 {
+		logger = h.logger.WithFields(logrus.Fields(keyvals.ToMap(kvs)))
+	}
+
+	type errorCollection interface {
+		Errors() []error
+	}
+
+	if errs, ok := err.(errorCollection); ok {
+		for _, e := range errs.Errors() {
+			logger.WithField("parent", err.Error()).Error(e.Error())
+		}
+	} else {
+		logger.Error(err.Error())
+	}
+}

--- a/vendor/github.com/goph/emperror/handler/rollbarhandler/error.go
+++ b/vendor/github.com/goph/emperror/handler/rollbarhandler/error.go
@@ -1,0 +1,84 @@
+package rollbarhandler
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rollbar/rollbar-go"
+)
+
+type stackTracer interface {
+	Error() string
+	StackTrace() errors.StackTrace
+}
+
+type causeStacker struct {
+	err stackTracer
+}
+
+func newCauseStacker(err stackTracer) *causeStacker {
+	return &causeStacker{
+		err: err,
+	}
+}
+
+func (e *causeStacker) Error() string {
+	return e.err.Error()
+}
+
+func (e *causeStacker) Cause() error {
+	if c, ok := e.err.(interface{ Cause() error }); ok {
+		return c.Cause()
+	}
+
+	return nil
+}
+
+func (e *causeStacker) Stack() rollbar.Stack {
+	stackTrace := e.err.StackTrace()
+	stack := make(rollbar.Stack, len(stackTrace))
+
+	for i, frame := range stackTrace {
+		line, _ := strconv.Atoi(fmt.Sprintf("%d", frame))
+
+		stack[i] = rollbar.Frame{
+			Filename: shortenFilePath(strings.SplitN(fmt.Sprintf("%+s", frame), "\n\t", 2)[1]), // nolint: govet
+			Method:   fmt.Sprintf("%n", frame),                                                 // nolint: govet
+			Line:     line,
+		}
+	}
+
+	return stack
+}
+
+// copied from rollbar
+
+// nolint: gochecknoglobals
+var (
+	knownFilePathPatterns = []string{
+		"github.com/",
+		"code.google.com/",
+		"bitbucket.org/",
+		"launchpad.net/",
+	}
+)
+
+func shortenFilePath(s string) string {
+	// added to the original function
+	s = strings.TrimPrefix(s, runtime.GOROOT())
+
+	idx := strings.Index(s, "/src/pkg/")
+	if idx != -1 {
+		return s[idx+5:]
+	}
+	for _, pattern := range knownFilePathPatterns {
+		idx = strings.Index(s, pattern)
+		if idx != -1 {
+			return s[idx:]
+		}
+	}
+	return s
+}

--- a/vendor/github.com/goph/emperror/handler/rollbarhandler/handler.go
+++ b/vendor/github.com/goph/emperror/handler/rollbarhandler/handler.go
@@ -1,0 +1,52 @@
+// Package rollbarhandler provides Rollbar integration.
+package rollbarhandler
+
+import (
+	"github.com/rollbar/rollbar-go"
+
+	"github.com/goph/emperror"
+	"github.com/goph/emperror/httperr"
+	"github.com/goph/emperror/internal/keyvals"
+)
+
+// Handler is responsible for sending errors to Rollbar.
+type Handler struct {
+	client *rollbar.Client
+}
+
+// New creates a new handler.
+func New(token, environment, codeVersion, serverHost, serverRoot string) *Handler {
+	return NewFromClient(rollbar.New(token, environment, codeVersion, serverHost, serverRoot))
+}
+
+// NewFromClient creates a new handler from a client instance.
+func NewFromClient(client *rollbar.Client) *Handler {
+	return &Handler{
+		client: client,
+	}
+}
+
+// Handle sends the error to Rollbar.
+func (h *Handler) Handle(err error) {
+	// Get the context from the error
+	ctx := keyvals.ToMap(emperror.Context(err))
+
+	// Expose the stackTracer interface on the outer error (if there is stack trace in the error)
+	// Convert error with stack trace to an internal error type
+	if e, ok := emperror.ExposeStackTrace(err).(stackTracer); ok {
+		err = newCauseStacker(e)
+	}
+
+	if req, ok := httperr.HTTPRequest(err); ok {
+		h.client.RequestErrorWithStackSkipWithExtras(rollbar.ERR, req, err, 3, ctx)
+
+		return
+	}
+
+	h.client.ErrorWithStackSkipWithExtras(rollbar.ERR, err, 3, ctx)
+}
+
+// Close closes the underlying notifier and waits for asynchronous reports to finish.
+func (h *Handler) Close() error {
+	return h.client.Close()
+}

--- a/vendor/github.com/goph/emperror/handler/sentryhandler/handler.go
+++ b/vendor/github.com/goph/emperror/handler/sentryhandler/handler.go
@@ -1,0 +1,91 @@
+package sentryhandler
+
+import (
+	"github.com/getsentry/raven-go"
+	"github.com/pkg/errors"
+
+	"github.com/goph/emperror"
+	"github.com/goph/emperror/httperr"
+	"github.com/goph/emperror/internal/keyvals"
+)
+
+// Handler is responsible for sending errors to Sentry.
+type Handler struct {
+	client *raven.Client
+
+	sendSynchronously bool
+}
+
+// New creates a new handler.
+func New(dsn string) (*Handler, error) {
+	client, err := raven.New(dsn)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create raven client")
+	}
+
+	return NewFromClient(client), nil
+}
+
+// NewSync creates a new handler that sends errors synchronously.
+func NewSync(dsn string) (*Handler, error) {
+	handler, err := New(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	handler.sendSynchronously = true
+
+	return handler, nil
+}
+
+// NewFromClient creates a new handler from a client instance.
+func NewFromClient(client *raven.Client) *Handler {
+	return &Handler{
+		client: client,
+	}
+}
+
+// NewSyncFromClient creates a new handler from a client instance that sends errors synchronously.
+func NewSyncFromClient(client *raven.Client) *Handler {
+	handler := NewFromClient(client)
+
+	handler.sendSynchronously = true
+
+	return handler
+}
+
+// Handle sends the error to Rollbar.
+func (h *Handler) Handle(err error) {
+	var interfaces []raven.Interface
+
+	// Get HTTP request (if any)
+	if req, ok := httperr.HTTPRequest(err); ok {
+		interfaces = append(interfaces, raven.NewHttp(req))
+	}
+
+	packet := raven.NewPacketWithExtra(
+		err.Error(),
+		keyvals.ToMap(emperror.Context(err)),
+		append(
+			interfaces,
+			raven.NewException(
+				err,
+				raven.GetOrNewStacktrace(emperror.ExposeStackTrace(err), 1, 3, h.client.IncludePaths()),
+			),
+		)...,
+	)
+
+	eventID, ch := h.client.Capture(packet, nil)
+
+	if h.sendSynchronously && eventID != "" {
+		<-ch
+	}
+}
+
+// Close closes the underlying notifier and waits for asynchronous reports to finish.
+func (h *Handler) Close() error {
+	h.client.Close()
+	h.client.Wait()
+
+	return nil
+}

--- a/vendor/github.com/goph/emperror/handler_composite.go
+++ b/vendor/github.com/goph/emperror/handler_composite.go
@@ -1,0 +1,18 @@
+package emperror
+
+// compositeHandler allows an error to be processed by multiple handlers.
+type compositeHandler struct {
+	handlers []Handler
+}
+
+// NewCompositeHandler returns a new compositeHandler.
+func NewCompositeHandler(handlers ...Handler) Handler {
+	return &compositeHandler{handlers}
+}
+
+// Handle goes through the handlers and call each of them for the error.
+func (h *compositeHandler) Handle(err error) {
+	for _, handler := range h.handlers {
+		handler.Handle(err)
+	}
+}

--- a/vendor/github.com/goph/emperror/handler_context.go
+++ b/vendor/github.com/goph/emperror/handler_context.go
@@ -1,0 +1,93 @@
+package emperror
+
+// The implementation bellow is heavily influenced by go-kit's log context.
+
+// HandlerWith returns a new error handler with keyvals context appended to it.
+// If the wrapped error handler is already a contextual error handler created by HandlerWith or HandlerWithPrefix
+// keyvals is appended to the existing context, but a new error handler is returned.
+//
+// The created handler will prepend it's own context to the handled errors.
+func HandlerWith(handler Handler, keyvals ...interface{}) Handler {
+	if len(keyvals) == 0 {
+		return handler
+	}
+
+	kvs, handler := extractHandlerContext(handler)
+
+	kvs = append(kvs, keyvals...)
+
+	if len(kvs)%2 != 0 {
+		kvs = append(kvs, nil)
+	}
+
+	// Limiting the capacity of the stored keyvals ensures that a new
+	// backing array is created if the slice must grow in HandlerWith.
+	// Using the extra capacity without copying risks a data race.
+	return newContextualHandler(handler, kvs[:len(kvs):len(kvs)])
+}
+
+// HandlerWithPrefix returns a new error handler with keyvals context prepended to it.
+// If the wrapped error handler is already a contextual error handler created by HandlerWith or HandlerWithPrefix
+// keyvals is prepended to the existing context, but a new error handler is returned.
+//
+// The created handler will prepend it's own context to the handled errors.
+func HandlerWithPrefix(handler Handler, keyvals ...interface{}) Handler {
+	if len(keyvals) == 0 {
+		return handler
+	}
+
+	prevkvs, handler := extractHandlerContext(handler)
+
+	n := len(prevkvs) + len(keyvals)
+	if len(keyvals)%2 != 0 {
+		n++
+	}
+
+	kvs := make([]interface{}, 0, n)
+	kvs = append(kvs, keyvals...)
+
+	if len(kvs)%2 != 0 {
+		kvs = append(kvs, nil)
+	}
+
+	kvs = append(kvs, prevkvs...)
+
+	return newContextualHandler(handler, kvs)
+}
+
+// extractHandlerContext extracts the context and optionally the wrapped handler when it's the same container.
+func extractHandlerContext(handler Handler) ([]interface{}, Handler) {
+	var kvs []interface{}
+
+	if c, ok := handler.(*contextualHandler); ok {
+		handler = c.handler
+		kvs = c.keyvals
+	}
+
+	return kvs, handler
+}
+
+// contextualHandler is a Handler implementation returned by HandlerWith or HandlerWithPrefix.
+//
+// It wraps an error handler and a holds keyvals as the context.
+type contextualHandler struct {
+	handler Handler
+	keyvals []interface{}
+}
+
+// newContextualHandler creates a new *contextualHandler or a struct which is contextual and holds a stack trace.
+func newContextualHandler(handler Handler, kvs []interface{}) Handler {
+	chandler := &contextualHandler{
+		handler: handler,
+		keyvals: kvs,
+	}
+
+	return chandler
+}
+
+// Handle prepends the handler's context to the error's (if any) and delegates the call to the underlying handler.
+func (h *contextualHandler) Handle(err error) {
+	err = With(err, h.keyvals...)
+
+	h.handler.Handle(err)
+}

--- a/vendor/github.com/goph/emperror/handler_func.go
+++ b/vendor/github.com/goph/emperror/handler_func.go
@@ -1,0 +1,9 @@
+package emperror
+
+// HandlerFunc wraps a function and turns it into an error handler.
+type HandlerFunc func(err error)
+
+// Handle calls the underlying log function.
+func (h HandlerFunc) Handle(err error) {
+	h(err)
+}

--- a/vendor/github.com/goph/emperror/handler_noop.go
+++ b/vendor/github.com/goph/emperror/handler_noop.go
@@ -1,0 +1,11 @@
+package emperror
+
+type noopHandler struct{}
+
+// NewNoopHandler creates a no-op error handler that discards all received errors.
+// Useful in examples and as a fallback error handler.
+func NewNoopHandler() Handler {
+	return &noopHandler{}
+}
+
+func (*noopHandler) Handle(err error) {}

--- a/vendor/github.com/goph/emperror/handler_testing.go
+++ b/vendor/github.com/goph/emperror/handler_testing.go
@@ -1,0 +1,53 @@
+package emperror
+
+import "sync"
+
+// TestHandler is a simple stub for the handler interface recording every error.
+//
+// The TestHandler is safe for concurrent use.
+type TestHandler struct {
+	errors []error
+
+	mu sync.RWMutex
+}
+
+// NewTestHandler returns a new TestHandler.
+func NewTestHandler() *TestHandler {
+	return &TestHandler{}
+}
+
+// Count returns the number of events recorded in the logger.
+func (h *TestHandler) Count() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return len(h.errors)
+}
+
+// LastError returns the last handled error (if any).
+func (h *TestHandler) LastError() error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if len(h.errors) < 1 {
+		return nil
+	}
+
+	return h.errors[len(h.errors)-1]
+}
+
+// Errors returns all handled errors.
+func (h *TestHandler) Errors() []error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	return h.errors
+}
+
+// Handle records the error.
+func (h *TestHandler) Handle(err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.errors = append(h.errors, err)
+}

--- a/vendor/github.com/goph/emperror/httperr/http.go
+++ b/vendor/github.com/goph/emperror/httperr/http.go
@@ -1,0 +1,76 @@
+package httperr
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/goph/emperror"
+)
+
+// WithHTTPRequest attaches an HTTP request to the error.
+func WithHTTPRequest(err error, r *http.Request) error {
+	return &withHTTPRequest{
+		req: r,
+		err: err,
+	}
+}
+
+// HTTPRequest extracts an HTTP request from an error (if any).
+//
+// It loops through the whole error chain (if any).
+func HTTPRequest(err error) (*http.Request, bool) {
+	type httpError interface {
+		HTTPRequest() *http.Request
+	}
+
+	var req *http.Request
+
+	emperror.ForEachCause(err, func(err error) bool {
+		if httpErr, ok := err.(httpError); ok {
+			req = httpErr.HTTPRequest()
+
+			return false
+		}
+
+		return true
+	})
+
+	return req, req != nil
+}
+
+type withHTTPRequest struct {
+	req *http.Request
+	err error
+}
+
+func (w *withHTTPRequest) Error() string {
+	return w.err.Error()
+}
+
+func (w *withHTTPRequest) Cause() error {
+	return w.err
+}
+
+func (w *withHTTPRequest) HTTPRequest() *http.Request {
+	return w.req
+}
+
+func (w *withHTTPRequest) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = fmt.Fprintf(s, "%+v", w.Cause())
+
+			return
+		}
+
+		fallthrough
+
+	case 's':
+		_, _ = io.WriteString(s, w.Error())
+
+	case 'q':
+		_, _ = fmt.Fprintf(s, "%q", w.Error())
+	}
+}

--- a/vendor/github.com/goph/emperror/internal/keyvals/to_map.go
+++ b/vendor/github.com/goph/emperror/internal/keyvals/to_map.go
@@ -1,0 +1,58 @@
+package keyvals
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ToMap creates a map of key-value pairs from a variadic key-value pair slice.
+//
+// The implementation bellow is from go-kit's JSON logger.
+func ToMap(kvs []interface{}) map[string]interface{} {
+	m := map[string]interface{}{}
+
+	if len(kvs) == 0 {
+		return m
+	}
+
+	if len(kvs)%2 == 1 {
+		kvs = append(kvs, nil)
+	}
+
+	for i := 0; i < len(kvs); i += 2 {
+		merge(m, kvs[i], kvs[i+1])
+	}
+
+	return m
+}
+
+func merge(dst map[string]interface{}, k, v interface{}) {
+	var key string
+
+	switch x := k.(type) {
+	case string:
+		key = x
+	case fmt.Stringer:
+		key = safeString(x)
+	default:
+		key = fmt.Sprint(x)
+	}
+
+	dst[key] = v
+}
+
+func safeString(str fmt.Stringer) (s string) {
+	defer func() {
+		if panicVal := recover(); panicVal != nil {
+			if v := reflect.ValueOf(str); v.Kind() == reflect.Ptr && v.IsNil() {
+				s = "NULL"
+			} else {
+				panic(panicVal)
+			}
+		}
+	}()
+
+	s = str.String()
+
+	return
+}

--- a/vendor/github.com/goph/emperror/multierr.go
+++ b/vendor/github.com/goph/emperror/multierr.go
@@ -1,0 +1,78 @@
+package emperror
+
+// multiError aggregates multiple errors into a single value.
+//
+// While ErrorCollection is only an interface for listing errors,
+// multiError actually implements the error interface so it can be returned as an error.
+type multiError struct {
+	errors []error
+	msg    string
+}
+
+// Error implements the error interface.
+func (e *multiError) Error() string {
+	if e.msg != "" {
+		return e.msg
+	}
+
+	return "Multiple errors happened"
+}
+
+// Errors returns the list of wrapped errors.
+func (e *multiError) Errors() []error {
+	return e.errors
+}
+
+// SingleWrapMode defines how MultiErrorBuilder behaves when there is only one error in the list.
+type SingleWrapMode int
+
+// These constants cause MultiErrorBuilder to behave as described if there is only one error in the list.
+const (
+	AlwaysWrap   SingleWrapMode = iota // Always return a MultiError.
+	ReturnSingle                       // Return the single error.
+)
+
+// MultiErrorBuilder provides an interface for aggregating errors and exposing them as a single value.
+type MultiErrorBuilder struct {
+	errors []error
+
+	Message        string
+	SingleWrapMode SingleWrapMode
+}
+
+// NewMultiErrorBuilder returns a new MultiErrorBuilder.
+func NewMultiErrorBuilder() *MultiErrorBuilder {
+	return &MultiErrorBuilder{
+		SingleWrapMode: AlwaysWrap,
+	}
+}
+
+// Add adds an error to the list.
+//
+// Calling this method concurrently is not safe.
+func (b *MultiErrorBuilder) Add(err error) {
+	// Do not add nil values.
+	if err == nil {
+		return
+	}
+
+	b.errors = append(b.errors, err)
+}
+
+// ErrOrNil returns a MultiError the builder aggregates a list of errors,
+// or returns nil if the list of errors is empty.
+//
+// It is useful to avoid checking if there are any errors added to the list.
+func (b *MultiErrorBuilder) ErrOrNil() error {
+	// No errors added, return nil.
+	if len(b.errors) == 0 {
+		return nil
+	}
+
+	// Return a single error when there is only one and the builder is told to do so.
+	if len(b.errors) == 1 && b.SingleWrapMode == ReturnSingle {
+		return b.errors[0]
+	}
+
+	return &multiError{b.errors, b.Message}
+}

--- a/vendor/github.com/goph/emperror/panic.go
+++ b/vendor/github.com/goph/emperror/panic.go
@@ -1,0 +1,19 @@
+package emperror
+
+// Panic panics if the passed error is not nil.
+// If the error does not contain any stack trace, the function attaches one, starting from the frame of the
+// "Panic" function call.
+//
+// This function is useful with HandleRecover when panic is used as a flow control tool to stop the application.
+func Panic(err error) {
+	if err != nil {
+		if _, ok := StackTrace(err); !ok {
+			err = &wrappedError{
+				err:   err,
+				stack: callers(),
+			}
+		}
+
+		panic(err)
+	}
+}

--- a/vendor/github.com/goph/emperror/recover.go
+++ b/vendor/github.com/goph/emperror/recover.go
@@ -1,0 +1,29 @@
+package emperror
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Recover accepts a recovered panic (if any) and converts it to an error (if necessary).
+func Recover(r interface{}) (err error) {
+	if r != nil {
+		switch x := r.(type) {
+		case string:
+			err = errors.New(x)
+		case error:
+			err = x
+		default:
+			err = fmt.Errorf("unknown panic, received: %v", r)
+		}
+
+		if _, ok := StackTrace(err); !ok {
+			err = &wrappedError{
+				err:   err,
+				stack: callers()[2:], // TODO: improve callers?
+			}
+		}
+	}
+
+	return err
+}

--- a/vendor/github.com/goph/emperror/stack.go
+++ b/vendor/github.com/goph/emperror/stack.go
@@ -1,0 +1,91 @@
+package emperror
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+// StackTrace returns the stack trace from an error (if any).
+func StackTrace(err error) (errors.StackTrace, bool) {
+	st, ok := getStackTracer(err)
+	if ok {
+		return st.StackTrace(), true
+	}
+
+	return nil, false
+}
+
+// getStackTracer returns the stack trace from an error (if any).
+func getStackTracer(err error) (stackTracer, bool) {
+	var st stackTracer
+
+	ForEachCause(err, func(err error) bool {
+		if s, ok := err.(stackTracer); ok {
+			st = s
+
+			return false
+		}
+
+		return true
+	})
+
+	return st, st != nil
+}
+
+type withStack struct {
+	err error
+	st  stackTracer
+}
+
+func (w *withStack) Error() string {
+	return w.err.Error()
+}
+
+func (w *withStack) Cause() error {
+	return w.err
+}
+
+func (w *withStack) StackTrace() errors.StackTrace {
+	return w.st.StackTrace()
+}
+
+// Format implements the fmt.Formatter interface.
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = fmt.Fprintf(s, "%+v", w.Cause())
+			return
+		}
+		fallthrough
+
+	case 's':
+		_, _ = io.WriteString(s, w.Error())
+
+	case 'q':
+		_, _ = fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// ExposeStackTrace exposes the stack trace (if any) in the outer error.
+func ExposeStackTrace(err error) error {
+	if err == nil {
+		return err
+	}
+
+	st, ok := getStackTracer(err)
+	if !ok {
+		return err
+	}
+
+	return &withStack{
+		err: err,
+		st:  st,
+	}
+}

--- a/vendor/github.com/goph/emperror/utils.go
+++ b/vendor/github.com/goph/emperror/utils.go
@@ -1,0 +1,18 @@
+package emperror
+
+// HandleRecover recovers from a panic and handles the error.
+//
+// 		defer emperror.HandleRecover(errorHandler)
+func HandleRecover(handler Handler) {
+	err := Recover(recover())
+	if err != nil {
+		handler.Handle(err)
+	}
+}
+
+// Handle handles an error whenever it occurs.
+func Handle(handler Handler, err error) {
+	if err != nil {
+		handler.Handle(err)
+	}
+}

--- a/vendor/github.com/goph/emperror/wrap.go
+++ b/vendor/github.com/goph/emperror/wrap.go
@@ -1,0 +1,115 @@
+package emperror
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+
+	"github.com/pkg/errors"
+)
+
+func callers() []uintptr {
+	const depth = 32
+	var pcs [depth]uintptr
+
+	n := runtime.Callers(3, pcs[:])
+
+	return pcs[0:n]
+}
+
+type wrappedError struct {
+	err   error
+	stack []uintptr
+}
+
+func (e *wrappedError) Error() string {
+	return e.err.Error()
+}
+
+func (e *wrappedError) Cause() error {
+	return e.err
+}
+
+func (e *wrappedError) StackTrace() errors.StackTrace {
+	f := make([]errors.Frame, len(e.stack))
+
+	for i := 0; i < len(f); i++ {
+		f[i] = errors.Frame((e.stack)[i])
+	}
+
+	return f
+}
+
+func (e *wrappedError) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = fmt.Fprintf(s, "%+v", e.Cause())
+
+			for _, pc := range e.stack {
+				f := errors.Frame(pc)
+				_, _ = fmt.Fprintf(s, "\n%+v", f)
+			}
+
+			return
+		}
+
+		fallthrough
+
+	case 's':
+		_, _ = io.WriteString(s, e.Error())
+
+	case 'q':
+		_, _ = fmt.Fprintf(s, "%q", e.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called (if there is none attached to the error yet), and the supplied message.
+// If err is nil, Wrap returns nil.
+//
+// Note: do not use this method when passing errors between goroutines.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+
+	_, ok := getStackTracer(err)
+
+	err = errors.WithMessage(err, message)
+
+	// There is no stack trace in the error, so attach it here
+	if !ok {
+		err = &wrappedError{
+			err:   err,
+			stack: callers(),
+		}
+	}
+
+	return err
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call (if there is none attached to the error yet), and the format specifier.
+// If err is nil, Wrapf returns nil.
+//
+// Note: do not use this method when passing errors between goroutines.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	_, ok := getStackTracer(err)
+
+	err = errors.WithMessage(err, fmt.Sprintf(format, args...))
+
+	// There is no stack trace in the error, so attach it here
+	if !ok {
+		err = &wrappedError{
+			err:   err,
+			stack: callers(),
+		}
+	}
+
+	return err
+}

--- a/vendor/github.com/goph/emperror/wrap_context.go
+++ b/vendor/github.com/goph/emperror/wrap_context.go
@@ -1,0 +1,34 @@
+package emperror
+
+import "github.com/pkg/errors"
+
+// WrapWith returns an error annotating err with a stack trace
+// at the point Wrap is called (if there is none attached to the error yet), the supplied message,
+// and the supplied context.
+// If err is nil, Wrap returns nil.
+//
+// Note: do not use this method when passing errors between goroutines.
+func WrapWith(err error, message string, keyvals ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	_, ok := getStackTracer(err)
+
+	err = errors.WithMessage(err, message)
+
+	// There is no stack trace in the error, so attach it here
+	if !ok {
+		err = &wrappedError{
+			err:   err,
+			stack: callers(),
+		}
+	}
+
+	// Attach context to the error
+	if len(keyvals) > 0 {
+		err = With(err, keyvals...)
+	}
+
+	return err
+}


### PR DESCRIPTION
This PR adds the lib called k8s-objectmatcher which helps to compare resources and check if need an update or not.
Some fields in any resource (like services/deployments) are immutable and the Deepequal does not exclude that.

Adding this lib helps us to validate and apply the update if necessary