### PR TITLE
Mm 23681 - Adding support for custom resource labels

### DIFF
--- a/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
+++ b/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
@@ -1186,6 +1186,10 @@ spec:
                 set by 'Size'.
               format: int32
               type: integer
+            resourceLabels:
+              additionalProperties:
+                type: string
+              type: object
             resources:
               description: Defines the resource requests and limits for the Mattermost
                 app server pods.

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -71,6 +71,9 @@ type ClusterInstallationSpec struct {
 	UseIngressTLS bool `json:"useIngressTLS,omitempty"`
 
 	// +optional
+	ResourceLabels map[string]string `json:"resourceLabels,omitempty"`
+
+	// +optional
 	IngressAnnotations map[string]string `json:"ingressAnnotations,omitempty"`
 	// Optional environment variables to set in the Mattermost application pods.
 	// +optional

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.deepcopy.go
@@ -171,6 +171,13 @@ func (in *ClusterInstallationSpec) DeepCopyInto(out *ClusterInstallationSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ResourceLabels != nil {
+		in, out := &in.ResourceLabels, &out.ResourceLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.IngressAnnotations != nil {
 		in, out := &in.IngressAnnotations, &out.IngressAnnotations
 		*out = make(map[string]string, len(*in))

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -198,6 +198,20 @@ func schema_pkg_apis_mattermost_v1alpha1_ClusterInstallationSpec(ref common.Refe
 							Format: "",
 						},
 					},
+					"resourceLabels": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 					"ingressAnnotations": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"object"},

--- a/pkg/controller/clusterinstallation/controller_test.go
+++ b/pkg/controller/clusterinstallation/controller_test.go
@@ -127,7 +127,7 @@ func TestReconcile(t *testing.T) {
 		podTemplate := corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: ciNamespace,
-				Labels:    mattermostv1alpha1.ClusterInstallationLabels(ciName),
+				Labels:    ci.ClusterInstallationLabels(ciName),
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
@@ -246,7 +246,7 @@ func TestReconcile(t *testing.T) {
 			podTemplate := corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: ciNamespace,
-					Labels:    mattermostv1alpha1.ClusterInstallationLabels(deployment.Name),
+					Labels:    ci.ClusterInstallationLabels(deployment.Name),
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -280,7 +280,7 @@ func TestReconcile(t *testing.T) {
 			}
 			listOptions := []client.ListOption{
 				client.InNamespace(ciNamespace),
-				client.MatchingLabels(mattermostv1alpha1.ClusterInstallationLabels(deployment.Name)),
+				client.MatchingLabels(ci.ClusterInstallationLabels(deployment.Name)),
 			}
 			err = c.List(context.TODO(), podList, listOptions...)
 			require.NoError(t, err)

--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -39,7 +39,7 @@ func (r *ReconcileClusterInstallation) handleCheckClusterInstallation(mattermost
 		mattermost.Spec.BlueGreen.Blue.Version,
 		mattermost.Spec.Replicas,
 		mattermost.Spec.UseServiceLoadBalancer,
-		mattermost.ClusterInstallationLabels(mattermost.Name),
+		mattermost.ClusterInstallationLabels(mattermost.Spec.BlueGreen.Blue.Name),
 	)
 	greenStatus, greenErr := r.checkClusterInstallation(
 		mattermost.GetNamespace(),
@@ -49,7 +49,7 @@ func (r *ReconcileClusterInstallation) handleCheckClusterInstallation(mattermost
 		mattermost.Spec.BlueGreen.Green.Version,
 		mattermost.Spec.Replicas,
 		mattermost.Spec.UseServiceLoadBalancer,
-		mattermost.ClusterInstallationLabels(mattermost.Name),
+		mattermost.ClusterInstallationLabels(mattermost.Spec.BlueGreen.Green.Name),
 	)
 
 	var status mattermostv1alpha1.ClusterInstallationStatus

--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -25,6 +25,7 @@ func (r *ReconcileClusterInstallation) handleCheckClusterInstallation(mattermost
 			mattermost.Spec.Version,
 			mattermost.Spec.Replicas,
 			mattermost.Spec.UseServiceLoadBalancer,
+			mattermost.ClusterInstallationLabels(mattermost.Name),
 		)
 	}
 
@@ -38,6 +39,7 @@ func (r *ReconcileClusterInstallation) handleCheckClusterInstallation(mattermost
 		mattermost.Spec.BlueGreen.Blue.Version,
 		mattermost.Spec.Replicas,
 		mattermost.Spec.UseServiceLoadBalancer,
+		mattermost.ClusterInstallationLabels(mattermost.Name),
 	)
 	greenStatus, greenErr := r.checkClusterInstallation(
 		mattermost.GetNamespace(),
@@ -47,6 +49,7 @@ func (r *ReconcileClusterInstallation) handleCheckClusterInstallation(mattermost
 		mattermost.Spec.BlueGreen.Green.Version,
 		mattermost.Spec.Replicas,
 		mattermost.Spec.UseServiceLoadBalancer,
+		mattermost.ClusterInstallationLabels(mattermost.Name),
 	)
 
 	var status mattermostv1alpha1.ClusterInstallationStatus
@@ -75,7 +78,7 @@ func (r *ReconcileClusterInstallation) handleCheckClusterInstallation(mattermost
 // NOTE: this is a vital health check. Every reconciliation loop should run this
 // check at the very end to ensure that everything in the installation is as it
 // should be. Over time, more types of checks should be added here as needed.
-func (r *ReconcileClusterInstallation) checkClusterInstallation(namespace, name, imageName, image, version string, replicas int32, useServiceLoadBalancer bool) (mattermostv1alpha1.ClusterInstallationStatus, error) {
+func (r *ReconcileClusterInstallation) checkClusterInstallation(namespace, name, imageName, image, version string, replicas int32, useServiceLoadBalancer bool, labels map[string]string) (mattermostv1alpha1.ClusterInstallationStatus, error) {
 	status := mattermostv1alpha1.ClusterInstallationStatus{
 		State:           mattermostv1alpha1.Reconciling,
 		Replicas:        0,
@@ -91,7 +94,7 @@ func (r *ReconcileClusterInstallation) checkClusterInstallation(namespace, name,
 
 	listOptions := []client.ListOption{
 		client.InNamespace(namespace),
-		client.MatchingLabels(mattermostv1alpha1.ClusterInstallationLabels(name)),
+		client.MatchingLabels(labels),
 	}
 	err := r.client.List(context.TODO(), pods, listOptions...)
 	if err != nil {


### PR DESCRIPTION
This PR adds support for custom Resource labels.
At the moment the Mattermost operator is applying some default labels in all resources. With this change a user can add the resourceLabels section in the cluster installation and specify a map of labels that will be applied in all resources. 

This change covers blue/green deployments too.

A new function called ClusterInstallationSelectorLabels was created to cover selector labels. The reason is that selector labels are immutable and cannot be edited after creation.