### PR TITLE
bump version to prepare the 1.6.0 release before the v1beta1

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-var version = "1.4.0"
+var version = "1.6.0"
 var buildTime string
 var buildHash string
 


### PR DESCRIPTION
#### Summary
bump version to prepare the 1.6.0 release

#### Ticket Link



#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
