### PR TITLE
[GH-123] Treat Size as an write-only field

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,13 @@ You don't need to push the mattermost-operator image to DockerHub or any other r
 ```bash
 $ kind load docker-image mattermost/mattermost-operator:test
 ```
+
+## 4 Notes
+
+### 4.1 Installation Size
+
+The `spec.Size` field was modified to be treated as a write-only field. 
+After adjusting values according to the size, the value of `spec.Size` is erased. 
+
+Replicas and resource requests/limits values can be overridden manually but setting new Size will override those values again regardless if set by the previous Size or adjusted manually. 
+

--- a/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
+++ b/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
@@ -1282,14 +1282,16 @@ spec:
               size:
                 description: 'Size defines the size of the ClusterInstallation. This
                   is typically specified in number of users. This will override replica
-                  and resource requests/limits appropriately for the provided number of users.
-                  This is write-only field - its value is erased after setting appropriate values
-                  of resources. Accepted values are: 100users, 1000users, 5000users, 10000users,
-                  250000users. If replicas and resource requests/limits are not specified, and
-                  Size is not provided the configuration for 5000users will be applied.
-                  Setting ''Replicas'', ''Resources'', ''Minio.Replicas'', ''Minio.Resource'',
-                  ''Database.Replicas'', or ''Database.Resources'' will override the values set by Size.
-                  Setting new Size will override previous values regardless if set by Size or manually.'
+                  and resource requests/limits appropriately for the provided number
+                  of users. This is write-only field - its value is erased after setting
+                  appropriate values of resources. Accepted values are: 100users,
+                  1000users, 5000users, 10000users, 250000users. If replicas and resource
+                  requests/limits are not specified, and Size is not provided the
+                  configuration for 5000users will be applied. Setting ''Replicas'',
+                  ''Resources'', ''Minio.Replicas'', ''Minio.Resource'', ''Database.Replicas'',
+                  or ''Database.Resources'' will override the values set by Size.
+                  Setting new Size will override previous values regardless if set
+                  by Size or manually.'
                 type: string
               startupProbe:
                 description: Defines the probe to check if the application is up and

--- a/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
+++ b/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
@@ -1281,12 +1281,15 @@ spec:
                 type: object
               size:
                 description: 'Size defines the size of the ClusterInstallation. This
-                  is typically specified in number of users. This will set replica
-                  and resource requests/limits appropriately for the provided number
-                  of users. Accepted values are: 100users, 1000users, 5000users, 10000users,
-                  250000users. Defaults to 5000users. Setting ''Replicas'', ''Resources'',
-                  ''Minio.Replicas'', ''Minio.Resource'', ''Database.Replicas'', or
-                  ''Database.Resources'' will override the values set by Size.'
+                  is typically specified in number of users. This will override replica
+                  and resource requests/limits appropriately for the provided number of users.
+                  This is write-only field - its value is erased after setting appropriate values
+                  of resources. Accepted values are: 100users, 1000users, 5000users, 10000users,
+                  250000users. If replicas and resource requests/limits are not specified, and
+                  Size is not provided the configuration for 5000users will be applied.
+                  Setting ''Replicas'', ''Resources'', ''Minio.Replicas'', ''Minio.Resource'',
+                  ''Database.Replicas'', or ''Database.Resources'' will override the values set by Size.
+                  Setting new Size will override previous values regardless if set by Size or manually.'
                 type: string
               startupProbe:
                 description: Defines the probe to check if the application is up and

--- a/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
+++ b/deploy/crds/mattermost.com_clusterinstallations_crd.yaml
@@ -1283,8 +1283,8 @@ spec:
                 description: 'Size defines the size of the ClusterInstallation. This
                   is typically specified in number of users. This will override replica
                   and resource requests/limits appropriately for the provided number
-                  of users. This is write-only field - its value is erased after setting
-                  appropriate values of resources. Accepted values are: 100users,
+                  of users. This is a write-only field - its value is erased after
+                  setting appropriate values of resources. Accepted values are: 100users,
                   1000users, 5000users, 10000users, 250000users. If replicas and resource
                   requests/limits are not specified, and Size is not provided the
                   configuration for 5000users will be applied. Setting ''Replicas'',

