### PR TITLE
add option to use digest id instead of tag

### DIFF
--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"testing"
 
 	operatortest "github.com/mattermost/mattermost-operator/test"
@@ -117,6 +118,7 @@ func TestClusterInstallation(t *testing.T) {
 		assert.Contains(t, ci.GetImageName(), ci.Spec.Image)
 		assert.Contains(t, ci.GetImageName(), ci.Spec.Version)
 		assert.Contains(t, ci.GetImageName(), ":")
+		assert.Equal(t, ci.GetImageName(), fmt.Sprintf("%s:%s", ci.Spec.Image, ci.Spec.Version))
 	})
 
 	t.Run("bluegreen", func(t *testing.T) {
@@ -138,6 +140,13 @@ func TestClusterInstallation(t *testing.T) {
 			assert.Equal(t, ci.GetProductionDeploymentName(), ci.Spec.BlueGreen.Green.Name)
 		})
 	})
+
+	t.Run("using digest", func(t *testing.T) {
+		ci.Spec.Version = "sha256:dd15a51ac7dafd213744d1ef23394e7532f71a90f477c969b94600e46da5a0cf"
+		assert.Contains(t, ci.GetImageName(), ci.Spec.Image)
+		assert.Contains(t, ci.GetImageName(), ci.Spec.Version)
+		assert.Equal(t, ci.GetImageName(), fmt.Sprintf("%s@%s", ci.Spec.Image, ci.Spec.Version))
+	})
 }
 
 func TestGetDeploymentImageName(t *testing.T) {
@@ -150,6 +159,14 @@ func TestGetDeploymentImageName(t *testing.T) {
 		assert.Contains(t, d.GetDeploymentImageName(), d.Image)
 		assert.Contains(t, d.GetDeploymentImageName(), d.Version)
 		assert.Contains(t, d.GetDeploymentImageName(), ":")
+		assert.Equal(t, d.GetDeploymentImageName(), fmt.Sprintf("%s:%s", d.Image, d.Version))
+	})
+
+	t.Run("using digest", func(t *testing.T) {
+		d.Version = "sha256:dd15a51ac7dafd213744d1ef23394e7532f71a90f477c969b94600e46da5a0cf"
+		assert.Contains(t, d.GetDeploymentImageName(), d.Image)
+		assert.Contains(t, d.GetDeploymentImageName(), d.Version)
+		assert.Equal(t, d.GetDeploymentImageName(), fmt.Sprintf("%s@%s", d.Image, d.Version))
 	})
 }
 

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -166,6 +166,12 @@ func (mattermost *ClusterInstallation) GetMattermostAppContainer(deployment *app
 // GetImageName returns the container image name that matches the spec of the
 // ClusterInstallation.
 func (mattermost *ClusterInstallation) GetImageName() string {
+	// if user set the version using the Digest instead of tag like
+	// sha256:dd15a51ac7dafd213744d1ef23394e7532f71a90f477c969b94600e46da5a0cf
+	// we need to set the @ instead of : to split the image name and "tag"
+	if strings.Contains(mattermost.Spec.Version, "sha256:") {
+		return fmt.Sprintf("%s@%s", mattermost.Spec.Image, mattermost.Spec.Version)
+	}
 	return fmt.Sprintf("%s:%s", mattermost.Spec.Image, mattermost.Spec.Version)
 }
 
@@ -187,6 +193,9 @@ func (mattermost *ClusterInstallation) GetProductionDeploymentName() string {
 // GetDeploymentImageName returns the container image name that matches the spec
 // of the deployment.
 func (d *AppDeployment) GetDeploymentImageName() string {
+	if strings.Contains(d.Version, "sha256:") {
+		return fmt.Sprintf("%s@%s", d.Image, d.Version)
+	}
 	return fmt.Sprintf("%s:%s", d.Image, d.Version)
 }
 


### PR DESCRIPTION
#### Summary
Add the option to use digest instead of tags.
Some users use digest instead of tags because that digests are immutable and tags are mutable.


In our cloud use case:
We pull the master tag daily to update community-daily and the process of that is:
- pull the master tag
- retag master adding a suffix, ie ci_build env var
- push the newly tagged image which is the same as the current master
- update the manifest to use the new image

using the digest we avoid the tagging and pushing a duplicate image


#### Ticket Link
n/a

#### Release Note

```release-note
add option to use digest id instead of tag
```
