### PR TITLE
MM-16276 Allow k8s reconcile loop to monitor ongoing updates

### DIFF
--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -259,9 +259,9 @@ func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermost
 		alreadyRunning, err := r.fetchRunningUpdateJob(mi, reqLogger)
 		if err != nil && k8sErrors.IsNotFound(err) {
 			reqLogger.Info("Launching update job")
-			if err := r.launchUpdateJob(mi, new, imageName, reqLogger); err != nil {
+			if er := r.launchUpdateJob(mi, new, imageName, reqLogger); er != nil {
 				reqLogger.Error(err, "Launching update job failed")
-				return err
+				return er
 			} else {
 				return errors.New("Began update job")
 			}

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
 	objectMatcher "github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/go-logr/logr"
@@ -15,10 +14,14 @@ import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 )
+
+const updateName = "mattermost-update-check"
 
 func (r *ReconcileClusterInstallation) checkMattermost(mattermost *mattermostv1alpha1.ClusterInstallation, reqLogger logr.Logger) error {
 	reqLogger = reqLogger.WithValues("Reconcile", "mattermost")
@@ -197,6 +200,36 @@ func (r *ReconcileClusterInstallation) checkMattermostDeployment(mattermost *mat
 	return nil
 }
 
+func (r *ReconcileClusterInstallation) launchUpdateJob(mi *mattermostv1alpha1.ClusterInstallation, new *appsv1.Deployment, imageName string, reqLogger logr.Logger) error {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      updateName,
+			Namespace: mi.GetNamespace(),
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": updateName},
+				},
+				Spec: *new.Spec.Template.Spec.DeepCopy(),
+			},
+		},
+	}
+
+	// Override values for job-specific behavior.
+	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+	for i := range job.Spec.Template.Spec.Containers {
+		job.Spec.Template.Spec.Containers[i].Command = []string{"mattermost", "version"}
+	}
+
+	err := r.client.Create(context.TODO(), job)
+	if err != nil && !k8sErrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
 // updateMattermostDeployment checks if the deployment should be updated.
 // If an update is required then the deployment spec is set to:
 // - roll forward version
@@ -223,89 +256,89 @@ func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermost
 	// we will return and not upgrade the deployment.
 	if update {
 		reqLogger.Info(fmt.Sprintf("Running Mattermost image %s upgrade job check", imageName))
-
-		updateName := "mattermost-update-check"
-		job := &batchv1.Job{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      updateName,
-				Namespace: mi.GetNamespace(),
-			},
-			Spec: batchv1.JobSpec{
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{"app": updateName},
-					},
-					Spec: *new.Spec.Template.Spec.DeepCopy(),
-				},
-			},
+		alreadyRunning, err := r.fetchRunningUpdateJob(mi, reqLogger)
+		if err != nil && k8sErrors.IsNotFound(err) {
+			reqLogger.Info("Launching update job")
+			if err := r.launchUpdateJob(mi, new, imageName, reqLogger); err != nil {
+				reqLogger.Error(err, "Launching update job failed")
+				return err
+			} else {
+				return errors.New("Began update job")
+			}
 		}
 