--- a/docs/examples/full.yaml
+++ b/docs/examples/full.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: mattermost/mattermost-enterprise-edition # Docker image for the app servers.
   version: 5.19.1 # Docker tag for the image.
-  size: 5000users # Size of the Mattermost installation, typically based on the number of users. Automatically sets the replica and resource limits for Minio, databaes and app servers based on the number provided here. Accepts 100users, 1000users, 5000users, 10000users, or 25000users. Manually setting replicas or resources will override the values set by 'size'.
+  size: 5000users # Size of the Mattermost installation, typically based on the number of users. Write-only field erased after being processed. Automatically sets the replica and resource limits for Minio, databases and app servers based on the number provided here. Accepts 100users, 1000users, 5000users, 10000users, or 25000users. Manually setting replicas or resources will override the values set by 'size'.
   useServiceLoadBalancer: true # Set to true to use AWS or Azure load balancers instead of an NGINX controller.
   serviceAnnotations: {} # Service annotations to use with AWS or Azure load balancers.
   ingressName: example.mattermost-example.com # Set to your hostname, e.g. example.mattermost-example.com. Required when using an Ingress controller. Ignored if useServiceLoadBalancer is true.

--- a/docs/examples/full.yaml
+++ b/docs/examples/full.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: mattermost/mattermost-enterprise-edition # Docker image for the app servers.
   version: 5.19.1 # Docker tag for the image.
-  size: 5000users # Size of the Mattermost installation, typically based on the number of users. Write-only field erased after being processed. Automatically sets the replica and resource limits for Minio, databases and app servers based on the number provided here. Accepts 100users, 1000users, 5000users, 10000users, or 25000users. Manually setting replicas or resources will override the values set by 'size'.
+  size: 5000users # Size of the Mattermost installation, typically based on the number of users. This is write-only field - its value is erased after setting appropriate values of resources. Automatically sets the replica and resource limits for Minio, databases and app servers based on the number provided here. Accepts 100users, 1000users, 5000users, 10000users, or 25000users. Manually setting replicas or resources will override the values set by 'size'.
   useServiceLoadBalancer: true # Set to true to use AWS or Azure load balancers instead of an NGINX controller.
   serviceAnnotations: {} # Service annotations to use with AWS or Azure load balancers.
   ingressName: example.mattermost-example.com # Set to your hostname, e.g. example.mattermost-example.com. Required when using an Ingress controller. Ignored if useServiceLoadBalancer is true.

--- a/docs/examples/full.yaml
+++ b/docs/examples/full.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: mattermost/mattermost-enterprise-edition # Docker image for the app servers.
   version: 5.19.1 # Docker tag for the image.
