### PR TITLE
not fail the pipeline if coveralls is down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           make unittest
       - run:
           name: coveralls
-          command: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken $COVERALLS_REPO_TOKEN
+          command: goveralls -coverprofile=coverage.out -service=circle-ci -repotoken $COVERALLS_REPO_TOKEN || true
 
   e2e:
     environment:


### PR DESCRIPTION
coverall is down since yestarday or more and the pipeline is failing.
This change not fail the pipeline if we cannot push the results to coveralls

pr from cloud: https://github.com/mattermost/mattermost-cloud/pull/67
```
#!/bin/bash -eo pipefail
goveralls -coverprofile=coverage.out -service=circle-ci -repotoken $COVERALLS_REPO_TOKEN
Bad response status from coveralls: 405
<html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx</center>
</body>
```