-		// Override values for job-specific behavior.
-		job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
-		for i := range job.Spec.Template.Spec.Containers {
-			job.Spec.Template.Spec.Containers[i].Command = []string{"mattermost", "version"}
-		}
-
-		err := r.client.Create(context.TODO(), job)
-		if err != nil && !k8sErrors.IsAlreadyExists(err) {
+		if err != nil {
+			reqLogger.Error(err, "Error trying to determine if an update job already is running")
 			return err
 		}
-		defer func() {
-			err = r.client.Delete(context.TODO(), job)
-			if err != nil {
-				reqLogger.Error(err, "Unable to cleanup image update check job")
-			}
-		}()
 
-		// Wait up to 60 seconds for the update check job to return successfully.
-		timer := time.NewTimer(60 * time.Second)
-		defer timer.Stop()
+		// job is done, schedule cleanup
+		if alreadyRunning.Status.CompletionTime != nil {
+			defer func() {
+				reqLogger.Info(fmt.Sprintf("Deleting job %s/%s",
+					alreadyRunning.GetNamespace(), alreadyRunning.GetName()))
 
-	upgradeJobCheck:
-		for {
-			select {
-			case <-timer.C:
-				return errors.New("timed out waiting for mattermost image update check job to succeed")
-			default:
-				foundJob := &batchv1.Job{}
-				err = r.client.Get(
-					context.TODO(),
-					types.NamespacedName{
-						Name:      updateName,
-						Namespace: mi.GetNamespace(),
-					},
-					foundJob,
-				)
+				err = r.client.Delete(context.TODO(), alreadyRunning)
 				if err != nil {
-					continue
-				}
-				if foundJob.Status.Failed > 0 {
-					return errors.New("Upgrade image job check failed")
-				}
-				if foundJob.Status.Succeeded > 0 {
-					break upgradeJobCheck
+					reqLogger.Error(err, "Unable to cleanup image update check job")
 				}
 
-				time.Sleep(1 * time.Second)
-			}
+				podList := &corev1.PodList{}
+				listOptions := k8sClient.ListOptions{
+					LabelSelector: labels.SelectorFromSet(
+						labels.Set(map[string]string{"app": updateName})),
+					Namespace: alreadyRunning.GetNamespace(),
+				}
+
+				err = r.client.List(context.Background(), &listOptions, podList)
+				reqLogger.Info(fmt.Sprintf("Deleting %d pods", len(podList.Items)))
+				for _, p := range podList.Items {
+					reqLogger.Info(fmt.Sprintf("Deleting pod %s/%s", p.Namespace, p.Name))
+					err = r.client.Delete(context.TODO(), &p)
+					if err != nil {
+						reqLogger.Error(err, "Problem deleting pod %s", p)
+					}
+				}
+			}()
+		} else {
+			return errors.New("Update image job still running...")
 		}
-	}
 
-	reqLogger.Info("Upgrade image job ran successfully")
+		// it's done, it either failed or succeded
 
-	patchResult, err := objectMatcher.DefaultPatchMaker.Calculate(original, new)
-	if err != nil {
-		return errors.Wrap(err, "error checking the difference in the deployment")
-	}
+		if alreadyRunning.Status.Failed > 0 {
+			err = errors.New("Upgrade job failed")
+			return err
+		}
 
-	if !patchResult.IsEmpty() {
-		err := objectMatcher.DefaultAnnotator.SetLastAppliedAnnotation(new)
+		reqLogger.Info("Upgrade image job ran successfully")
+
+		patchResult, err := objectMatcher.DefaultPatchMaker.Calculate(original, new)
 		if err != nil {
-			return errors.Wrap(err, "error applying the annotation in the deployment")
+			return errors.Wrap(err, "error checking the difference in the deployment")
 		}
 
-		return r.client.Update(context.TODO(), new)
-	}
+		if !patchResult.IsEmpty() {
+			err := objectMatcher.DefaultAnnotator.SetLastAppliedAnnotation(new)
+			if err != nil {
+				return errors.Wrap(err, "error applying the annotation in the deployment")
+			}
 
+			return r.client.Update(context.TODO(), new)
+		}
+	}
 	return nil
