### PR TITLE
update checker: remove probes from the job

### DIFF
--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -226,6 +226,13 @@ func (r *ReconcileClusterInstallation) launchUpdateJob(
 		},
 	}
 
+	// We dont need to validate the readiness/liveness for this short live job
+	// if the job fails it will get another later.
+	for i := range job.Spec.Template.Spec.Containers {
+		job.Spec.Template.Spec.Containers[i].LivenessProbe = nil
+		job.Spec.Template.Spec.Containers[i].ReadinessProbe = nil
+	}
+
 	// Override values for job-specific behavior.
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 	for i := range job.Spec.Template.Spec.Containers {


### PR DESCRIPTION
#### Summary
Removing the probes from the Job (update mattermost checker) because this is a short live execution and we don't need to have the readiness probe to start receiving traffic because this will not serve any request.

Also, the liveness can kill the job before it completes its execution, which is the case in community-daily (more context [see this 🧵 ](https://community-daily.mattermost.com/core/pl/1it9rb319pgs3x33j4wsyh4f3h) 

The job will run a specific command and will exit with success or fail which is we will check later. If the image does not exist it will fail in the initialization part and we don't need the probes for that.

#### Ticket Link
n/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
job: remove probes from the job image checker
```
