### PR TITLE
[MM-23256] TLS support for ingress resource

### DIFF
--- a/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
+++ b/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
@@ -1218,6 +1218,8 @@ spec:
                 ''Minio.Replicas'', ''Minio.Resource'', ''Database.Replicas'', or
                 ''Database.Resources'' will override the values set by Size.'
               type: string
+            useIngressTLS:
+              type: boolean
             useServiceLoadBalancer:
               type: boolean
             version:

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -68,6 +68,9 @@ type ClusterInstallationSpec struct {
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 
 	// +optional
+	UseIngressTLS bool `json:"useIngressTLS,omitempty"`
+
+	// +optional
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
 	// Optional environment variables to set in the Mattermost application pods.
 	// +optional

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -233,8 +233,8 @@ func (mattermost *ClusterInstallation) GenerateService(serviceName, selectorName
 }
 
 // GenerateIngress returns the ingress for Mattermost
-func (mattermost *ClusterInstallation) GenerateIngress(name, ingressName string, ingressAnnotations map[string]string) *v1beta1.Ingress {
-	return &v1beta1.Ingress{
+func (mattermost *ClusterInstallation) GenerateIngress(name, ingressName string, ingressAnnotations map[string]string, useTLS bool) *v1beta1.Ingress {
+	ingress := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: mattermost.Namespace,
@@ -269,6 +269,17 @@ func (mattermost *ClusterInstallation) GenerateIngress(name, ingressName string,
 			},
 		},
 	}
+
+	if useTLS {
+		ingress.Spec.TLS = []v1beta1.IngressTLS{
+			{
+				Hosts:      []string{ingressName},
+				SecretName: strings.ReplaceAll(ingressName, ".", "-") + "-tls-cert",
+			},
+		}
+	}
+
+	return ingress
 }
 
 // GetContainerByName gets container from a deployment by name

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -192,6 +192,12 @@ func schema_pkg_apis_mattermost_v1alpha1_ClusterInstallationSpec(ref common.Refe
 							},
 						},
 					},
+					"useIngressTLS": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"ingressAnnotations": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"object"},

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -73,7 +73,7 @@ func (r *ReconcileClusterInstallation) checkMattermostService(mattermost *matter
 }
 
 func (r *ReconcileClusterInstallation) checkMattermostIngress(mattermost *mattermostv1alpha1.ClusterInstallation, resourceName, ingressName string, ingressAnnotations map[string]string, reqLogger logr.Logger) error {
-	desired := mattermost.GenerateIngress(resourceName, ingressName, ingressAnnotations)
+	desired := mattermost.GenerateIngress(resourceName, ingressName, ingressAnnotations, mattermost.Spec.UseIngressTLS)
 
 	err := r.createIngressIfNotExists(mattermost, desired, reqLogger)
 	if err != nil {


### PR DESCRIPTION
#### Summary
This PR adds support to create TLS when creating the Ingress resource.

When user want to create the ingress and TLS support need to set the `UseIngressTLS` and the ingress annotations (for example for cert-manager) to make it work

 - Fixes: https://github.com/mattermost/mattermost-operator/issues/97

And it is related to https://github.com/mattermost/mattermost-operator/pull/113 but due inactivity we decided to move forward

#### Ticket Link
JIRA: https://mattermost.atlassian.net/browse/MM-23256