### PR TITLE
add check modules to check outdated dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,13 @@ jobs:
       - checkout
       - run: make check-style
 
+  check-modules:
+    executor:
+      name: default
+    steps:
+    - checkout
+    - run: make check-modules
+
   generate:
     executor:
       name: default
@@ -101,6 +108,12 @@ workflows:
   version: 2
   untagged-build:
     jobs:
+      - check-modules:
+          filters:
+            branches:
+              ignore:
+                - master
+                - /^v.*/
       - shellcheck/check:
           exclude: ./vendor/*
           filters:
@@ -151,6 +164,11 @@ workflows:
 
   master-build:
     jobs:
+      - check-modules:
+          filters:
+            branches:
+              only:
+                - master
       - lint:
           filters:
             branches:

--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,4 @@ tags
 .vscode/*
 .history
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
-/bin/openapi-gen
-/bin/openapi-gen-master
-/bin/shadow
-/bin/shadow-master
+/bin/*

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ GOVERALLS_VER := master
 GOVERALLS_BIN := goveralls
 GOVERALLS_GEN := $(TOOLS_BIN_DIR)/$(GOVERALLS_BIN)
 
+OUTDATED_VER := master
+OUTDATED_BIN := go-mod-outdated
+OUTDATED_GEN := $(TOOLS_BIN_DIR)/$(OUTDATED_BIN)
+
 all: check-style unittest build ## Run all the things
 
 unittest: ## Runs unit tests
@@ -124,14 +128,19 @@ clean: ## Clean up everything
 $(SHADOW_GEN): ## Build shadow
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow $(SHADOW_BIN) $(SHADOW_VER)
 
-
 $(OPENAPI_GEN): ## Build open-api
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) k8s.io/kube-openapi/cmd/openapi-gen $(OPENAPI_BIN) $(OPENAPI_VER)
-
 
 $(GOVERALLS_GEN): ## Build open-api
 	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/mattn/goveralls $(GOVERALLS_BIN) $(GOVERALLS_VER)
 
+$(OUTDATED_GEN): ## Build open-api
+	GOBIN=$(TOOLS_BIN_DIR) $(GO_INSTALL) github.com/psampaz/go-mod-outdated $(OUTDATED_BIN) $(OUTDATED_VER)
+
+.PHONY: check-modules
+check-modules: $(OUTDATED_GEN) ## Check outdated modules
+	@echo Checking outdated modules
+	$(GO) list -mod=mod -u -m -json all | $(OUTDATED_GEN) -update -direct
 
 ## Help documentatin à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Similar we have done for mattermost-cloud this adds a make entry to check outdated modules.
The job in the pipeline is a non-blocking

will output something like
```
+--------------------------------------------+------------------------------------+------------------------------------+--------+------------------+
|                   MODULE                   |              VERSION               |            NEW VERSION             | DIRECT | VALID TIMESTAMPS |
+--------------------------------------------+------------------------------------+------------------------------------+--------+------------------+
| github.com/banzaicloud/k8s-objectmatcher   | v1.3.3                             | v1.4.0                             | true   | true             |
| github.com/go-logr/logr                    | v0.1.0                             | v0.2.0                             | true   | true             |
| github.com/minio/minio-operator            | v0.0.0-20200214142425-158e343f1f19 | v0.0.0-20200721015126-04d8f76733a6 | true   | true             |
| github.com/operator-framework/operator-sdk | v0.18.2                            | v0.19.0                            | true   | true             |
| golang.org/x/net                           | v0.0.0-20200625001655-4c5254603344 | v0.0.0-20200707034311-ab3426394381 | true   | true             |
| k8s.io/api                                 | v0.18.2                            | v0.18.6                            | true   | true             |
| k8s.io/apimachinery                        | v0.18.2                            | v0.18.6                            | true   | true             |
| k8s.io/code-generator                      | v0.18.2                            | v0.18.6                            | true   | true             |
| k8s.io/kube-openapi                        | v0.0.0-20200121204235-bf4fb3bd569c | v0.0.0-20200615155156-dffdd1682719 | true   | true             |
| sigs.k8s.io/controller-runtime             | v0.6.0                             | v0.6.1                             | true   | true             |
+--------------------------------------------+------------------------------------+------------------------------------+--------+------------------+
```

#### Ticket Link
n/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
add check modules to check outdated dependencies
```
