### PR TITLE
Upgrade default Mattermost version to 5.19.1

### DIFF
--- a/docs/examples/full.yaml
+++ b/docs/examples/full.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mm-example-full # Name of your cluster as shown in Kubernetes.
 spec:
   image: mattermost/mattermost-enterprise-edition # Docker image for the app servers.
-  version: 5.18.0 # Docker tag for the image.
+  version: 5.19.1 # Docker tag for the image.
   size: 5000users # Size of the Mattermost installation, typically based on the number of users. Automatically sets the replica and resource limits for Minio, databaes and app servers based on the number provided here. Accepts 100users, 1000users, 5000users, 10000users, or 25000users. Manually setting replicas or resources will override the values set by 'size'.
   useServiceLoadBalancer: true # Set to true to use AWS or Azure load balancers instead of an NGINX controller.
   serviceAnnotations: {} # Service annotations to use with AWS or Azure load balancers.

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"testing"
 
+	operatortest "github.com/mattermost/mattermost-operator/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,7 +23,7 @@ func TestClusterInstallation(t *testing.T) {
 		Spec: ClusterInstallationSpec{
 			Replicas:    7,
 			Image:       "mattermost/mattermost-enterprise-edition",
-			Version:     "5.18.0",
+			Version:     operatortest.LatestStableMattermostVersion,
 			IngressName: "foo.mattermost.dev",
 		},
 	}
@@ -54,7 +55,7 @@ func TestClusterInstallation(t *testing.T) {
 			},
 			Spec: ClusterInstallationSpec{
 				Image:       "mattermost/mattermost-enterprise-edition",
-				Version:     "5.18.0",
+				Version:     operatortest.LatestStableMattermostVersion,
 				IngressName: "foo.mattermost.dev",
 				Size:        "1000users",
 			},
