### PR TITLE
Check Mattermost pod readiness

### DIFF
--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -107,6 +107,21 @@ func (r *ReconcileClusterInstallation) checkClusterInstallation(name, imageName,
 		if pod.Spec.Containers[0].Image != imageName {
 			return status, fmt.Errorf("mattermost pod %s is running incorrect image", pod.Name)
 		}
+
+		podIsReady := false
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady {
+				if condition.Status == corev1.ConditionTrue {
+					podIsReady = true
+				} else {
+					return status, fmt.Errorf("mattermost pod %s is not ready", pod.Name)
+				}
+			}
+		}
+		if !podIsReady {
+			return status, fmt.Errorf("mattermost pod %s is not ready", pod.Name)
+		}
+
 		status.UpdatedReplicas++
 	}
 

--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -113,6 +113,7 @@ func (r *ReconcileClusterInstallation) checkClusterInstallation(name, imageName,
 			if condition.Type == corev1.PodReady {
 				if condition.Status == corev1.ConditionTrue {
 					podIsReady = true
+					break
 				} else {
 					return status, fmt.Errorf("mattermost pod %s is not ready", pod.Name)
 				}


### PR DESCRIPTION
The final health check for the Mattermost pods didn't check for
readiness. This could lead to the cluster installation passing
the operator check and being marked as stable, only to fail future
deployment health checks and then be restarted.

https://mattermost.atlassian.net/browse/MM-19298