### PR TITLE
Ensure generate-test checks generated manifests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,12 @@ jobs:
       - run: |
           mkdir -p /tmp/pkg/apis/mattermost/v1alpha1
           cp -R pkg/apis/mattermost/v1alpha1/* /tmp/pkg/apis/mattermost/v1alpha1
+      - run: |
+          mkdir -p /tmp/deploy/crds
+          cp -R deploy/crds/* /tmp/deploy/crds
       - run: make generate
       - run: diff /tmp/pkg/apis/mattermost/v1alpha1 pkg/apis/mattermost/v1alpha1
+      - run: diff /tmp/deploy/crds deploy/crds
 
   unittest:
     executor:


### PR DESCRIPTION
Before, this test would only check generated code. It now ensures
the manifests were generated properly as well.

https://mattermost.atlassian.net/browse/MM-20176