### PR TITLE
Always set clustering config

### DIFF
--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -349,6 +349,14 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 			Name:  "MM_METRICSSETTINGS_LISTENADDRESS",
 			Value: ":8067",
 		},
+		{
+			Name:  "MM_CLUSTERSETTINGS_ENABLE",
+			Value: "true",
+		},
+		{
+			Name:  "MM_CLUSTERSETTINGS_CLUSTERNAME",
+			Value: "production",
+		},
 	}
 
 	valueSize := strconv.Itoa(defaultMaxFileSize * sizeMB)
@@ -399,19 +407,6 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 				},
 			},
 		})
-
-		clusterEnvVars := []corev1.EnvVar{
-			{
-				Name:  "MM_CLUSTERSETTINGS_ENABLE",
-				Value: "true",
-			},
-			{
-				Name:  "MM_CLUSTERSETTINGS_CLUSTERNAME",
-				Value: "production",
-			},
-		}
-
-		envVarGeneral = append(envVarGeneral, clusterEnvVars...)
 
 		podAnnotations = map[string]string{
 			"prometheus.io/scrape": "true",


### PR DESCRIPTION
This simplifies the logic for enabling Mattermost server clustering
by always setting the default values. They will be ignored when no
license is present.

Fixes https://mattermost.atlassian.net/browse/MM-26907

```release-note
Always set clustering config
```
