### PR TITLE
Add option to restore a MySQL Mattermost Database when deploying a new Mattermost installation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -550,12 +550,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:752482fc318d9953463ab59a0fb370bf9924fadc2d69591de04ac53e0b492894"
+  digest = "1:2c62d4f37b23c6fc35fc20f8b1bf2f164df2b18e4255de817d1327cbb3cd2c38"
   name = "github.com/presslabs/mysql-operator"
   packages = ["pkg/apis/mysql/v1alpha1"]
   pruneopts = "NT"
-  revision = "80e8f35dbac0d9dfa9ab2c77aa2d8a8cab4dbfa4"
-  version = "v0.3.0"
+  revision = "5bd2f20509657d51543bf969c6f389949c132fab"
+  version = "v0.3.2"
 
 [[projects]]
   digest = "1:ec2a29e3bd141038ae5c3d3a4f57db0c341fcc1d98055a607aedd683aed124ee"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -90,4 +90,4 @@ version="v1.4.7"
 
 [[constraint]]
   name = "github.com/presslabs/mysql-operator"
-  version = "0.3.0"
+  version = "0.3.2"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,31 @@ Use Case: An existing AWS RDS Database
   - Perform the backup using the `Percona XtraBackup`
     - `xtrabackup --innodb_file_per_table=1 --innodb_flush_log_at_trx_commit=2 --innodb_flush_method=O_DIRECT --innodb_log_files_in_group=2 --log_bin=/var/lib/mysql/mysql-bin --open_files_limit=65535 --innodb_buffer_pool_size=512M --innodb_log_file_size=128M --server-id=100 --backup=1 --slave-info=1 --stream=xbstream --host=127.0.0.1 --user=USER --password=PASSWORD --target-dir=~/xtrabackup_backupfiles/ | gzip - > BACKNAME.gz`
   - Upload to an AWS S3 bucket
