### PR TITLE
Remove hard-coded cluster DNS for minio

### DIFF
--- a/pkg/controller/clusterinstallation/minio.go
+++ b/pkg/controller/clusterinstallation/minio.go
@@ -126,6 +126,6 @@ func (r *ReconcileClusterInstallation) getMinioService(mattermost *mattermostv1a
 		return "", err
 	}
 
-	connectionString := fmt.Sprintf("%s.%s.svc.cluster.local:%d", minioService.Name, mattermost.Namespace, minioService.Spec.Ports[0].Port)
+	connectionString := fmt.Sprintf("%s.%s:%d", minioService.Name, mattermost.Namespace, minioService.Spec.Ports[0].Port)
 	return connectionString, nil
 }


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Allows the operator to work with clusters that don't use the default "cluster.local" domain name.  SQL's reference uses {service name}.{namespace} without the `svc.cluster.local` for its connection string. 

This change applies that same DNS approach to the minio service. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-operator/issues/143

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fixes bug in minio connection when not using default "cluster.local" cluster domain. 
```
