### PR TITLE
Remove old Go Dep instructions and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ unittest: ## Runs unit tests
 
 build: ## Build the mattermost-operator
 	@echo Building Mattermost-operator
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build $(GOFLAGS) -gcflags all=-trimpath=$(GOPATH) -asmflags all=-trimpath=$(GOPATH) -a -installsuffix cgo -o build/_output/bin/mattermost-operator $(GO_LINKER_FLAGS) ./cmd/manager/main.go
+	GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build $(GOFLAGS) -gcflags all=-trimpath=$(GOPATH) -asmflags all=-trimpath=$(GOPATH) -a -installsuffix cgo -o build/_output/bin/mattermost-operator $(GO_LINKER_FLAGS) ./cmd/manager/main.go
 
 build-image: operator-sdk ## Build the docker image for mattermost-operator
 	@echo Building Mattermost-operator Docker Image
@@ -87,10 +87,6 @@ yaml: ## Generate the YAML file for easy operator installation
 	echo --- >> $(INSTALL_YAML)
 	cat deploy/operator.yaml >> $(INSTALL_YAML)
 	sed -i '' 's/mattermost-operator:test/mattermost-operator:latest/g' ./$(INSTALL_YAML)
-
-
-dep: ## Get dependencies
-	dep ensure -v
 
 operator-sdk: ## Download sdk only if it's not available. Used in the docker build
 	build/get-operator-sdk.sh $(SDK_VERSION)

--- a/README.md
+++ b/README.md
@@ -80,8 +80,6 @@ $ git checkout master
 $ make install
 ```
 
-Second, you need to make sure you have [dep](https://github.com/golang/dep) installed. 
-
 ### 3.2 Building mattermost-operator
 To start contributing to mattermost-operator you need to clone this repo to your local workspace. 
 
@@ -91,7 +89,6 @@ $ cd $GOPATH/src/github.com/mattermost
 $ git clone https://github.com/mattermost/mattermost-operator
 $ cd mattermost-operator
 $ git checkout master
-$ make dep
 $ make build
 ```
 


### PR DESCRIPTION
Since moving to Go Modules, the Dep tooling and processes are no
longer needed.

https://github.com/mattermost/mattermost-operator/issues/129

