### PR TITLE
Handle negative replica count on final check

### DIFF
--- a/pkg/controller/clusterinstallation/utils.go
+++ b/pkg/controller/clusterinstallation/utils.go
@@ -132,6 +132,10 @@ func (r *ReconcileClusterInstallation) checkClusterInstallation(namespace, name,
 		status.UpdatedReplicas++
 	}
 
+	if replicas < 0 {
+		replicas = 0
+	}
+
 	if int32(len(pods.Items)) != replicas {
 		return status, fmt.Errorf("found %d pods, but wanted %d", len(pods.Items), replicas)
 	}


### PR DESCRIPTION
This updates the final reconciliation check to match the negative
replica setting logic for the Mattermost app deployment.

Relates to https://github.com/mattermost/mattermost-operator/pull/151

Fixes https://mattermost.atlassian.net/browse/MM-26024

```release-note
Handle negative replica count on final check
```
