### PR TITLE
probes: add startup probe to take care for the starting up process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ gofmt: ## Runs gofmt against all packages.
 
 govet: ## Runs govet against all packages.
 	@echo Running GOVET
-	#$(GO) get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
 	$(GO) vet $(GOFLAGS) $(PACKAGES)
 	$(GO) vet $(GOFLAGS) -vettool=$(SHADOW_GEN) $(PACKAGES)
 	@echo "govet success";

--- a/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
+++ b/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
@@ -1288,6 +1288,117 @@ spec:
                   ''Minio.Replicas'', ''Minio.Resource'', ''Database.Replicas'', or
                   ''Database.Resources'' will override the values set by Size.'
                 type: string
+              startupProbe:
+                description: Defines the probe to check if the application is up and
+                  running during the start up process.
+                properties:
+                  exec:
+                    description: One and only one of the following should be specified.
+                      Exec specifies the action to take.
+                    properties:
+                      command:
+                        description: Command is the command line to execute inside
+                          the container, the working directory for the command  is
+                          root ('/') in the container's filesystem. The command is
+                          simply exec'd, it is not run inside a shell, so traditional
+                          shell instructions ('|', etc) won't work. To use a shell,
+                          you need to explicitly call out to that shell. Exit status
+                          of 0 is treated as live/healthy and non-zero is unhealthy.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded. Defaults to 3. Minimum
+                      value is 1.
+                    format: int32
+                    type: integer
+                  httpGet:
+                    description: HTTPGet specifies the http request to perform.
+                    properties:
+                      host:
+                        description: Host name to connect to, defaults to the pod
+                          IP. You probably want to set "Host" in httpHeaders instead.
+                        type: string
+                      httpHeaders:
+                        description: Custom headers to set in the request. HTTP allows
+                          repeated headers.
+                        items:
+                          description: HTTPHeader describes a custom header to be
+                            used in HTTP probes
+                          properties:
+                            name:
+                              description: The header field name
+                              type: string
+                            value:
+                              description: The header field value
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      path:
+                        description: Path to access on the HTTP server.
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Name or number of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                      scheme:
+                        description: Scheme to use for connecting to the host. Defaults
+                          to HTTP.
+                        type: string
+                    required:
+                    - port
+                    type: object
+                  initialDelaySeconds:
+                    description: 'Number of seconds after the container has started
+                      before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe. Default
+                      to 10 seconds. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed. Defaults to 1. Must
+                      be 1 for liveness and startup. Minimum value is 1.
+                    format: int32
+                    type: integer
+                  tcpSocket:
+                    description: 'TCPSocket specifies an action involving a TCP port.
+                      TCP hooks not yet supported TODO: implement a realistic TCP
+                      lifecycle hook'
+                    properties:
+                      host:
+                        description: 'Optional: Host name to connect to, defaults
+                          to the pod IP.'
+                        type: string
+                      port:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Number or name of the port to access on the container.
+                          Number must be in the range 1 to 65535. Name must be an
+                          IANA_SVC_NAME.
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - port
+                    type: object
+                  timeoutSeconds:
+                    description: 'Number of seconds after which the probe times out.
+                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                    format: int32
+                    type: integer
+                type: object
               useIngressTLS:
                 type: boolean
               useServiceLoadBalancer:

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -81,6 +81,9 @@ type ClusterInstallationSpec struct {
 	// Defines the probe to check if the application is up and running.
 	// +optional
 	LivenessProbe corev1.Probe `json:"livenessProbe,omitempty"`
+	// Defines the probe to check if the application is up and running during the start up process.
+	// +optional
+	StartupProbe corev1.Probe `json:"startupProbe,omitempty"`
 	// Defines the probe to check if the application is ready to accept traffic.
 	// +optional
 	ReadinessProbe corev1.Probe `json:"readinessProbe,omitempty"`

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.deepcopy.go
@@ -200,6 +200,7 @@ func (in *ClusterInstallationSpec) DeepCopyInto(out *ClusterInstallationSpec) {
 		}
 	}
 	in.LivenessProbe.DeepCopyInto(&out.LivenessProbe)
+	in.StartupProbe.DeepCopyInto(&out.StartupProbe)
 	in.ReadinessProbe.DeepCopyInto(&out.ReadinessProbe)
 	return
 }

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -245,6 +245,12 @@ func schema_pkg_apis_mattermost_v1alpha1_ClusterInstallationSpec(ref common.Refe
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
+					"startupProbe": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Defines the probe to check if the application is up and running during the start up process.",
+							Ref:         ref("k8s.io/api/core/v1.Probe"),
+						},
+					},
 					"readinessProbe": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Defines the probe to check if the application is ready to accept traffic.",

