### PR TITLE
Bump default Mattermost version

### DIFF
--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -23,7 +23,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "5.19.1"
+	DefaultMattermostVersion = "5.23.1"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database


### PR DESCRIPTION
This changes the default version of Mattermost that is deployed
from 5.19.1 to 5.23.1.

```release-note
Bump default Mattermost version to 5.23.1
```