@@ -146,7 +147,7 @@ func TestClusterInstallation(t *testing.T) {
 func TestDeployment(t *testing.T) {
 	d := AppDeployment{
 		Image:   "mattermost/mattermost-enterprise-edition",
-		Version: "5.18.0",
+		Version: operatortest.LatestStableMattermostVersion,
 	}
 
 	t.Run("correct image", func(t *testing.T) {

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -23,7 +23,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "5.18.0"
+	DefaultMattermostVersion = "5.19.1"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/pkg/controller/clusterinstallation/controller_test.go
+++ b/pkg/controller/clusterinstallation/controller_test.go
@@ -9,6 +9,7 @@ import (
 
 	blubr "github.com/mattermost/blubr"
 	"github.com/mattermost/mattermost-operator/pkg/apis"
+	operatortest "github.com/mattermost/mattermost-operator/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
@@ -47,7 +48,7 @@ func TestReconcile(t *testing.T) {
 		Spec: mattermostv1alpha1.ClusterInstallationSpec{
 			Replicas:    replicas,
 			Image:       "mattermost/mattermost-enterprise-edition",
-			Version:     "5.18.0",
+			Version:     operatortest.LatestStableMattermostVersion,
 			IngressName: "foo.mattermost.dev",
 		},
 	}
@@ -220,13 +221,13 @@ func TestReconcile(t *testing.T) {
 				Name:        "blue-installation",
 				IngressName: "blue-ingress",
 				Image:       "mattermost/mattermost-blue-edition",
-				Version:     "5.17.2",
+				Version:     operatortest.PreviousStableMattermostVersion,
 			},
 			Green: mattermostv1alpha1.AppDeployment{
 				Name:        "green-installation",
 				IngressName: "green-ingress",
 				Image:       "mattermost/mattermost-green-edition",
-				Version:     "5.18.0",
+				Version:     operatortest.LatestStableMattermostVersion,
 			},
 		}
 

--- a/pkg/controller/clusterinstallation/mattermost_test.go
+++ b/pkg/controller/clusterinstallation/mattermost_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/mattermost-operator/pkg/apis"
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	mattermostmysql "github.com/mattermost/mattermost-operator/pkg/components/mysql"
+	operatortest "github.com/mattermost/mattermost-operator/test"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -40,7 +41,7 @@ func TestCheckMattermost(t *testing.T) {
 		Spec: mattermostv1alpha1.ClusterInstallationSpec{
 			Replicas:    replicas,
 			Image:       "mattermost/mattermost-enterprise-edition",
-			Version:     "5.18.0",
+			Version:     operatortest.LatestStableMattermostVersion,
 			IngressName: "foo.mattermost.dev",
 		},
 	}
@@ -180,7 +181,7 @@ func TestCheckMattermostExternalDB(t *testing.T) {
 		Spec: mattermostv1alpha1.ClusterInstallationSpec{
 			Replicas:    replicas,
 			Image:       "mattermost/mattermost-enterprise-edition",
-			Version:     "5.18.0",
+			Version:     operatortest.LatestStableMattermostVersion,
 			IngressName: "foo.mattermost.dev",
 			Database: mattermostv1alpha1.Database{
 				Secret: externalDBSecretName,

--- a/test/constants.go
+++ b/test/constants.go
@@ -1,0 +1,11 @@
+package test
+
+const (
+	// LatestStableMattermostVersion is the most recent stable version of
+	// Mattermost.
+	LatestStableMattermostVersion = "5.19.1"
+	// PreviousStableMattermostVersion is the latest dot release of Mattermost
+	// that is one minor version lower than the latest release.
+	// i.e. It's a typical release that would need to be upgraded from.
+	PreviousStableMattermostVersion = "5.18.2"
+)

--- a/test/e2e/mattermost_test.go
+++ b/test/e2e/mattermost_test.go
@@ -12,6 +12,7 @@ import (
 	apis "github.com/mattermost/mattermost-operator/pkg/apis"
 	operator "github.com/mattermost/mattermost-operator/pkg/apis/mattermost/v1alpha1"
 	"github.com/mattermost/mattermost-operator/pkg/components/utils"
+	operatortest "github.com/mattermost/mattermost-operator/test"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
@@ -192,7 +193,7 @@ func mattermostUpgradeTest(t *testing.T, f *framework.Framework, ctx *framework.
 		},
 		Spec: operator.ClusterInstallationSpec{
 			Image:       "mattermost/mattermost-enterprise-edition",
-			Version:     "5.17.2",
+			Version:     operatortest.PreviousStableMattermostVersion,
 			IngressName: "test-example2.mattermost.dev",
 			Replicas:    1,
 			Resources: corev1.ResourceRequirements{
@@ -257,7 +258,7 @@ func mattermostUpgradeTest(t *testing.T, f *framework.Framework, ctx *framework.
 	require.NoError(t, err)
 
 	// Apply the new version
-	exampleMattermost.Spec.Version = "5.18.0"
+	exampleMattermost.Spec.Version = operatortest.LatestStableMattermostVersion
 	err = f.Client.Update(context.TODO(), exampleMattermost)
 	require.NoError(t, err)
 
@@ -276,12 +277,12 @@ func mattermostUpgradeTest(t *testing.T, f *framework.Framework, ctx *framework.
 	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: testName, Namespace: namespace}, newMattermost)
 	require.NoError(t, err)
 	require.Equal(t, "mattermost/mattermost-enterprise-edition", newMattermost.Status.Image)
-	require.Equal(t, "5.18.0", newMattermost.Status.Version)
+	require.Equal(t, operatortest.LatestStableMattermostVersion, newMattermost.Status.Version)
 
 	mmDeployment := &appsv1.Deployment{}
 	err = f.Client.Get(context.TODO(), types.NamespacedName{Name: testName, Namespace: namespace}, mmDeployment)
 	require.NoError(t, err)
-	require.Equal(t, "mattermost/mattermost-enterprise-edition:5.18.0", mmDeployment.Spec.Template.Spec.Containers[0].Image)
+	require.Equal(t, "mattermost/mattermost-enterprise-edition:"+operatortest.LatestStableMattermostVersion, mmDeployment.Spec.Template.Spec.Containers[0].Image)
 
 	err = f.Client.Delete(context.TODO(), newMattermost)
 	require.NoError(t, err)


### PR DESCRIPTION
This also moves most of the manually-defined Mattermost version
strings we set for tests to two constants. This should reduce the
chance for error in the future.
