### PR TITLE
added TLS support during the deployment of Mattermost on Kubernetes

### DIFF
--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -234,7 +234,7 @@ func (mattermost *ClusterInstallation) GenerateService(serviceName, selectorName
 
 // GenerateIngress returns the ingress for Mattermost
 func (mattermost *ClusterInstallation) GenerateIngress(name, ingressName string, ingressAnnotations map[string]string) *v1beta1.Ingress {
-	return &v1beta1.Ingress{
+	var ingress = &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: mattermost.Namespace,
@@ -269,6 +269,16 @@ func (mattermost *ClusterInstallation) GenerateIngress(name, ingressName string,
 			},
 		},
 	}
+	if ingressAnnotations["cert-manager.io/issuer"] != "" {
+
+		ingress.Spec.TLS = []v1beta1.IngressTLS{
+			{
+				Hosts:      []string{ingressName},
+				SecretName: strings.ReplaceAll(ingressName, ".", "-") + "-tls-cert",
+			},
+		}
+	}
+	return ingress
 }
 
 // GetContainerByName gets container from a deployment by name

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -270,7 +270,6 @@ func (mattermost *ClusterInstallation) GenerateIngress(name, ingressName string,
 		},
 	}
 	if ingressAnnotations["cert-manager.io/issuer"] != "" {
-
 		ingress.Spec.TLS = []v1beta1.IngressTLS{
 			{
 				Hosts:      []string{ingressName},


### PR DESCRIPTION
#### Summary
Now it is possible to add TLS support during the deployment of Mattermost on Kubernetes. 
We tested this feature in combination with [cert-manager](https://cert-manager.io). Therefore you have to add the cert-manager issuer to your Mattermost deployment manifest. 

```yaml
apiVersion: mattermost.com/v1alpha1
kind: ClusterInstallation
metadata:
  name: your-mattermost-hostname.com
spec:
  size: 100users
  ingressName: yourmattermost.hostname.com
  ingressAnnotations:
    kubernetes.io/ingress.class: nginx
    cert-manager.io/issuer: letsencrypt-prod
  version: 5.17.1
  mattermostLicenseSecret: ""
  database:
    storageSize: 50Gi
  minio:
    storageSize: 50Gi
  elasticSearch:
    host: ""
    username: ""
    password: ""
```

The [cert-manager issuer](https://cert-manager.io/docs/tutorials/acme/ingress/#step-6-configure-let-s-encrypt-issuer) needs to be deployed into the Mattermost namespace. 

During the automatic configuration of the TLS feature a secret will be added to the cluster. The name of this secret follows this convention:

The name of the secret is identical to the ingressName but all the dots (.) are replaced by dashes (-) and the suffice "-tls-cert" will be appended. In the example above the secretName will be "yourmattermost-hostname-com-tls-cert".

As an additional point the official installation guide for Mattermost on Kubernetes needs to be updated (https://docs.mattermost.com/install/install-kubernetes.html).

#### Ticket Link
Fixes #97