+  - Create the Restore/Backup secret with the AWS credentials
+  ```
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: test-restore
+  type: Opaque
+  stringData:
+    AWS_ACCESS_KEY_ID: XXXXXXXXXXXX
+    AWS_SECRET_ACCESS_KEY: XXXXXXXXXXXX/XXXXXXXXXXXX
+    AWS_REGION: us-east-1
+    S3_PROVIDER: AWS
+  ```
+  - Create the mattermost manifest to deploy
+  ```
+  apiVersion: mattermost.com/v1alpha1
+  kind: ClusterInstallation
+  metadata:
+    name: example-clusterinstallation
+  spec:
+    ingressName: example.mattermost-example.dev
+    database:
+      backupRestoreSecret: test-restore
+      initBucketURL: s3://my-backup-bucket/my-backup.gz
+  ```
 
 If you have an machine running MySQL you just need to perform the `Percona XtraBackup` step
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ For the customized install options example:
 $ kubectl delete -f mm_clusterinstallation.yaml
 ```
 
+### 2.5 Restore an existing Mattermost MySQL Database
+To restore an existing Mattermost MySQL Database into a new Mattermost installation using the Mattermost Operator you will need to do a few steps.
+
+Use Case: An existing AWS RDS Database
+  - First you need to dump the data using mysqldump
+  - Create an EC2 instance and install MySQL
+  - Restore the dump in this new database
+  - Install `Percona XtraBackup`
+  - Perform the backup using the `Percona XtraBackup`
+    - `xtrabackup --innodb_file_per_table=1 --innodb_flush_log_at_trx_commit=2 --innodb_flush_method=O_DIRECT --innodb_log_files_in_group=2 --log_bin=/var/lib/mysql/mysql-bin --open_files_limit=65535 --innodb_buffer_pool_size=512M --innodb_log_file_size=128M --server-id=100 --backup=1 --slave-info=1 --stream=xbstream --host=127.0.0.1 --user=USER --password=PASSWORD --target-dir=~/xtrabackup_backupfiles/ | gzip - > BACKNAME.gz`
+  - Upload to an AWS S3 bucket
+
+If you have an machine running MySQL you just need to perform the `Percona XtraBackup` step
+
 ## 3. Developer flow
 To test the operator locally. We recommend [Kind](https://kind.sigs.k8s.io/), however, you can use Minikube or Minishift as well.
 

--- a/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
+++ b/deploy/crds/mattermost_v1alpha1_clusterinstallation_crd.yaml
@@ -104,9 +104,18 @@ spec:
               type: object
             database:
               properties:
+                backupRestoreSecret:
+                  description: Defines the secret to be used for uploading backup
+                    or to restore the backup.
+                  type: string
                 externalSecret:
                   description: If the user want to use an external DB. This can be
                     inside the same k8s cluster or outside like AWS RDS.
+                  type: string
+                initBucketURL:
+                  description: Defines the AWS S3 bucket where the Database Backup
+                    is stored. The operator will download the file to restore the
+                    data.
                   type: string
                 replicas:
                   description: Defines the number of database replicas. For redundancy

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -143,6 +143,13 @@ type Database struct {
 	// Defines the resource requests and limits for the database pods.
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Defines the secret to be used for uploading backup or to restore the backup.
+	// +optional
+	BackupRestoreSecret string `json:"backupRestoreSecret,omitempty"`
+	// Defines the AWS S3 bucket where the Database Backup is stored.
+	// The operator will download the file to restore the data.
+	// +optional
+	InitBucketURL string `json:"initBucketURL,omitempty"`
 }
 
 // ElasticSearch defines the ElasticSearch configuration for a ClusterInstallation.

--- a/pkg/components/mysql/mysql.go
+++ b/pkg/components/mysql/mysql.go
@@ -17,7 +17,7 @@ import (
 
 // Cluster returns the MySQL cluster to deploy
 func Cluster(mattermost *mattermostv1alpha1.ClusterInstallation) *mysqlOperator.MysqlCluster {
-	return &mysqlOperator.MysqlCluster{
+	mysql := &mysqlOperator.MysqlCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "db",
 			Namespace: mattermost.Namespace,
@@ -48,4 +48,11 @@ func Cluster(mattermost *mattermostv1alpha1.ClusterInstallation) *mysqlOperator.
 			},
 		},
 	}
+
+	if mattermost.Spec.Database.InitBucketURL != "" && mattermost.Spec.Database.BackupRestoreSecret != "" {
+		mysql.Spec.InitBucketURL = mattermost.Spec.Database.InitBucketURL
+		mysql.Spec.InitBucketSecretName = mattermost.Spec.Database.BackupRestoreSecret
+	}
+
+	return mysql
 }

--- a/vendor/github.com/presslabs/mysql-operator/cmd/orc-helper/main.go
+++ b/vendor/github.com/presslabs/mysql-operator/cmd/orc-helper/main.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2019 Pressinfra SRL
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	"github.com/presslabs/mysql-operator/pkg/apis"
+	"github.com/presslabs/mysql-operator/pkg/orc-helper"
+)
+
+var (
+	c client.Client
+)
+
+func main() {
+
+	cmd := &cobra.Command{
+		Use:   "orchestrator-helper",
+		Short: "Helper for orchestrator.",
+		Long:  `This command is a helper for updating MySQL cluster resources. Record events.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Fatal("you run orchestrator helper, see help section")
+		},
+	}
+
+	// Get a config to talk to the apiserver
+	cfg, err := config.GetConfig()
+	if err != nil {
+		log.Fatal("unable to get configuration: ", err)
+	}
+
+	// Setup Scheme for all resources
+	s := scheme.Scheme
+	if err = apis.AddToScheme(s); err != nil {
+		log.Fatal("unable to register types to scheme: ", err)
+	}
+
+	// initialize k8s client
+	c, err = client.New(cfg, client.Options{Scheme: s})
+	if err != nil {
+		log.Fatal("unable to get the k8s client: ", err)
+	}
+
+	fipCmd := &cobra.Command{
+		Use:   "failover-in-progress",
+		Short: "Set failover in progress condition for given cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			// check command line args
+			if len(args) != 2 {
+				log.Fatal("see usage: <cluster.name> <message>")
+			}
+
+			err = orchelper.UpdateClusterFailoverCond(c, args[0], "OrcFailoverInProgress", args[1], true)
+			if err != nil {
+				log.Fatal("error in updating cluster: ", err)
+			}
+		},
+	}
+	cmd.AddCommand(fipCmd)
+
+	evWarningType := false
+	evCmd := &cobra.Command{
+		Use:   "event",
+		Short: "Set event on a given cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			// check command line args
+			if len(args) != 3 {
+				log.Fatal("see usage: <cluster.name> <event-name> <message> [-warning]")
+			}
+
+			err = orchelper.UpdateEventForCluster(c, s, args[0], args[1], args[2], evWarningType)
+			if err != nil {
+				log.Fatal("error in updating cluster: ", err)
+			}
+		},
+	}
+	evCmd.Flags().BoolVarP(&evWarningType, "warning", "w", false, "if it's a warning event in k8s")
+	cmd.AddCommand(evCmd)
+
+	if err := cmd.Execute(); err != nil {
+		log.Fatal("failed to execute command: ", err)
+	}
+}

