### PR TITLE
add job to notify releases into a Mattermost channel

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,25 @@
+name: notify-release
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - shell: bash
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          REPO=$(echo $GITHUB_CONTEXT | jq -r '.repository')
+          TAGVERSION=$(echo $GITHUB_CONTEXT | jq -r '.event.release.tag_name')
+          TAGURL=$(echo $GITHUB_CONTEXT | jq -r '.event.release.html_url')
+          BODY=$(echo $GITHUB_CONTEXT | jq -r '.event.release.body' | sed -E ':a;N;$!ba;s/\r{0,1}\n/\\n/g')
+
+          echo "{\"username\":\"Cloud Bot Notify\",\"icon_url\":\"https://www.mattermost.org/wp-content/uploads/2016/04/icon.png\",\"attachments\":[{\"author_name\":\"New Release for $REPO - Release $TAGVERSION\",\"author_link\":\"$TAGURL\",\"fallback\":\"$BODY\",\"color\":\"good\",\"text\":\"$BODY\"}]}" > mattermost.json
+          cat mattermost.json
+
+      - uses: mattermost/action-mattermost-notify@1.0.2
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}


### PR DESCRIPTION
#### Summary
With this GH Action every time we create a new release this action will be triggered and will post the release notification in the mattermost channel, in this case in the `Developers: Operators` channel, the webhook is already configured in the repo.

#### Ticket Link
n/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
