### PR TITLE
dont create ingress when using the service as loadbalancer

### DIFF
--- a/pkg/controller/clusterinstallation/bluegreen.go
+++ b/pkg/controller/clusterinstallation/bluegreen.go
@@ -16,9 +16,11 @@ func (r *ReconcileClusterInstallation) checkBlueGreen(mattermost *mattermostv1al
 			if err != nil {
 				return err
 			}
-			err = r.checkMattermostIngress(mattermost, deployment.Name, deployment.IngressName, reqLogger)
-			if err != nil {
-				return err
+			if !mattermost.Spec.UseServiceLoadBalancer {
+				err = r.checkMattermostIngress(mattermost, deployment.Name, deployment.IngressName, reqLogger)
+				if err != nil {
+					return err
+				}
 			}
 			err = r.checkMattermostDeployment(mattermost, deployment.Name, deployment.IngressName, deployment.GetDeploymentImageName(), reqLogger)
 			if err != nil {

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -28,9 +28,11 @@ func (r *ReconcileClusterInstallation) checkMattermost(mattermost *mattermostv1a
 		return err
 	}
 
-	err = r.checkMattermostIngress(mattermost, mattermost.Name, mattermost.Spec.IngressName, reqLogger)
-	if err != nil {
-		return err
+	if !mattermost.Spec.UseServiceLoadBalancer {
+		err = r.checkMattermostIngress(mattermost, mattermost.Name, mattermost.Spec.IngressName, reqLogger)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !mattermost.Spec.BlueGreen.Enable {


### PR DESCRIPTION
When creating a cluster installation and using the service as a load balancer `UseServiceLoadBalancer = true`  we dont need to create and check the ingress because this resource is not used at all