--- a/vendor/github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1/mysqlbackup_types.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1/mysqlbackup_types.go
@@ -85,7 +85,8 @@ const (
 
 // MysqlBackupStatus defines the observed state of MysqlBackup
 type MysqlBackupStatus struct {
-	// Complete marks the backup in final state
+	// Completed indicates whether the backup is in a final state,
+	// no matter whether its' corresponding job failed or succeeded
 	Completed bool `json:"completed,omitempty"`
 	// Conditions represents the backup resource conditions list.
 	Conditions []BackupCondition `json:"conditions,omitempty"`

--- a/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlbackup/internal/syncer/deletionjob.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlbackup/internal/syncer/deletionjob.go
@@ -35,6 +35,7 @@ import (
 	"github.com/presslabs/mysql-operator/pkg/internal/mysqlbackup"
 	"github.com/presslabs/mysql-operator/pkg/internal/mysqlcluster"
 	"github.com/presslabs/mysql-operator/pkg/options"
+	"github.com/presslabs/mysql-operator/pkg/util/constants"
 )
 
 const (
@@ -154,7 +155,9 @@ func (s *deletionJobSyncer) ensureContainers() []core.Container {
 			Image:           s.opt.SidecarImage,
 			ImagePullPolicy: s.opt.ImagePullPolicy,
 			Args: []string{
-				"rclone", "--config=/etc/rclone.conf", "delete",
+				"rclone",
+				constants.RcloneConfigArg,
+				"delete",
 				bucketForRclone(s.backup.Spec.BackupURL),
 			},
 			EnvFrom: []core.EnvFromSource{

--- a/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlbackup/internal/syncer/job.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlbackup/internal/syncer/job.go
@@ -133,6 +133,14 @@ func (s *jobSyncer) ensurePodSpec(in core.PodSpec) core.PodSpec {
 		s.backup.GetBackupURL(s.cluster),
 	}
 
+	in.ServiceAccountName = s.cluster.Spec.PodSpec.ServiceAccountName
+
+	in.Affinity = s.cluster.Spec.PodSpec.Affinity
+	in.ImagePullSecrets = s.cluster.Spec.PodSpec.ImagePullSecrets
+	in.NodeSelector = s.cluster.Spec.PodSpec.NodeSelector
+	in.PriorityClassName = s.cluster.Spec.PodSpec.PriorityClassName
+	in.Tolerations = s.cluster.Spec.PodSpec.Tolerations
+
 	boolTrue := true
 	in.Containers[0].Env = []core.EnvVar{
 		{
@@ -188,6 +196,10 @@ func (s *jobSyncer) updateStatus(job *batch.Job) {
 	// check for failed condition
 	if cond := jobCondition(batch.JobFailed, job); cond != nil {
 		s.backup.UpdateStatusCondition(api.BackupFailed, cond.Status, cond.Reason, cond.Message)
+
+		if cond.Status == core.ConditionTrue {
+			s.backup.Status.Completed = true
+		}
 	}
 }
 

--- a/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlbackupcron/job_backup.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlbackupcron/job_backup.go
@@ -37,6 +37,7 @@ type job struct {
 	c client.Client
 
 	BackupScheduleJobsHistoryLimit *int
+	BackupRemoteDeletePolicy       api.DeletePolicy
 }
 
 func (j *job) Run() {
@@ -84,7 +85,8 @@ func (j *job) createBackup() (*api.MysqlBackup, error) {
 			Labels:    j.recurrentBackupLabels(),
 		},
 		Spec: api.MysqlBackupSpec{
-			ClusterName: j.ClusterName,
+			ClusterName:        j.ClusterName,
+			RemoteDeletePolicy: j.BackupRemoteDeletePolicy,
 		},
 	}
 	return backup, j.c.Create(context.TODO(), backup)

--- a/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlbackupcron/mysqlbackupcron_controller.go
@@ -187,6 +187,7 @@ func (r *ReconcileMysqlBackup) updateClusterSchedule(cluster *mysqlv1alpha1.Mysq
 		Namespace:                      cluster.Namespace,
 		c:                              r.Client,
 		BackupScheduleJobsHistoryLimit: cluster.Spec.BackupScheduleJobsHistoryLimit,
+		BackupRemoteDeletePolicy:       cluster.Spec.BackupRemoteDeletePolicy,
 	}, cluster.Name)
 
 	return nil

--- a/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlcluster/internal/upgrades/upgrades.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/controller/mysqlcluster/internal/upgrades/upgrades.go
@@ -33,6 +33,7 @@ import (
 	"github.com/presslabs/mysql-operator/pkg/internal/mysqlcluster"
 	"github.com/presslabs/mysql-operator/pkg/options"
 	orc "github.com/presslabs/mysql-operator/pkg/orchestrator"
+	"github.com/presslabs/mysql-operator/pkg/util/constants"
 )
 
 var log = logf.Log.WithName("upgrades.cluster")
@@ -69,14 +70,20 @@ func (u *upgrader) Run(ctx context.Context) error {
 		return err
 	}
 
+	// register old nodes in new orchestrator
+	for _, ns := range u.cluster.Status.Nodes {
+		if err = u.orcClient.Discover(ns.Name, constants.MysqlPort); err != nil {
+			log.Error(err, "failed to discover old hosts in new orchestrator - continue", "host", ns.Name)
+		}
+	}
+
+	// retrieve instances from orchestrator
 	insts, err := u.instancesFromOrc()
 	if err != nil {
 		return err
 	}
 
-	// more than 1 replica so there is the case when node 0 is slave so mark all other nodes as
-	// in maintenance except node 0.
-	// TODO: or set promotion rules
+	// more than 1 replica so there is the case when node 0 is slave so scale down to 1
 	if int(*sts.Spec.Replicas) > 1 {
 		one := int32(1)
 		sts.Spec.Replicas = &one
@@ -181,7 +188,7 @@ func (u *upgrader) checkNode0Ok(insts []orc.Instance) error {
 	node0 := u.getNodeFrom(insts, 0)
 	if node0 == nil {
 		// continue
-		log.Info("no node found in orchestraotr")
+		log.Info("no node found in orchestrator")
 		return fmt.Errorf("node-0 not found in orchestarotr")
 	}
 

--- a/vendor/github.com/presslabs/mysql-operator/pkg/internal/mysqlcluster/defaults.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/internal/mysqlcluster/defaults.go
@@ -26,6 +26,7 @@ import (
 
 	api "github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1"
 	"github.com/presslabs/mysql-operator/pkg/options"
+	"github.com/presslabs/mysql-operator/pkg/util/constants"
 )
 
 // nolint: megacheck, deadcode, varcheck
@@ -53,8 +54,9 @@ func (cluster *MysqlCluster) SetDefaults(opt *options.Options) {
 		}
 	}
 
+	// set mysql version if not set to avoid spamming logs
 	if len(cluster.Spec.MysqlVersion) == 0 {
-		cluster.Spec.MysqlVersion = "5.7"
+		cluster.Spec.MysqlVersion = constants.MySQLDefaultVersion.String()
 	}
 
 	// set pod antiaffinity to nodes stay away from other nodes.

--- a/vendor/github.com/presslabs/mysql-operator/pkg/internal/mysqlcluster/mysqlcluster.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/internal/mysqlcluster/mysqlcluster.go
@@ -18,7 +18,10 @@ package mysqlcluster
 
 import (
 	"fmt"
+	"github.com/presslabs/mysql-operator/pkg/options"
+	"strings"
 
+	"github.com/blang/semver"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -60,11 +63,6 @@ func (c *MysqlCluster) GetLabels() labels.Set {
 		instance = inst
 	}
 
-	version := "5.7"
-	if len(c.Spec.MysqlVersion) != 0 {
-		version = c.Spec.MysqlVersion
-	}
-
 	component := "database"
 	if comp, ok := c.Annotations["app.kubernetes.io/component"]; ok {
 		component = comp
@@ -75,7 +73,7 @@ func (c *MysqlCluster) GetLabels() labels.Set {
 
 		"app.kubernetes.io/name":       "mysql",
 		"app.kubernetes.io/instance":   instance,
-		"app.kubernetes.io/version":    version,
+		"app.kubernetes.io/version":    c.GetMySQLSemVer().String(),
 		"app.kubernetes.io/component":  component,
 		"app.kubernetes.io/managed-by": "mysql.presslabs.org",
 	}
@@ -170,19 +168,42 @@ func (c *MysqlCluster) GetMasterHost() string {
 	return masterHost
 }
 
+// GetMySQLSemVer returns the MySQL server version in semver format, or the default one
+func (c *MysqlCluster) GetMySQLSemVer() semver.Version {
+	version := c.Spec.MysqlVersion
+	// lookup for an alias, usually this will solve 5.7 to 5.7.x
+	if v, ok := constants.MySQLTagsToSemVer[version]; ok {
+		version = v
+	}
+
+	sv, err := semver.Make(version)
+	if err != nil {
+		log.Error(err, "failed to parse given MySQL version", "input", version)
+	}
+
+	// if there is an error will return 0.0.0
+	return sv
+}
+
 // GetMysqlImage returns the mysql image for current mysql cluster
 func (c *MysqlCluster) GetMysqlImage() string {
 	if len(c.Spec.Image) != 0 {
 		return c.Spec.Image
 	}
 
-	if len(c.Spec.MysqlVersion) != 0 {
-		if img, ok := constants.MysqlImageVersions[c.Spec.MysqlVersion]; ok {
-			return img
-		}
+	// check if the user set some overrides
+	opt := options.GetOptions()
+	if img, ok := opt.MySQLVersionImageOverride[c.GetMySQLSemVer().String()]; ok {
+		return img
+	}
+
+	if img, ok := constants.MysqlImageVersions[c.GetMySQLSemVer().String()]; ok {
+		return img
 	}
 
 	// this means the cluster has a wrong MysqlVersion set
+	log.Error(nil, "no image found with given MySQL version, the image can manually be set by setting .spec.mysqlImage on cluster",
+		"version", c.GetMySQLSemVer())
 	return ""
 }
 
@@ -192,4 +213,11 @@ func (c *MysqlCluster) UpdateSpec() {
 	if len(c.Spec.InitBucketURL) == 0 {
 		c.Spec.InitBucketURL = c.Spec.InitBucketURI
 	}
+}
+
+// ShouldHaveInitContainerForMysql checks the MySQL version and returns true or false if the docker image supports or not init only
+func (c *MysqlCluster) ShouldHaveInitContainerForMysql() bool {
+	expectedRange := semver.MustParseRange(">=5.7.26 <8.0.0 || >=8.0.15")
+
+	return strings.Contains(c.GetMysqlImage(), "percona") && expectedRange(c.GetMySQLSemVer())
 }

--- a/vendor/github.com/presslabs/mysql-operator/pkg/options/options.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/options/options.go
@@ -65,6 +65,10 @@ type Options struct {
 
 	// Namespace where to look after objects. This will limit the operator action range.
 	Namespace string
+
+	// MySQLVersionImageOverride define a map between MySQL version and image.
+	// This overrides the default versions and has priority.
+	MySQLVersionImageOverride map[string]string
 }
 
 type pullpolicy corev1.PullPolicy
@@ -89,7 +93,7 @@ func newPullPolicyValue(defaultValue corev1.PullPolicy, v *corev1.PullPolicy) *p
 }
 
 const (
-	defaultExporterImage = "prom/mysqld-exporter:latest"
+	defaultExporterImage = "prom/mysqld-exporter:v0.11.0"
 
 	defaultImagePullPolicy     = corev1.PullIfNotPresent
 	defaultImagePullSecretName = ""
@@ -98,7 +102,7 @@ const (
 	defaultOrchestratorTopologyPassword = ""
 
 	defaultLeaderElectionNamespace = "default"
-	defaultLeaderElectionID        = ""
+	defaultLeaderElectionID        = "mysql-operator-leader-election"
 
 	defaultNamespace = ""
 )
@@ -134,6 +138,9 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&o.Namespace, "namespace", defaultNamespace,
 		"The namespace to restrict the client to watch objects.")
+
+	fs.StringToStringVar(&o.MySQLVersionImageOverride, "mysql-versions-to-image", map[string]string{},
+		"A map to override default image for different mysql versions. Example: 5.7.23=mysql:5.7,5.7.24=mysql:5.7")
 }
 
 var instance *Options

--- a/vendor/github.com/presslabs/mysql-operator/pkg/orc-helper/helper.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/orc-helper/helper.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2019 Pressinfra SRL
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchelper
+
+import (
+	"context"
+	"fmt"
+	"github.com/presslabs/controller-util/rand"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/reference"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"time"
+
+	api "github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1"
+	"github.com/presslabs/mysql-operator/pkg/internal/mysqlcluster"
+)
+
+// parse the orchestrator cluster name as NamespacedName
+func orcNameToKey(name string) (types.NamespacedName, error) {
+	components := strings.Split(name, ".")
+	if len(components) != 2 {
+		return types.NamespacedName{}, fmt.Errorf("can't parse name: %s", name)
+	}
+
+	return types.NamespacedName{Name: components[0], Namespace: components[1]}, nil
+}
+
+// UpdateClusterFailoverCond updates the cluster FailoverInProgress condition on the given cluster
+func UpdateClusterFailoverCond(c client.Client, clusterName, reason, msg string, status bool) error {
+	key, err := orcNameToKey(clusterName)
+	if err != nil {
+		return err
+	}
+
+	cluster := mysqlcluster.New(&api.MysqlCluster{})
+
+	// get cluster from k8s
+	if err := c.Get(context.TODO(), key, cluster.Unwrap()); err != nil {
+		return err
+	}
+
+	s := corev1.ConditionFalse
+	if status {
+		s = corev1.ConditionTrue
+	}
+
+	// update cluster failover in progress condition
+	cluster.UpdateStatusCondition(api.ClusterConditionFailoverInProgress, s, reason, msg)
+
+	// update cluster status
+	if err := c.Status().Update(context.TODO(), cluster.Unwrap()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateEventForCluster records an event on MySQL cluster resource
+func UpdateEventForCluster(c client.Client, s *runtime.Scheme, clusterName, evReason, evMsg string, warning bool) error {
+	key, err := orcNameToKey(clusterName)
+	if err != nil {
+		return err
+	}
+
+	cluster := mysqlcluster.New(&api.MysqlCluster{})
+
+	// get cluster from k8s
+	if err = c.Get(context.TODO(), key, cluster.Unwrap()); err != nil {
+		return err
+	}
+
+	evType := corev1.EventTypeNormal
+	if warning {
+		evType = corev1.EventTypeWarning
+	}
+
+	ref, err := reference.GetReference(s, cluster.Unwrap())
+	if err != nil {
+		return err
+	}
+
+	randStr, err := rand.AlphaNumericString(5)
+	if err != nil {
+		return err
+	}
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s.%d", cluster.Name, randStr, time.Now().Unix()),
+			Namespace: cluster.Namespace,
+		},
+		FirstTimestamp: metav1.Now(),
+		Type:           evType,
+		Reason:         evReason,
+		Message:        evMsg,
+		Source:         corev1.EventSource{Component: "orchestrator"},
+		InvolvedObject: *ref,
+	}
+	if err := c.Create(context.TODO(), event); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/presslabs/mysql-operator/pkg/sidecar/appclone.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/sidecar/appclone.go
@@ -24,11 +24,10 @@ import (
 )
 
 // RunCloneCommand clone the data from source.
-// nolint: gocyclo
 func RunCloneCommand(cfg *Config) error {
 	log.Info("cloning command", "host", cfg.Hostname)
 
-	if checkIfDataExists() {
+	if cfg.ExistsMySQLData {
 		log.Info("data already exists! Remove manually PVC to cleanup or to reinitialize.")
 		return nil
 	}
@@ -37,23 +36,22 @@ func RunCloneCommand(cfg *Config) error {
 		return fmt.Errorf("removing lost+found: %s", err)
 	}
 
-	if cfg.ServerID() == 100 {
-		if len(cfg.InitBucketURL) == 0 {
-			log.Info("skip cloning init bucket uri is not set.")
-			// let mysqld initialize data dir
-			return nil
-		}
-		err := cloneFromBucket(cfg.InitBucketURL)
-		if err != nil {
-			return fmt.Errorf("failed to clone from bucket, err: %s", err)
-		}
-	} else {
-		// clonging from prior node
+	if cfg.ServerID() > 100 {
+		// cloning from prior node
 		sourceHost := cfg.FQDNForServer(cfg.ServerID() - 1)
 		err := cloneFromSource(cfg, sourceHost)
 		if err != nil {
 			return fmt.Errorf("failed to clone from %s, err: %s", sourceHost, err)
 		}
+	} else if cfg.ShouldCloneFromBucket() {
+		// cloning from provided initBucketURL
+		err := cloneFromBucket(cfg.InitBucketURL)
+		if err != nil {
+			return fmt.Errorf("failed to clone from bucket, err: %s", err)
+		}
+	} else {
+		log.Info("nothing to clone or init from")
+		return nil
 	}
 
 	// prepare backup
@@ -76,8 +74,7 @@ func cloneFromBucket(initBucket string) error {
 	// rclone --config={conf file} cat {bucket uri}
 	// writes to stdout the content of the bucket uri
 	// nolint: gosec
-	rclone := exec.Command("rclone", "-vv",
-		fmt.Sprintf("--config=%s", rcloneConfigFile), "cat", initBucket)
+	rclone := exec.Command("rclone", "-vv", rcloneConfigArg, "cat", initBucket)
 
 	// gzip reads from stdin decompress and then writes to stdout
 	// nolint: gosec
@@ -171,20 +168,6 @@ func xtrabackupPreperData() error {
 	xtbkCmd.Stderr = os.Stderr
 
 	return xtbkCmd.Run()
-}
-
-// nolint: gosec
-func checkIfDataExists() bool {
-	path := fmt.Sprintf("%s/mysql", dataDir)
-	_, err := os.Open(path)
-
-	if os.IsNotExist(err) {
-		return false
-	} else if err != nil {
-		log.Error(err, "failed to open file", "file", path)
-	}
-
-	return true
 }
 
 func deleteLostFound() error {

--- a/vendor/github.com/presslabs/mysql-operator/pkg/sidecar/apptakebackup.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/sidecar/apptakebackup.go
@@ -42,8 +42,7 @@ func pushBackupFromTo(cfg *Config, srcHost, destBucket string) error {
 	gzip := exec.Command("gzip", "-c")
 
 	// nolint: gosec
-	rclone := exec.Command("rclone",
-		fmt.Sprintf("--config=%s", rcloneConfigFile), "rcat", tmpDestBucket)
+	rclone := exec.Command("rclone", rcloneConfigArg, "rcat", tmpDestBucket)
 
 	gzip.Stdin = response.Body
 	gzip.Stderr = os.Stderr
@@ -83,8 +82,7 @@ func pushBackupFromTo(cfg *Config, srcHost, destBucket string) error {
 	// the backup was a success
 	// remove .tmp extension
 	// nolint: gosec
-	rcMove := exec.Command("rclone",
-		fmt.Sprintf("--config=%s", rcloneConfigFile), "moveto", tmpDestBucket, destBucket)
+	rcMove := exec.Command("rclone", rcloneConfigArg, "moveto", tmpDestBucket, destBucket)
 
 	if err = rcMove.Start(); err != nil {
 		return fmt.Errorf("final move failed: %s", err)

--- a/vendor/github.com/presslabs/mysql-operator/pkg/sidecar/constants.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/sidecar/constants.go
@@ -68,8 +68,9 @@ var (
 )
 
 const (
-	// RcloneConfigFile represents the path to the file that contains rclon
+	// RcloneConfigFile represents the path to the file that contains rclone
 	// configs. This path should be the same as defined in docker entrypoint
-	// script from mysql-operator-sidecar/docker-entrypoint.sh. /etc/rclone.conf
-	rcloneConfigFile = "/tmp/rclone.conf"
+	// script from mysql-operator-sidecar/docker-entrypoint.sh. /tmp/rclone.conf
+	rcloneConfigFile = constants.RcloneConfigFile
+	rcloneConfigArg  = constants.RcloneConfigArg
 )

--- a/vendor/github.com/presslabs/mysql-operator/pkg/sidecar/server.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/sidecar/server.go
@@ -19,11 +19,12 @@ package sidecar
 import (
 	"context"
 	"fmt"
-	"github.com/presslabs/mysql-operator/pkg/util/constants"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
+
+	"github.com/presslabs/mysql-operator/pkg/util/constants"
 )
 
 const (

--- a/vendor/github.com/presslabs/mysql-operator/pkg/util/constants/constants.go
+++ b/vendor/github.com/presslabs/mysql-operator/pkg/util/constants/constants.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package constants
 
+import "github.com/blang/semver"
+
 const (
 	// MysqlPort is the default mysql port.
 	MysqlPort = 3306
@@ -64,12 +66,28 @@ const (
 	// ConfHeartBeatPath the path where to put the heartbeat.conf file
 	// it's important to have a different extension than .cnf to be ignore by MySQL include
 	ConfHeartBeatPath = "/etc/mysql/heartbeat.conf"
+
+	// RcloneConfigFile represents the path to the file that contains rclone
+	// configs. This path should be the same as defined in docker entrypoint
+	// script from mysql-operator-sidecar/docker-entrypoint.sh. /tmp/rclone.conf
+	RcloneConfigFile = "/tmp/rclone.conf"
+
+	// RcloneConfigArg represents the config argument to rclone cmd
+	RcloneConfigArg = "--config=" + RcloneConfigFile
 )
 
 var (
+	// MySQLDefaultVersion is the version for mysql that should be used
+	MySQLDefaultVersion = semver.MustParse("5.7.26")
+	// MySQLTagsToSemVer maps simple version to semver versions
+	MySQLTagsToSemVer = map[string]string{
+		"5.7": "5.7.26",
+	}
 	// MysqlImageVersions is a map of supported mysql version and their image
 	MysqlImageVersions = map[string]string{
-		// percona:5.7.24 centos based image
-		"5.7": "percona@sha256:b3b7fb177b416563c46fe012298e042ec1607cc0539ce6014146380b0d27b08c",
+		// Percona:5.7.26 CentOS based image
+		"5.7.26": "percona@sha256:713c1817615b333b17d0fbd252b0ccc53c48a665d4cfcb42178167435a957322",
+		// Percona:5.7.24 CentOS based image
+		"5.7.24": "percona@sha256:b3b7fb177b416563c46fe012298e042ec1607cc0539ce6014146380b0d27b08c",
 	}
 )

--- a/vendor/github.com/presslabs/mysql-operator/test/e2e/e2e.go
+++ b/vendor/github.com/presslabs/mysql-operator/test/e2e/e2e.go
@@ -59,7 +59,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	ginkgo.By("Port-forward orchestrator")
 	client := core.NewForConfigOrDie(kubeCfg).RESTClient()
 	orcTunnel = pf.NewTunnel(client, kubeCfg, operatorNamespace,
-		fmt.Sprintf("%s-orchestrator-0", releaseName),
+		fmt.Sprintf("%s-mysql-operator-0", releaseName),
 		orchestratorPort,
 	)
 	if err := orcTunnel.ForwardPort(); err != nil {

--- a/vendor/github.com/presslabs/mysql-operator/test/e2e/framework/helm.go
+++ b/vendor/github.com/presslabs/mysql-operator/test/e2e/framework/helm.go
@@ -33,6 +33,7 @@ func HelmInstallChart(release, ns string) {
 		"--kube-context", TestContext.KubeContext,
 		"--set", fmt.Sprintf("image=%s", TestContext.OperatorImage),
 		"--set", fmt.Sprintf("sidecarImage=%s", TestContext.SidecarImage),
+		"--set", fmt.Sprintf("orchestrator.image=%s", TestContext.OrchestratorImage),
 	}
 
 	cmd := exec.Command("helm", args...)

--- a/vendor/github.com/presslabs/mysql-operator/test/e2e/framework/text_context.go
+++ b/vendor/github.com/presslabs/mysql-operator/test/e2e/framework/text_context.go
@@ -36,8 +36,9 @@ type TestContextType struct {
 	ChartPath   string
 	ChartValues string
 
-	OperatorImage string
-	SidecarImage  string
+	OperatorImage     string
+	SidecarImage      string
+	OrchestratorImage string
 
 	TimeoutSeconds    int
 	DumpLogsOnFailure bool
@@ -66,6 +67,7 @@ func RegisterCommonFlags() {
 
 	flag.StringVar(&TestContext.OperatorImage, "operator-image", "quay.io/presslabs/mysql-operator:build", "Image for mysql operator.")
 	flag.StringVar(&TestContext.SidecarImage, "sidecar-image", "quay.io/presslabs/mysql-operator-sidecar:build", "Image for mysql helper.")
+	flag.StringVar(&TestContext.OrchestratorImage, "orchestrator-image", "quay.io/presslabs/mysql-operator-orchestrator:build", "Image for mysql orchestrator.")
 
 	flag.IntVar(&TestContext.TimeoutSeconds, "pod-wait-timeout", 100, "Timeout to wait for a pod to be ready.")
 	flag.BoolVar(&TestContext.DumpLogsOnFailure, "dump-logs-on-failure", true, "Dump pods logs when a test fails.")


### PR DESCRIPTION
This adds the option the user restore an existing Mattermost database when requesting a new mattermost installation

- the user need to create the back/restore secret like
```
apiVersion: v1
kind: Secret
metadata:
  name: backrestore
type: Opaque
stringData:
  AWS_ACCESS_KEY_ID: XXXXXXX
  AWS_SECRET_ACCESS_KEY: XXXX
  AWS_REGION: us-east-1
  S3_PROVIDER: AWS
```