### PR TITLE
Correctly set cluster settings for licensed MM deployments

### DIFF
--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -366,6 +366,19 @@ func (mattermost *ClusterInstallation) GenerateDeployment(dbUser, dbPassword str
 				},
 			},
 		})
+
+		clusterEnvVars := []corev1.EnvVar{
+			{
+				Name:  "MM_CLUSTERSETTINGS_ENABLE",
+				Value: "true",
+			},
+			{
+				Name:  "MM_CLUSTERSETTINGS_CLUSTERNAME",
+				Value: "production",
+			},
+		}
+
+		envVarGeneral = append(envVarGeneral, clusterEnvVars...)
 	}
 
 	// EnvVars Section


### PR DESCRIPTION
We weren't enabling HA for licensed deployments.