--- a/pkg/mattermost/helpers_test.go
+++ b/pkg/mattermost/helpers_test.go
@@ -110,13 +110,16 @@ func TestSetProbes(t *testing.T) {
 	tests := []struct {
 		name            string
 		customLiveness  corev1.Probe
+		customStartup   corev1.Probe
 		customReadiness corev1.Probe
 		wantLiveness    *corev1.Probe
+		wantStartup     *corev1.Probe
 		wantReadiness   *corev1.Probe
 	}{
 		{
 			name:            "No Custom probes",
 			customLiveness:  corev1.Probe{},
+			customStartup:   corev1.Probe{},
 			customReadiness: corev1.Probe{},
 			wantLiveness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -128,6 +131,17 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 10,
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
+			},
+			wantStartup: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/api/v4/system/ping",
+						Port: intstr.FromInt(8065),
+					},
+				},
+				InitialDelaySeconds: 1,
+				PeriodSeconds:       10,
+				FailureThreshold:    60,
 			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -146,6 +160,9 @@ func TestSetProbes(t *testing.T) {
 			customLiveness: corev1.Probe{
 				InitialDelaySeconds: 120,
 			},
+			customStartup: corev1.Probe{
+				InitialDelaySeconds: 1,
+			},
 			customReadiness: corev1.Probe{
 				InitialDelaySeconds: 90,
 			},
@@ -159,6 +176,17 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 120,
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
+			},
+			wantStartup: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/api/v4/system/ping",
+						Port: intstr.FromInt(8065),
+					},
+				},
+				InitialDelaySeconds: 1,
+				PeriodSeconds:       10,
+				FailureThreshold:    60,
 			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -178,6 +206,10 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 20,
 				PeriodSeconds:       20,
 			},
+			customStartup: corev1.Probe{
+				InitialDelaySeconds: 20,
+				PeriodSeconds:       20,
+			},
 			customReadiness: corev1.Probe{
 				InitialDelaySeconds: 10,
 				FailureThreshold:    10,
@@ -192,6 +224,17 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 20,
 				PeriodSeconds:       20,
 				FailureThreshold:    3,
+			},
+			wantStartup: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/api/v4/system/ping",
+						Port: intstr.FromInt(8065),
+					},
+				},
+				InitialDelaySeconds: 20,
+				PeriodSeconds:       20,
+				FailureThreshold:    60,
 			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -216,6 +259,15 @@ func TestSetProbes(t *testing.T) {
 				},
 				InitialDelaySeconds: 120,
 			},
+			customStartup: corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/api/v4/system/pong",
+						Port: intstr.FromInt(8080),
+					},
+				},
+				InitialDelaySeconds: 120,
+			},
 			customReadiness: corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -235,6 +287,17 @@ func TestSetProbes(t *testing.T) {
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
 			},
+			wantStartup: &corev1.Probe{
+				Handler: corev1.Handler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/api/v4/system/pong",
+						Port: intstr.FromInt(8080),
+					},
+				},
+				InitialDelaySeconds: 120,
+				PeriodSeconds:       10,
+				FailureThreshold:    60,
+			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -251,8 +314,9 @@ func TestSetProbes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			liveness, readiness := setProbes(tt.customLiveness, tt.customReadiness)
+			liveness, startUp, readiness := setProbes(tt.customLiveness, tt.customStartup, tt.customReadiness)
 			require.Equal(t, tt.wantLiveness, liveness)
+			require.Equal(t, tt.wantStartup, startUp)
 			require.Equal(t, tt.wantReadiness, readiness)
 		})
 	}

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -434,7 +434,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 	maxUnavailable := intstr.FromInt(defaultMaxUnavailable)
 	maxSurge := intstr.FromInt(defaultMaxSurge)
 
-	liveness, readiness := setProbes(mattermost.Spec.LivenessProbe, mattermost.Spec.ReadinessProbe)
+	liveness, startupProbe, readiness := setProbes(mattermost.Spec.LivenessProbe, mattermost.Spec.StartupProbe, mattermost.Spec.ReadinessProbe)
 
 	replicas := mattermost.Spec.Replicas
 	if replicas < 0 {
@@ -490,6 +490,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 							},
 							ReadinessProbe: readiness,
 							LivenessProbe:  liveness,
+							StartupProbe:   startupProbe,
 							VolumeMounts:   volumeMountLicense,
 							Resources:      mattermost.Spec.Resources,
 						},


### PR DESCRIPTION
#### Summary
Sometimes, we need to deal the MM require an additional startup time on their first initialization. 
In such cases, it can be tricky to set up liveness probe parameters without compromising the fast response to deadlocks that motivated such a probe. 
The trick is to set up a startup probe with the same command, HTTP or TCP check, with a failureThreshold * periodSeconds long enough to cover the worse case startup time.

So after some knowledge refresh I discovery the new probe called `startupProbe` that works only in the initialization part, and after that the `livenessProbe` assume.

#### Ticket Link
N/a


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
probes: add startup probe to take care for the starting up process
```

/cc @jwilander 