### PR TITLE
Mm 18604 - Adding hardcoded value for NGINX file size limit and configuring Mattermost config to get the same value 

### DIFF
--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -416,10 +417,12 @@ func (mattermost *ClusterInstallation) GenerateDeployment(deploymentName, ingres
 
 	if !mattermost.Spec.UseServiceLoadBalancer {
 		if _, ok := mattermost.Spec.IngressAnnotations["nginx.ingress.kubernetes.io/proxy-body-size"]; ok {
-			size, _ := strconv.Atoi(mattermost.Spec.IngressAnnotations["nginx.ingress.kubernetes.io/proxy-body-size"])
+			size := mattermost.Spec.IngressAnnotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+			reg := regexp.MustCompile(`M`)
+			sizeWithoutUnit, _ := strconv.Atoi(reg.Split(size, 2)[0])
 			envVarGeneral = append(envVarGeneral, corev1.EnvVar{
 				Name:  "MM_FILESETTINGS_MAXFILESIZE",
-				Value: strconv.Itoa(size * 1048576),
+				Value: strconv.Itoa(sizeWithoutUnit * 1048576),
 			})
 		} else {
 			envVarGeneral = append(envVarGeneral, corev1.EnvVar{

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -411,6 +412,21 @@ func (mattermost *ClusterInstallation) GenerateDeployment(deploymentName, ingres
 			Name:  "MM_PLUGINSETTINGS_ENABLEUPLOADS",
 			Value: "true",
 		},
+	}
+
+	if !mattermost.Spec.UseServiceLoadBalancer {
+		if _, ok := mattermost.Spec.IngressAnnotations["nginx.ingress.kubernetes.io/proxy-body-size"]; ok {
+			size, _ := strconv.Atoi(mattermost.Spec.IngressAnnotations["nginx.ingress.kubernetes.io/proxy-body-size"])
+			envVarGeneral = append(envVarGeneral, corev1.EnvVar{
+				Name:  "MM_FILESETTINGS_MAXFILESIZE",
+				Value: strconv.Itoa(size * 1048576),
+			})
+		} else {
+			envVarGeneral = append(envVarGeneral, corev1.EnvVar{
+				Name:  "MM_FILESETTINGS_MAXFILESIZE",
+				Value: strconv.Itoa(1000 * 1048576),
+			})
+		}
 	}
 
 	// Mattermost License

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -34,7 +34,7 @@ func (r *ReconcileClusterInstallation) checkMattermost(mattermost *mattermostv1a
 	if !mattermost.Spec.UseServiceLoadBalancer {
 		ingressAnnotations := map[string]string{
 			"kubernetes.io/ingress.class":                 "nginx",
-			"nginx.ingress.kubernetes.io/proxy-body-size": "1000",
+			"nginx.ingress.kubernetes.io/proxy-body-size": "1000M",
 		}
 		for k, v := range mattermost.Spec.IngressAnnotations {
 			ingressAnnotations[k] = v

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -32,7 +32,15 @@ func (r *ReconcileClusterInstallation) checkMattermost(mattermost *mattermostv1a
 	}
 
 	if !mattermost.Spec.UseServiceLoadBalancer {
-		err = r.checkMattermostIngress(mattermost, mattermost.Name, mattermost.Spec.IngressName, mattermost.Spec.IngressAnnotations, reqLogger)
+		ingressAnnotations := map[string]string{
+			"kubernetes.io/ingress.class":                 "nginx",
+			"nginx.ingress.kubernetes.io/proxy-body-size": "1000",
+		}
+		for k, v := range mattermost.Spec.IngressAnnotations {
+			ingressAnnotations[k] = v
+		}
+
+		err = r.checkMattermostIngress(mattermost, mattermost.Name, mattermost.Spec.IngressName, ingressAnnotations, reqLogger)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
With this PR a default value of 1000M is added when Nginx is used together with the Nginx Annotation. The same default value is added in the Mattermost configuration.

In case a user adds manually ingressAnnotations in the cluster installation config, the default value is overwritten with the user option.

Ticket -> https://mattermost.atlassian.net/browse/MM-18604