### PR TITLE
probes: remove startup probe because 1.17 this is not enabled and was causing reconcile infinite loop

### DIFF
--- a/pkg/controller/clusterinstallation/create_resources.go
+++ b/pkg/controller/clusterinstallation/create_resources.go
@@ -54,7 +54,7 @@ func (r *ReconcileClusterInstallation) update(current, desired Object, reqLogger
 			reqLogger.Error(err, "error applying the annotation in the resource")
 			return err
 		}
-		reqLogger.Info("updating resource", "name", desired.GetName(), "namespace", desired.GetNamespace())
+		reqLogger.Info("updating resource", "name", desired.GetName(), "namespace", desired.GetNamespace(), "diff", patchResult.String())
 		// Resource version is required for the update, but need to be set after
 		// the last applied annotation to avoid unnecessary diffs
 		desired.SetResourceVersion(current.GetResourceVersion())

--- a/pkg/mattermost/helpers.go
+++ b/pkg/mattermost/helpers.go
@@ -44,7 +44,7 @@ func mergeEnvVars(original, new []corev1.EnvVar) []corev1.EnvVar {
 	return original
 }
 
-func setProbes(customLiveness, customStartup, customReadiness corev1.Probe) (*corev1.Probe, *corev1.Probe, *corev1.Probe) {
+func setProbes(customLiveness, customReadiness corev1.Probe) (*corev1.Probe, *corev1.Probe) {
 	liveness := &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -75,38 +75,6 @@ func setProbes(customLiveness, customStartup, customReadiness corev1.Probe) (*co
 
 	if customLiveness.SuccessThreshold != 0 {
 		liveness.SuccessThreshold = customLiveness.SuccessThreshold
-	}
-
-	startUp := &corev1.Probe{
-		Handler: corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path: "/api/v4/system/ping",
-				Port: intstr.FromInt(8065),
-			},
-		},
-		InitialDelaySeconds: 1,
-		PeriodSeconds:       10,
-		FailureThreshold:    60,
-	}
-
-	if customStartup.Handler != (corev1.Handler{}) {
-		startUp.Handler = customStartup.Handler
-	}
-
-	if customStartup.InitialDelaySeconds != 0 {
-		startUp.InitialDelaySeconds = customStartup.InitialDelaySeconds
-	}
-
-	if customStartup.PeriodSeconds != 0 {
-		startUp.PeriodSeconds = customStartup.PeriodSeconds
-	}
-
-	if customStartup.FailureThreshold != 0 {
-		startUp.FailureThreshold = customStartup.FailureThreshold
-	}
-
-	if customStartup.SuccessThreshold != 0 {
-		startUp.SuccessThreshold = customStartup.SuccessThreshold
 	}
 
 	readiness := &corev1.Probe{
@@ -141,5 +109,5 @@ func setProbes(customLiveness, customStartup, customReadiness corev1.Probe) (*co
 		readiness.SuccessThreshold = customReadiness.SuccessThreshold
 	}
 
-	return liveness, startUp, readiness
+	return liveness, readiness
 }

--- a/pkg/mattermost/helpers_test.go
+++ b/pkg/mattermost/helpers_test.go
@@ -110,16 +110,13 @@ func TestSetProbes(t *testing.T) {
 	tests := []struct {
 		name            string
 		customLiveness  corev1.Probe
-		customStartup   corev1.Probe
 		customReadiness corev1.Probe
 		wantLiveness    *corev1.Probe
-		wantStartup     *corev1.Probe
 		wantReadiness   *corev1.Probe
 	}{
 		{
 			name:            "No Custom probes",
 			customLiveness:  corev1.Probe{},
-			customStartup:   corev1.Probe{},
 			customReadiness: corev1.Probe{},
 			wantLiveness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -131,17 +128,6 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 10,
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
-			},
-			wantStartup: &corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/ping",
-						Port: intstr.FromInt(8065),
-					},
-				},
-				InitialDelaySeconds: 1,
-				PeriodSeconds:       10,
-				FailureThreshold:    60,
 			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -160,9 +146,6 @@ func TestSetProbes(t *testing.T) {
 			customLiveness: corev1.Probe{
 				InitialDelaySeconds: 120,
 			},
-			customStartup: corev1.Probe{
-				InitialDelaySeconds: 1,
-			},
 			customReadiness: corev1.Probe{
 				InitialDelaySeconds: 90,
 			},
@@ -176,17 +159,6 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 120,
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
-			},
-			wantStartup: &corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/ping",
-						Port: intstr.FromInt(8065),
-					},
-				},
-				InitialDelaySeconds: 1,
-				PeriodSeconds:       10,
-				FailureThreshold:    60,
 			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -206,10 +178,6 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 20,
 				PeriodSeconds:       20,
 			},
-			customStartup: corev1.Probe{
-				InitialDelaySeconds: 20,
-				PeriodSeconds:       20,
-			},
 			customReadiness: corev1.Probe{
 				InitialDelaySeconds: 10,
 				FailureThreshold:    10,
@@ -224,17 +192,6 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 20,
 				PeriodSeconds:       20,
 				FailureThreshold:    3,
-			},
-			wantStartup: &corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/ping",
-						Port: intstr.FromInt(8065),
-					},
-				},
-				InitialDelaySeconds: 20,
-				PeriodSeconds:       20,
-				FailureThreshold:    60,
 			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -259,15 +216,6 @@ func TestSetProbes(t *testing.T) {
 				},
 				InitialDelaySeconds: 120,
 			},
-			customStartup: corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/pong",
-						Port: intstr.FromInt(8080),
-					},
-				},
-				InitialDelaySeconds: 120,
-			},
 			customReadiness: corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -287,17 +235,6 @@ func TestSetProbes(t *testing.T) {
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
 			},
-			wantStartup: &corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/pong",
-						Port: intstr.FromInt(8080),
-					},
-				},
-				InitialDelaySeconds: 120,
-				PeriodSeconds:       10,
-				FailureThreshold:    60,
-			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -314,9 +251,8 @@ func TestSetProbes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			liveness, startUp, readiness := setProbes(tt.customLiveness, tt.customStartup, tt.customReadiness)
+			liveness, readiness := setProbes(tt.customLiveness, tt.customReadiness)
 			require.Equal(t, tt.wantLiveness, liveness)
-			require.Equal(t, tt.wantStartup, startUp)
 			require.Equal(t, tt.wantReadiness, readiness)
 		})
 	}

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -434,7 +434,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 	maxUnavailable := intstr.FromInt(defaultMaxUnavailable)
 	maxSurge := intstr.FromInt(defaultMaxSurge)
 
-	liveness, startupProbe, readiness := setProbes(mattermost.Spec.LivenessProbe, mattermost.Spec.StartupProbe, mattermost.Spec.ReadinessProbe)
+	liveness, readiness := setProbes(mattermost.Spec.LivenessProbe, mattermost.Spec.ReadinessProbe)
 
 	replicas := mattermost.Spec.Replicas
 	if replicas < 0 {
@@ -490,7 +490,6 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 							},
 							ReadinessProbe: readiness,
 							LivenessProbe:  liveness,
-							StartupProbe:   startupProbe,
 							VolumeMounts:   volumeMountLicense,
 							Resources:      mattermost.Spec.Resources,
 						},


### PR DESCRIPTION
#### Summary
Removing the startup probe because it is not available by default in the 1.17 k8s clusters and this was causing the infinite loop in the reconciliation hammering the API 

#### Ticket Link
n/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
probes: remove startup probe because 1.17 this is not enabled and was causing reconcile infinite loop
```
