### PR TITLE
Handle negative Mattermost replicas

### DIFF
--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
@@ -20,6 +20,7 @@ type ComponentSize struct {
 	Resources corev1.ResourceRequirements
 }
 
+// Size100String represents estimated installation sizing for 100 users.
 const Size100String = "100users"
 
 var size100 = ClusterInstallationSize{
@@ -56,6 +57,7 @@ var size100 = ClusterInstallationSize{
 	},
 }
 
+// Size1000String represents estimated installation sizing for 1000 users.
 const Size1000String = "1000users"
 
 var size1000 = ClusterInstallationSize{
@@ -92,6 +94,7 @@ var size1000 = ClusterInstallationSize{
 	},
 }
 
+// Size5000String represents estimated installation sizing for 5000 users.
 const Size5000String = "5000users"
 
 var size5000 = ClusterInstallationSize{
@@ -128,6 +131,7 @@ var size5000 = ClusterInstallationSize{
 	},
 }
 
+// Size10000String represents estimated installation sizing for 10000 users.
 const Size10000String = "10000users"
 
 var size10000 = ClusterInstallationSize{
@@ -164,6 +168,7 @@ var size10000 = ClusterInstallationSize{
 	},
 }
 
+// Size25000String represents estimated installation sizing for 25000 users.
 const Size25000String = "25000users"
 
 var size25000 = ClusterInstallationSize{
@@ -202,6 +207,7 @@ var size25000 = ClusterInstallationSize{
 
 // Sizes used for development and testing
 
+// SizeMiniSingletonString represents a very small dev installation.
 const SizeMiniSingletonString = "miniSingleton"
 
 var sizeMiniSingleton = ClusterInstallationSize{
@@ -238,6 +244,7 @@ var sizeMiniSingleton = ClusterInstallationSize{
 	},
 }
 
+// SizeMiniHAString represents a very small dev installation with multiple replicas.
 const SizeMiniHAString = "miniHA"
 
 var sizeMiniHA = ClusterInstallationSize{

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
@@ -339,6 +339,17 @@ func TestClusterInstallationGenerateDeployment(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "negative app replica",
+			Spec: ClusterInstallationSpec{
+				Replicas: -1,
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: i32p(0),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -550,4 +561,8 @@ func TestSetProbes(t *testing.T) {
 			require.Equal(t, tt.wantReadiness, readiness)
 		})
 	}
+}
+
+func i32p(i int32) *int32 {
+	return &i
 }

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -296,8 +296,8 @@ type ClusterInstallation struct {
 	Status ClusterInstallationStatus `json:"status,omitempty"`
 }
 
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // ClusterInstallationList contains a list of ClusterInstallation
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type ClusterInstallationList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -65,7 +65,8 @@ const (
 	// Recommended not to be too high - in order to have not too many extra pods over requested `Replicas` number
 	defaultMaxSurge = 1
 
-	// Name of the container which runs Mattermost application
+	// MattermostAppContainerName is the name of the container which runs the
+	// Mattermost application
 	MattermostAppContainerName = "mattermost"
 )
 
@@ -575,6 +576,11 @@ func (mattermost *ClusterInstallation) GenerateDeployment(deploymentName, ingres
 
 	liveness, readiness := setProbes(mattermost.Spec.LivenessProbe, mattermost.Spec.ReadinessProbe)
 
+	replicas := mattermost.Spec.Replicas
+	if replicas < 0 {
+		replicas = 0
+	}
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
@@ -597,7 +603,7 @@ func (mattermost *ClusterInstallation) GenerateDeployment(deploymentName, ingres
 				},
 			},
 			RevisionHistoryLimit: &revHistoryLimit,
-			Replicas:             &mattermost.Spec.Replicas,
+			Replicas:             &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: ClusterInstallationSelectorLabels(deploymentName),
 			},


### PR DESCRIPTION
This change adds negative replica handling for the Mattermost app
deployment. Setting a negative number originally led to an invalid
deployment specification. Now, negative numbers will be converted
into 0, resulting in a valid deployment with 0 Mattermost app
containers.

Note that this is different from setting 0 in the ClusterInstallation
spec as that is the default value which will be updated to whatever
the size value specifies. This should probably be refactored in the
future.

Note: I know it's a bit odd that setting `0` for replicas will use the
default value size and setting `< 0` will translate to `0`, but this
seems like a good temporary way to prevent the bug and allow
for testing app deployments with no replicas. Once we start
handling size updates better we can look into a refactor.

https://mattermost.atlassian.net/browse/MM-26024

```release-note
Handle negative Mattermost replica counts
```