+}
+
+func (r *ReconcileClusterInstallation) fetchRunningUpdateJob(mi *mattermostv1alpha1.ClusterInstallation, reqLogger logr.Logger) (job *batchv1.Job, err error) {
+	foundJob := &batchv1.Job{}
+	err = r.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      updateName,
+			Namespace: mi.GetNamespace(),
+		},
+		foundJob,
+	)
+	return foundJob, err
 }

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -259,12 +259,11 @@ func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermost
 		alreadyRunning, err := r.fetchRunningUpdateJob(mi, reqLogger)
 		if err != nil && k8sErrors.IsNotFound(err) {
 			reqLogger.Info("Launching update job")
-			if er := r.launchUpdateJob(mi, new, imageName, reqLogger); er != nil {
+			if err = r.launchUpdateJob(mi, new, imageName, reqLogger); err != nil {
 				reqLogger.Error(err, "Launching update job failed")
-				return er
-			} else {
-				return errors.New("Began update job")
+				return err
 			}
+			return errors.New("Began update job")
 		}
 
 		if err != nil {
@@ -307,8 +306,7 @@ func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermost
 		// it's done, it either failed or succeded
 
 		if alreadyRunning.Status.Failed > 0 {
-			err = errors.New("Upgrade job failed")
-			return err
+			return errors.New("Upgrade job failed")
 		}
 
 		reqLogger.Info("Upgrade image job ran successfully")
@@ -330,9 +328,9 @@ func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermost
 	return nil
 }
 
-func (r *ReconcileClusterInstallation) fetchRunningUpdateJob(mi *mattermostv1alpha1.ClusterInstallation, reqLogger logr.Logger) (job *batchv1.Job, err error) {
+func (r *ReconcileClusterInstallation) fetchRunningUpdateJob(mi *mattermostv1alpha1.ClusterInstallation, reqLogger logr.Logger) (*batchv1.Job, error) {
 	foundJob := &batchv1.Job{}
-	err = r.client.Get(
+	err := r.client.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      updateName,

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -260,15 +260,13 @@ func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermost
 		if err != nil && k8sErrors.IsNotFound(err) {
 			reqLogger.Info("Launching update job")
 			if err = r.launchUpdateJob(mi, new, imageName, reqLogger); err != nil {
-				reqLogger.Error(err, "Launching update job failed")
-				return err
+				return errors.Wrap(err, "Launching update job failed")
 			}
 			return errors.New("Began update job")
 		}
 
 		if err != nil {
-			reqLogger.Error(err, "Error trying to determine if an update job already is running")
-			return err
+			return errors.Wrap(err, "Error trying to determine if an update job already is running")
 		}
 
 		if alreadyRunning.Status.CompletionTime == nil {
@@ -298,7 +296,7 @@ func (r *ReconcileClusterInstallation) updateMattermostDeployment(mi *mattermost
 				reqLogger.Info(fmt.Sprintf("Deleting pod %s/%s", p.Namespace, p.Name))
 				err = r.client.Delete(context.TODO(), &p)
 				if err != nil {
-					reqLogger.Error(err, "Problem deleting pod %s", p)
+					reqLogger.Error(err, fmt.Sprintf("Problem deleting pod %s/%s", p.Namespace, p.Name))
 				}
 			}
 		}()

--- a/pkg/controller/clusterinstallation/mattermost_test.go
+++ b/pkg/controller/clusterinstallation/mattermost_test.go
@@ -102,13 +102,15 @@ func TestCheckMattermost(t *testing.T) {
 
 	t.Run("deployment", func(t *testing.T) {
 		updateName := "mattermost-update-check"
+		now := metav1.Now()
 		job := &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      updateName,
 				Namespace: ci.GetNamespace(),
 			},
 			Status: batchv1.JobStatus{
-				Succeeded: 1,
+				Succeeded:      1,
+				CompletionTime: &now,
 			},
 		}
 		err := r.client.Create(context.TODO(), job)

--- a/test/e2e/mattermost_test.go
+++ b/test/e2e/mattermost_test.go
@@ -40,7 +40,7 @@ func TestMattermost(t *testing.T) {
 	ctx := framework.NewTestCtx(t)
 	defer ctx.Cleanup()
 
-	t.Run("initialize cluster resrouces", func(t *testing.T) {
+	t.Run("initialize cluster resources", func(t *testing.T) {
 		err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 		require.NoError(t, err)
 	})


### PR DESCRIPTION
Hi everyone, this change should resolve [MM-16276](https://mattermost.atlassian.net/browse/MM-16276).

After this change, when `updateMattermostDeployment` detects that an update `Job` needs to be run, it does not wait for the `Job` to complete before returning control back to the reconciliation loop. Instead, it starts the `Job` and then returns an error each time it is called until the update succeeds. This keeps the cluster `Reconciling` until the update completes.

When the update `Job` is complete, `updateMattermostDeployment` will detect this and clean up the created `Job` and `Pod`, regardless as to whether it succeeded or failed.

This change in architecture allows update to overcome the limitation previously imposed by the 1 minute timeout.