### PR TITLE
Add arbitrary Mattermost pod environment variables

### DIFF
--- a/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
+++ b/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
@@ -805,6 +805,105 @@ spec:
               description: IngressName defines the name to be used when creating the
                 ingress rules
               type: string
+            mattermostEnv:
+              description: Optional environment variables to set in the Mattermost
+                application pods.
+              items:
+                description: EnvVar represents an environment variable present in
+                  a Container.
+                properties:
+                  name:
+                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                    type: string
+                  value:
+                    description: 'Variable references $(VAR_NAME) are expanded using
+                      the previous defined environment variables in the container
+                      and any service environment variables. If a variable cannot
+                      be resolved, the reference in the input string will be unchanged.
+                      The $(VAR_NAME) syntax can be escaped with a double $$, ie:
+                      $$(VAR_NAME). Escaped references will never be expanded, regardless
+                      of whether the variable exists or not. Defaults to "".'
+                    type: string
+                  valueFrom:
+                    description: Source for the environment variable's value. Cannot
+                      be used if value is not empty.
+                    properties:
+                      configMapKeyRef:
+                        description: Selects a key of a ConfigMap.
+                        properties:
+                          key:
+                            description: The key to select.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the ConfigMap or its key
+                              must be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                      fieldRef:
+                        description: 'Selects a field of the pod: supports metadata.name,
+                          metadata.namespace, metadata.labels, metadata.annotations,
+                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP.'
+                        properties:
+                          apiVersion:
+                            description: Version of the schema the FieldPath is written
+                              in terms of, defaults to "v1".
+                            type: string
+                          fieldPath:
+                            description: Path of the field to select in the specified
+                              API version.
+                            type: string
+                        required:
+                        - fieldPath
+                        type: object
+                      resourceFieldRef:
+                        description: 'Selects a resource of the container: only resources
+                          limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage,
+                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                          are currently supported.'
+                        properties:
+                          containerName:
+                            description: 'Container name: required for volumes, optional
+                              for env vars'
+                            type: string
+                          divisor:
+                            description: Specifies the output format of the exposed
+                              resources, defaults to "1"
+                            type: string
+                          resource:
+                            description: 'Required: resource to select'
+                            type: string
+                        required:
+                        - resource
+                        type: object
+                      secretKeyRef:
+                        description: Selects a key of a secret in the pod's namespace
+                        properties:
+                          key:
+                            description: The key of the secret to select from.  Must
+                              be a valid secret key.
+                            type: string
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
+                            type: string
+                          optional:
+                            description: Specify whether the Secret or its key must
+                              be defined
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                    type: object
+                required:
+                - name
+                type: object
+              type: array
             mattermostLicenseSecret:
               description: Secret that contains the mattermost license
               type: string

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
@@ -351,3 +351,49 @@ func TestClusterInstallationGenerateDeployment(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeEnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		original []corev1.EnvVar
+		new      []corev1.EnvVar
+		want     []corev1.EnvVar
+	}{
+		{
+			name:     "empty",
+			original: []corev1.EnvVar{},
+			new:      []corev1.EnvVar{},
+			want:     []corev1.EnvVar{},
+		},
+		{
+			name:     "append",
+			original: []corev1.EnvVar{},
+			new:      []corev1.EnvVar{{Name: "env1", Value: "value1"}},
+			want:     []corev1.EnvVar{{Name: "env1", Value: "value1"}},
+		},
+		{
+			name:     "merge",
+			original: []corev1.EnvVar{{Name: "env1", Value: "value1"}},
+			new:      []corev1.EnvVar{{Name: "env1", Value: "value2"}},
+			want:     []corev1.EnvVar{{Name: "env1", Value: "value2"}},
+		},
+		{
+			name:     "append and merge",
+			original: []corev1.EnvVar{{Name: "env1", Value: "value1"}},
+			new:      []corev1.EnvVar{{Name: "env1", Value: "value2"}, {Name: "env2", Value: "value1"}},
+			want:     []corev1.EnvVar{{Name: "env1", Value: "value2"}, {Name: "env2", Value: "value1"}},
+		},
+		{
+			name:     "complex",
+			original: []corev1.EnvVar{{Name: "env1", Value: "value1"}, {Name: "env2", Value: "value1"}},
+			new:      []corev1.EnvVar{{Name: "env1", Value: "value2"}, {Name: "env3", Value: "value1"}},
+			want:     []corev1.EnvVar{{Name: "env1", Value: "value2"}, {Name: "env2", Value: "value1"}, {Name: "env3", Value: "value1"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, mergeEnvVars(tt.original, tt.new))
+		})
+	}
+}

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -69,6 +69,9 @@ type ClusterInstallationSpec struct {
 
 	// +optional
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
+	// Optional environment variables to set in the Mattermost application pods.
+	// +optional
+	MattermostEnv []corev1.EnvVar `json:"mattermostEnv,omitempty"`
 }
 
 // Canary defines the configuration of Canary deployment for a ClusterInstallation

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.deepcopy.go
@@ -178,6 +178,13 @@ func (in *ClusterInstallationSpec) DeepCopyInto(out *ClusterInstallationSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.MattermostEnv != nil {
+		in, out := &in.MattermostEnv, &out.MattermostEnv
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -201,12 +201,25 @@ func schema_pkg_apis_mattermost_v1alpha1_ClusterInstallationSpec(ref common.Refe
 							},
 						},
 					},
+					"mattermostEnv": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional environment variables to set in the Mattermost application pods.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"ingressName"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.BlueGreen", "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.Canary", "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.Database", "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.ElasticSearch", "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.Minio", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.ResourceRequirements"},
+			"github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.BlueGreen", "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.Canary", "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.Database", "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.ElasticSearch", "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1.Minio", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.EnvVar", "k8s.io/api/core/v1.ResourceRequirements"},
 	}
 }
 


### PR DESCRIPTION
This change adds the ability to specify new env vars for Mattermost
application pods in the ClusterInstallation spec. These env vars
will replace existing variables with the same name or will be
appended if they are new.

Partial fix for:
https://mattermost.atlassian.net/browse/MM-21845
https://mattermost.atlassian.net/browse/MM-21846