### PR TITLE
Update tests to use k8s 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
 
   e2e:
     environment:
-      - K8S_VERSION=v1.16.9
+      - K8S_VERSION=v1.17.5
       - IMAGE_NAME=mattermost/mattermost-operator
       - IMAGE_TAG=test
       - KIND_VERSION=v0.8.1

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 OPERATOR_IMAGE ?= mattermost/mattermost-operator:test
 SDK_VERSION = v0.17.1
 MACHINE = $(shell uname -m)
-BUILD_IMAGE = golang:1.13.9
-BASE_IMAGE = alpine:3.11
+BUILD_IMAGE = golang:1.14.4
+BASE_IMAGE = alpine:3.13
 GOROOT ?= $(shell go env GOROOT)
 GOPATH ?= $(shell go env GOPATH)
 GOFLAGS ?= $(GOFLAGS:) -mod=vendor

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OPERATOR_IMAGE ?= mattermost/mattermost-operator:test
 SDK_VERSION = v0.17.1
 MACHINE = $(shell uname -m)
 BUILD_IMAGE = golang:1.14.4
-BASE_IMAGE = alpine:3.13
+BASE_IMAGE = alpine:3.12
 GOROOT ?= $(shell go env GOROOT)
 GOPATH ?= $(shell go env GOPATH)
 GOFLAGS ?= $(GOFLAGS:) -mod=vendor

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,6 @@
 # Build the mattermost operator
-ARG BUILD_IMAGE=golang:1.12
-ARG BASE_IMAGE=alpine:3.10
+ARG BUILD_IMAGE=golang:1.14
+ARG BASE_IMAGE=alpine:3.12
 
 FROM ${BUILD_IMAGE} AS build
 WORKDIR /go/src/github.com/mattermost/mattermost-operator/

--- a/test/kind-config.yaml
+++ b/test/kind-config.yaml
@@ -2,10 +2,10 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+    image: kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a
   - role: worker
-    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+    image: kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a
   - role: worker
-    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+    image: kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a
   - role: worker
-    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+    image: kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a


### PR DESCRIPTION
#### Summary
- bump go image to 1.14.4
- bump alpine image to 3.12
- set the test k8s cluster to be 1.17

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
- bump go image to 1.14.4
- bump alpine image to 3.12
- set the test k8s cluster to be 1.17
```
