### PR TITLE
Update e2e kind cluster to user kind 0.8.1 and Kubernetes 1.16.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,10 +51,10 @@ jobs:
 
   e2e:
     environment:
-      - K8S_VERSION=v1.15.7
+      - K8S_VERSION=v1.16.9
       - IMAGE_NAME=mattermost/mattermost-operator
       - IMAGE_TAG=test
-      - KIND_VERSION=v0.7.0
+      - KIND_VERSION=v0.8.1
       - SDK_VERSION=v0.16.0
     machine: true
     resource_class: 2xlarge

--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -2,10 +2,10 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.15.7@sha256:e2df133f80ef633c53c0200114fce2ed5e1f6947477dbc83261a6a921169488d
+    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
   - role: worker
-    image: kindest/node:v1.15.7@sha256:e2df133f80ef633c53c0200114fce2ed5e1f6947477dbc83261a6a921169488d
+    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
   - role: worker
-    image: kindest/node:v1.15.7@sha256:e2df133f80ef633c53c0200114fce2ed5e1f6947477dbc83261a6a921169488d
+    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
   - role: worker
-    image: kindest/node:v1.15.7@sha256:e2df133f80ef633c53c0200114fce2ed5e1f6947477dbc83261a6a921169488d
+    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765


### PR DESCRIPTION
#### Summary
- update kind to release 0.8.1
- update kubernetes to 1.16.9

Since we are planning to move to mattermost-cloud to use kops 1.16 lets start testing the operator with the same release of k8s

#### Ticket Link
N/A

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Update Kind to release 0.8.1 and start testing with K8s 1.16.9 clusters
```