-  size: 5000users # Size of the Mattermost installation, typically based on the number of users. This is write-only field - its value is erased after setting appropriate values of resources. Automatically sets the replica and resource limits for Minio, databases and app servers based on the number provided here. Accepts 100users, 1000users, 5000users, 10000users, or 25000users. Manually setting replicas or resources will override the values set by 'size'.
+  size: 5000users # Size of the Mattermost installation, typically based on the number of users. This a is write-only field - its value is erased after setting appropriate values of resources. Automatically sets the replica and resource limits for Minio, databases and app servers based on the number provided here. Accepts 100users, 1000users, 5000users, 10000users, or 25000users. Manually setting replicas or resources will override the values set by 'size'.
   useServiceLoadBalancer: true # Set to true to use AWS or Azure load balancers instead of an NGINX controller.
   serviceAnnotations: {} # Service annotations to use with AWS or Azure load balancers.
   ingressName: example.mattermost-example.com # Set to your hostname, e.g. example.mattermost-example.com. Required when using an Ingress controller. Ignored if useServiceLoadBalancer is true.

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
@@ -342,32 +342,57 @@ func GetClusterSize(key string) (ClusterInstallationSize, error) {
 // and resource requests to set for a ClusterInstallation. If Replicas or Resources for any components are
 // manually set in the spec then those values will not be changed.
 func (mattermost *ClusterInstallation) SetReplicasAndResourcesFromSize() error {
+	if mattermost.Spec.Size == "" {
+		mattermost.setDefaultReplicasAndResources()
+		return nil
+	}
+
 	size, err := GetClusterSize(mattermost.Spec.Size)
 	if err != nil {
 		err = errors.Wrap(err, "using default")
-		size = defaultSize
+		mattermost.setDefaultReplicasAndResources()
+		return err
 	}
 
+	mattermost.overrideReplicasAndResourcesFromSize(size)
+
+	return nil
+}
+
+func (mattermost *ClusterInstallation) setDefaultReplicasAndResources() {
+	mattermost.Spec.Size = ""
+
 	if mattermost.Spec.Replicas == 0 {
-		mattermost.Spec.Replicas = size.App.Replicas
+		mattermost.Spec.Replicas = defaultSize.App.Replicas
 	}
 	if mattermost.Spec.Resources.Size() == 0 {
-		mattermost.Spec.Resources = size.App.Resources
+		mattermost.Spec.Resources = defaultSize.App.Resources
 	}
 
 	if mattermost.Spec.Minio.Replicas == 0 {
-		mattermost.Spec.Minio.Replicas = size.Minio.Replicas
+		mattermost.Spec.Minio.Replicas = defaultSize.Minio.Replicas
 	}
 	if mattermost.Spec.Minio.Resources.Size() == 0 {
-		mattermost.Spec.Minio.Resources = size.Minio.Resources
+		mattermost.Spec.Minio.Resources = defaultSize.Minio.Resources
 	}
 
 	if mattermost.Spec.Database.Replicas == 0 && mattermost.Spec.Database.InitBucketURL == "" {
-		mattermost.Spec.Database.Replicas = size.Database.Replicas
+		mattermost.Spec.Database.Replicas = defaultSize.Database.Replicas
 	}
 	if mattermost.Spec.Database.Resources.Size() == 0 {
-		mattermost.Spec.Database.Resources = size.Database.Resources
+		mattermost.Spec.Database.Resources = defaultSize.Database.Resources
 	}
-
-	return err
 }
+
+func (mattermost *ClusterInstallation) overrideReplicasAndResourcesFromSize(size ClusterInstallationSize) {
+	mattermost.Spec.Size = ""
+
+	mattermost.Spec.Replicas = size.App.Replicas
+	mattermost.Spec.Resources = size.App.Resources
+	mattermost.Spec.Minio.Replicas = size.Minio.Replicas
+	mattermost.Spec.Minio.Resources = size.Minio.Resources
+	mattermost.Spec.Database.Replicas = size.Database.Replicas
+	mattermost.Spec.Database.Resources = size.Database.Resources
+}
+
+

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
@@ -339,8 +339,9 @@ func GetClusterSize(key string) (ClusterInstallationSize, error) {
 }
 
 // SetReplicasAndResourcesFromSize will use the Size field to determine the number of replicas
-// and resource requests to set for a ClusterInstallation. If Replicas or Resources for any components are
-// manually set in the spec then those values will not be changed.
+// and resource requests to set for a ClusterInstallation. If the Size field is not set, values for default size will be used.
+// Setting Size to new value will override current values for Replicas and Resources.
+// The Size field is erased after adjusting the values.
 func (mattermost *ClusterInstallation) SetReplicasAndResourcesFromSize() error {
 	if mattermost.Spec.Size == "" {
 		mattermost.setDefaultReplicasAndResources()
@@ -394,5 +395,3 @@ func (mattermost *ClusterInstallation) overrideReplicasAndResourcesFromSize(size
 	mattermost.Spec.Database.Replicas = size.Database.Replicas
 	mattermost.Spec.Database.Resources = size.Database.Resources
 }
-
-

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_test.go
@@ -82,12 +82,12 @@ func TestClusterInstallation(t *testing.T) {
 				},
 			}
 
-			overridenReplicas := int32(7)
-			tci.Spec.Replicas = overridenReplicas
+			overriddenReplicas := int32(7)
+			tci.Spec.Replicas = overriddenReplicas
 			tci.Spec.Resources = resources
-			tci.Spec.Minio.Replicas = overridenReplicas
+			tci.Spec.Minio.Replicas = overriddenReplicas
 			tci.Spec.Minio.Resources = resources
-			tci.Spec.Database.Replicas = overridenReplicas
+			tci.Spec.Database.Replicas = overriddenReplicas
 			tci.Spec.Database.Resources = resources
 
 			err := tci.SetReplicasAndResourcesFromSize()

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -22,10 +22,12 @@ type ClusterInstallationSpec struct {
 	// Version defines the ClusterInstallation Docker image version.
 	Version string `json:"version,omitempty"`
 	// Size defines the size of the ClusterInstallation. This is typically specified in number of users.
-	// This will set replica and resource requests/limits appropriately for the provided number of users.
+	// This will override replica and resource requests/limits appropriately for the provided number of users.
+	// This is write-only field. Its value is removed after setting appropriate values of resources.
 	// Accepted values are: 100users, 1000users, 5000users, 10000users, 250000users. Defaults to 5000users.
 	// Setting 'Replicas', 'Resources', 'Minio.Replicas', 'Minio.Resource', 'Database.Replicas',
 	// or 'Database.Resources' will override the values set by Size.
+	// +optional
 	Size string `json:"size,omitempty"`
 	// Replicas defines the number of replicas to use for the Mattermost app servers.
 	// Setting this will override the number of replicas set by 'Size'.

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -23,7 +23,7 @@ type ClusterInstallationSpec struct {
 	Version string `json:"version,omitempty"`
 	// Size defines the size of the ClusterInstallation. This is typically specified in number of users.
 	// This will override replica and resource requests/limits appropriately for the provided number of users.
-	// This is write-only field - its value is erased after setting appropriate values of resources.
+	// This is a write-only field - its value is erased after setting appropriate values of resources.
 	// Accepted values are: 100users, 1000users, 5000users, 10000users, 250000users. If replicas and resource
 	// requests/limits are not specified, and Size is not provided the configuration for 5000users will be applied.
 	// Setting 'Replicas', 'Resources', 'Minio.Replicas', 'Minio.Resource', 'Database.Replicas',

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -23,10 +23,12 @@ type ClusterInstallationSpec struct {
 	Version string `json:"version,omitempty"`
 	// Size defines the size of the ClusterInstallation. This is typically specified in number of users.
 	// This will override replica and resource requests/limits appropriately for the provided number of users.
-	// This is write-only field. Its value is removed after setting appropriate values of resources.
-	// Accepted values are: 100users, 1000users, 5000users, 10000users, 250000users. Defaults to 5000users.
+	// This is write-only field - its value is erased after setting appropriate values of resources.
+	// Accepted values are: 100users, 1000users, 5000users, 10000users, 250000users. If replicas and resource
+	// requests/limits are not specified, and Size is not provided the configuration for 5000users will be applied.
 	// Setting 'Replicas', 'Resources', 'Minio.Replicas', 'Minio.Resource', 'Database.Replicas',
 	// or 'Database.Resources' will override the values set by Size.
+	// Setting new Size will override previous values regardless if set by Size or manually.
 	// +optional
 	Size string `json:"size,omitempty"`
 	// Replicas defines the number of replicas to use for the Mattermost app servers.

--- a/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/pkg/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -54,9 +54,6 @@ func (mattermost *ClusterInstallation) SetDefaults() error {
 	if mattermost.Spec.Version == "" {
 		mattermost.Spec.Version = DefaultMattermostVersion
 	}
-	if mattermost.Spec.Size == "" {
-		mattermost.Spec.Size = DefaultMattermostSize
-	}
 
 	mattermost.Spec.Minio.SetDefaults()
 	mattermost.Spec.Database.SetDefaults()

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -94,7 +94,7 @@ func schema_pkg_apis_mattermost_v1alpha1_ClusterInstallationSpec(ref common.Refe
 					},
 					"size": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Size defines the size of the ClusterInstallation. This is typically specified in number of users. This will override replica and resource requests/limits appropriately for the provided number of users. This is write-only field - its value is erased after setting appropriate values of resources. Accepted values are: 100users, 1000users, 5000users, 10000users, 250000users. If replicas and resource requests/limits are not specified, and Size is not provided the configuration for 5000users will be applied. Setting 'Replicas', 'Resources', 'Minio.Replicas', 'Minio.Resource', 'Database.Replicas', or 'Database.Resources' will override the values set by Size. Setting new Size will override previous values regardless if set by Size or manually.",
+							Description: "Size defines the size of the ClusterInstallation. This is typically specified in number of users. This will override replica and resource requests/limits appropriately for the provided number of users. This is a write-only field - its value is erased after setting appropriate values of resources. Accepted values are: 100users, 1000users, 5000users, 10000users, 250000users. If replicas and resource requests/limits are not specified, and Size is not provided the configuration for 5000users will be applied. Setting 'Replicas', 'Resources', 'Minio.Replicas', 'Minio.Resource', 'Database.Replicas', or 'Database.Resources' will override the values set by Size. Setting new Size will override previous values regardless if set by Size or manually.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -94,7 +94,7 @@ func schema_pkg_apis_mattermost_v1alpha1_ClusterInstallationSpec(ref common.Refe
 					},
 					"size": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Size defines the size of the ClusterInstallation. This is typically specified in number of users. This will set replica and resource requests/limits appropriately for the provided number of users. Accepted values are: 100users, 1000users, 5000users, 10000users, 250000users. Defaults to 5000users. Setting 'Replicas', 'Resources', 'Minio.Replicas', 'Minio.Resource', 'Database.Replicas', or 'Database.Resources' will override the values set by Size.",
+							Description: "Size defines the size of the ClusterInstallation. This is typically specified in number of users. This will override replica and resource requests/limits appropriately for the provided number of users. This is write-only field - its value is erased after setting appropriate values of resources. Accepted values are: 100users, 1000users, 5000users, 10000users, 250000users. If replicas and resource requests/limits are not specified, and Size is not provided the configuration for 5000users will be applied. Setting 'Replicas', 'Resources', 'Minio.Replicas', 'Minio.Resource', 'Database.Replicas', or 'Database.Resources' will override the values set by Size. Setting new Size will override previous values regardless if set by Size or manually.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/controller/clusterinstallation/controller_test.go
+++ b/pkg/controller/clusterinstallation/controller_test.go
@@ -30,8 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TODO: test with Size
-
 func TestReconcile(t *testing.T) {
 	// Setup logging for the reconciler so we can see what happened on failure.
 	logger := blubr.InitLogger()
@@ -120,7 +118,7 @@ func TestReconcile(t *testing.T) {
 			deployment := &appsv1.Deployment{}
 			err = c.Get(context.TODO(), ciKey, deployment)
 			require.NoError(t, err)
-			require.Equal(t, *deployment.Spec.Replicas, ci.Spec.Replicas)
+			require.Equal(t, deployment.Spec.Replicas, &ci.Spec.Replicas)
 		})
 	})
 

--- a/pkg/controller/clusterinstallation/controller_test.go
+++ b/pkg/controller/clusterinstallation/controller_test.go
@@ -30,6 +30,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// TODO: test with Size
+
 func TestReconcile(t *testing.T) {
 	// Setup logging for the reconciler so we can see what happened on failure.
 	logger := blubr.InitLogger()
@@ -118,7 +120,7 @@ func TestReconcile(t *testing.T) {
 			deployment := &appsv1.Deployment{}
 			err = c.Get(context.TODO(), ciKey, deployment)
 			require.NoError(t, err)
-			require.Equal(t, deployment.Spec.Replicas, &ci.Spec.Replicas)
+			require.Equal(t, *deployment.Spec.Replicas, ci.Spec.Replicas)
 		})
 	})
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Modify `spec.Size` field of `ClusterInstallation` CR to be treated as write-only.
This prevents from inconsistency between Replicas and Resources values, and Size value. This also allows to modify installation size after `ClusterInstallation` CR has been created.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-operator/issues/123


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
