### PR TITLE
Refactor ClusterInstallation state logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,14 @@ module github.com/mattermost/mattermost-operator
 go 1.14
 
 require (
-	github.com/banzaicloud/k8s-objectmatcher v1.4.0
+	github.com/banzaicloud/k8s-objectmatcher v1.4.1
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.9
 	github.com/mattermost/blubr v0.0.0-20200113232543-f0ce67760aeb
 	github.com/mattn/goveralls v0.0.6
 	github.com/minio/minio-operator v0.0.0-20200214142425-158e343f1f19
 	github.com/operator-framework/operator-sdk v0.19.1
-	github.com/pborman/uuid v1.2.0
+	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1
 	github.com/presslabs/mysql-operator v0.4.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZo
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
-github.com/banzaicloud/k8s-objectmatcher v1.4.0 h1:HpdEc9gVbZyGzh/3spVLrc+ErhOUuh3gjKYCuR4jvbs=
-github.com/banzaicloud/k8s-objectmatcher v1.4.0/go.mod h1:j+N22VwgVfa0ajVtNxOz2G72aSOL21lpB7qV2GDrr/I=
+github.com/banzaicloud/k8s-objectmatcher v1.4.1 h1:/HaUqQzTa5E+pLqG9qelRKUdrzU1Nl2BYPHDut7e1oU=
+github.com/banzaicloud/k8s-objectmatcher v1.4.1/go.mod h1:j+N22VwgVfa0ajVtNxOz2G72aSOL21lpB7qV2GDrr/I=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -769,6 +769,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
+github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v0.0.0-20180312054125-0646ccaebea1/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/pkg/controller/clusterinstallation/create_resources.go
+++ b/pkg/controller/clusterinstallation/create_resources.go
@@ -3,13 +3,15 @@ package clusterinstallation
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	objectMatcher "github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -32,34 +34,34 @@ func (r *ReconcileClusterInstallation) create(owner v1.Object, desired Object, r
 	// see: https://github.com/banzaicloud/k8s-objectmatcher
 	err := defaultAnnotator.SetLastAppliedAnnotation(desired)
 	if err != nil {
-		reqLogger.Error(err, "Error applying the annotation in the resource")
-		return err
+		return errors.Wrap(err, "failed to apply annotation to the resource")
 	}
 	err = r.client.Create(context.TODO(), desired)
 	if err != nil {
-		reqLogger.Error(err, "Error creating resource")
-		return err
+		return errors.Wrap(err, "failed to create resource")
 	}
+
 	return controllerutil.SetControllerReference(owner, desired, r.scheme)
 }
 
 func (r *ReconcileClusterInstallation) update(current, desired Object, reqLogger logr.Logger) error {
 	patchResult, err := objectMatcher.NewPatchMaker(defaultAnnotator).Calculate(current, desired)
 	if err != nil {
-		reqLogger.Error(err, "error checking the difference in the resource")
-		return err
+		return errors.Wrap(err, "failed to determine if resources differ")
 	}
 	if !patchResult.IsEmpty() {
 		if err := defaultAnnotator.SetLastAppliedAnnotation(desired); err != nil {
-			reqLogger.Error(err, "error applying the annotation in the resource")
-			return err
+			return errors.Wrap(err, "failed to apply annotation to the resource")
 		}
-		reqLogger.Info("updating resource", "name", desired.GetName(), "namespace", desired.GetNamespace())
+
+		reqLogger.Info("updating resource", "name", desired.GetName(), "namespace", desired.GetNamespace(), "patch", string(patchResult.Patch))
+
 		// Resource version is required for the update, but need to be set after
 		// the last applied annotation to avoid unnecessary diffs
 		desired.SetResourceVersion(current.GetResourceVersion())
 		return r.client.Update(context.TODO(), desired)
 	}
+
 	return nil
 }
 
@@ -67,12 +69,11 @@ func (r *ReconcileClusterInstallation) createServiceAccountIfNotExists(owner v1.
 	foundServiceAccount := &corev1.ServiceAccount{}
 
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: serviceAccount.Name, Namespace: serviceAccount.Namespace}, foundServiceAccount)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8sErrors.IsNotFound(err) {
 		reqLogger.Info("Creating service account", "name", serviceAccount.Name)
 		return r.create(owner, serviceAccount, reqLogger)
 	} else if err != nil {
-		reqLogger.Error(err, "Failed to check if service account exists")
-		return err
+		return errors.Wrap(err, "failed to check if service account exists")
 	}
 
 	return nil
@@ -81,12 +82,11 @@ func (r *ReconcileClusterInstallation) createServiceAccountIfNotExists(owner v1.
 func (r *ReconcileClusterInstallation) createRoleBindingIfNotExists(owner v1.Object, roleBinding *rbacv1beta1.RoleBinding, reqLogger logr.Logger) error {
 	foundRoleBinding := &rbacv1beta1.RoleBinding{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, foundRoleBinding)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8sErrors.IsNotFound(err) {
 		reqLogger.Info("Creating role binding", "name", roleBinding.Name)
 		return r.create(owner, roleBinding, reqLogger)
 	} else if err != nil {
-		reqLogger.Error(err, "Failed to check if role binding exists")
-		return err
+		return errors.Wrap(err, "failed to check if role binding exists")
 	}
 
 	return nil
@@ -95,12 +95,11 @@ func (r *ReconcileClusterInstallation) createRoleBindingIfNotExists(owner v1.Obj
 func (r *ReconcileClusterInstallation) createServiceIfNotExists(owner v1.Object, service *corev1.Service, reqLogger logr.Logger) error {
 	foundService := &corev1.Service{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: service.Name, Namespace: service.Namespace}, foundService)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8sErrors.IsNotFound(err) {
 		reqLogger.Info("Creating service", "name", service.Name)
 		return r.create(owner, service, reqLogger)
 	} else if err != nil {
-		reqLogger.Error(err, "Failed to check if service exists")
-		return err
+		return errors.Wrap(err, "failed to check if service exists")
 	}
 
 	return nil
@@ -109,12 +108,11 @@ func (r *ReconcileClusterInstallation) createServiceIfNotExists(owner v1.Object,
 func (r *ReconcileClusterInstallation) createIngressIfNotExists(owner v1.Object, ingress *v1beta1.Ingress, reqLogger logr.Logger) error {
 	foundIngress := &v1beta1.Ingress{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: ingress.Name, Namespace: ingress.Namespace}, foundIngress)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8sErrors.IsNotFound(err) {
 		reqLogger.Info("Creating ingress", "name", ingress.Name)
 		return r.create(owner, ingress, reqLogger)
 	} else if err != nil {
-		reqLogger.Error(err, "Failed to check if ingress exists")
-		return err
+		return errors.Wrap(err, "failed to check if ingress exists")
 	}
 
 	return nil
@@ -123,12 +121,11 @@ func (r *ReconcileClusterInstallation) createIngressIfNotExists(owner v1.Object,
 func (r *ReconcileClusterInstallation) createDeploymentIfNotExists(owner v1.Object, deployment *appsv1.Deployment, reqLogger logr.Logger) error {
 	foundDeployment := &appsv1.Deployment{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, foundDeployment)
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && k8sErrors.IsNotFound(err) {
 		reqLogger.Info("Creating deployment", "name", deployment.Name)
 		return r.create(owner, deployment, reqLogger)
 	} else if err != nil {
-		reqLogger.Error(err, "Failed to check if deployment exists")
-		return err
+		return errors.Wrap(err, "failed to check if deployment exists")
 	}
 
 	return nil

--- a/pkg/controller/clusterinstallation/mattermost.go
+++ b/pkg/controller/clusterinstallation/mattermost.go
@@ -248,23 +248,20 @@ func (r *ReconcileClusterInstallation) isMainContainerImageSame(
 ) (bool, error) {
 	// Sanity check
 	if (a == nil) || (b == nil) {
-		return false, errors.New("Unable to find main container, no deployment provided")
+		return false, errors.New("failed to find main container, no deployment provided")
 	}
 
 	// Fetch containers to compare
-
 	containerA := mattermost.GetMattermostAppContainer(a)
 	if containerA == nil {
-		return false, errors.Errorf("Unable to find main container, incorrect deployment %s/%s", a.Namespace, a.Name)
+		return false, errors.Errorf("failed to find main container, incorrect deployment %s/%s", a.Namespace, a.Name)
 	}
-
 	containerB := mattermost.GetMattermostAppContainer(b)
 	if containerB == nil {
-		return false, errors.Errorf("Unable to find main container, incorrect deployment %s/%s", b.Namespace, b.Name)
+		return false, errors.Errorf("failed to find main container, incorrect deployment %s/%s", b.Namespace, b.Name)
 	}
 
 	// Both containers fetched, can compare images
-
 	return containerA.Image == containerB.Image, nil
 }
 
@@ -334,13 +331,13 @@ func (r *ReconcileClusterInstallation) checkUpdateJob(
 	// Job is either running or completed
 
 	if job.Status.CompletionTime == nil {
-		return nil, errors.New("Update image job still running")
+		return nil, errors.New("update image job still running")
 	}
 
 	// Job is completed, can check completion status
 
 	if job.Status.Failed > 0 {
-		return job, errors.New("Update image job failed")
+		return job, errors.New("update image job failed")
 	}
 
 	reqLogger.Info("Update image job ran successfully")

--- a/pkg/controller/clusterinstallation/minio.go
+++ b/pkg/controller/clusterinstallation/minio.go
@@ -77,7 +77,6 @@ func (r *ReconcileClusterInstallation) checkMattermostMinioSecret(mattermost *ma
 
 func (r *ReconcileClusterInstallation) checkMinioSecret(mattermost *mattermostv1alpha1.ClusterInstallation, reqLogger logr.Logger) error {
 	if mattermost.Spec.Minio.Secret != "" {
-		reqLogger.Info("skipping minio secret creation, using custom secret")
 		return r.checkCustomMinioSecret(mattermost, reqLogger)
 	}
 	return r.checkMattermostMinioSecret(mattermost, reqLogger)

--- a/pkg/mattermost/helpers.go
+++ b/pkg/mattermost/helpers.go
@@ -44,7 +44,7 @@ func mergeEnvVars(original, new []corev1.EnvVar) []corev1.EnvVar {
 	return original
 }
 
-func setProbes(customLiveness, customStartup, customReadiness corev1.Probe) (*corev1.Probe, *corev1.Probe, *corev1.Probe) {
+func setProbes(customLiveness, customReadiness corev1.Probe) (*corev1.Probe, *corev1.Probe) {
 	liveness := &corev1.Probe{
 		Handler: corev1.Handler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -75,38 +75,6 @@ func setProbes(customLiveness, customStartup, customReadiness corev1.Probe) (*co
 
 	if customLiveness.SuccessThreshold != 0 {
 		liveness.SuccessThreshold = customLiveness.SuccessThreshold
-	}
-
-	startUp := &corev1.Probe{
-		Handler: corev1.Handler{
-			HTTPGet: &corev1.HTTPGetAction{
-				Path: "/api/v4/system/ping",
-				Port: intstr.FromInt(8065),
-			},
-		},
-		InitialDelaySeconds: 1,
-		PeriodSeconds:       10,
-		FailureThreshold:    60,
-	}
-
-	if customStartup.Handler != (corev1.Handler{}) {
-		startUp.Handler = customStartup.Handler
-	}
-
-	if customStartup.InitialDelaySeconds != 0 {
-		startUp.InitialDelaySeconds = customStartup.InitialDelaySeconds
-	}
-
-	if customStartup.PeriodSeconds != 0 {
-		startUp.PeriodSeconds = customStartup.PeriodSeconds
-	}
-
-	if customStartup.FailureThreshold != 0 {
-		startUp.FailureThreshold = customStartup.FailureThreshold
-	}
-
-	if customStartup.SuccessThreshold != 0 {
-		startUp.SuccessThreshold = customStartup.SuccessThreshold
 	}
 
 	readiness := &corev1.Probe{
@@ -141,5 +109,5 @@ func setProbes(customLiveness, customStartup, customReadiness corev1.Probe) (*co
 		readiness.SuccessThreshold = customReadiness.SuccessThreshold
 	}
 
-	return liveness, startUp, readiness
+	return liveness, readiness
 }

--- a/pkg/mattermost/helpers_test.go
+++ b/pkg/mattermost/helpers_test.go
@@ -110,16 +110,13 @@ func TestSetProbes(t *testing.T) {
 	tests := []struct {
 		name            string
 		customLiveness  corev1.Probe
-		customStartup   corev1.Probe
 		customReadiness corev1.Probe
 		wantLiveness    *corev1.Probe
-		wantStartup     *corev1.Probe
 		wantReadiness   *corev1.Probe
 	}{
 		{
 			name:            "No Custom probes",
 			customLiveness:  corev1.Probe{},
-			customStartup:   corev1.Probe{},
 			customReadiness: corev1.Probe{},
 			wantLiveness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -131,17 +128,6 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 10,
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
-			},
-			wantStartup: &corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/ping",
-						Port: intstr.FromInt(8065),
-					},
-				},
-				InitialDelaySeconds: 1,
-				PeriodSeconds:       10,
-				FailureThreshold:    60,
 			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -160,9 +146,6 @@ func TestSetProbes(t *testing.T) {
 			customLiveness: corev1.Probe{
 				InitialDelaySeconds: 120,
 			},
-			customStartup: corev1.Probe{
-				InitialDelaySeconds: 1,
-			},
 			customReadiness: corev1.Probe{
 				InitialDelaySeconds: 90,
 			},
@@ -176,17 +159,6 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 120,
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
-			},
-			wantStartup: &corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/ping",
-						Port: intstr.FromInt(8065),
-					},
-				},
-				InitialDelaySeconds: 1,
-				PeriodSeconds:       10,
-				FailureThreshold:    60,
 			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -206,10 +178,6 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 20,
 				PeriodSeconds:       20,
 			},
-			customStartup: corev1.Probe{
-				InitialDelaySeconds: 20,
-				PeriodSeconds:       20,
-			},
 			customReadiness: corev1.Probe{
 				InitialDelaySeconds: 10,
 				FailureThreshold:    10,
@@ -224,17 +192,6 @@ func TestSetProbes(t *testing.T) {
 				InitialDelaySeconds: 20,
 				PeriodSeconds:       20,
 				FailureThreshold:    3,
-			},
-			wantStartup: &corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/ping",
-						Port: intstr.FromInt(8065),
-					},
-				},
-				InitialDelaySeconds: 20,
-				PeriodSeconds:       20,
-				FailureThreshold:    60,
 			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
@@ -259,15 +216,6 @@ func TestSetProbes(t *testing.T) {
 				},
 				InitialDelaySeconds: 120,
 			},
-			customStartup: corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/pong",
-						Port: intstr.FromInt(8080),
-					},
-				},
-				InitialDelaySeconds: 120,
-			},
 			customReadiness: corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -287,17 +235,6 @@ func TestSetProbes(t *testing.T) {
 				PeriodSeconds:       10,
 				FailureThreshold:    3,
 			},
-			wantStartup: &corev1.Probe{
-				Handler: corev1.Handler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/api/v4/system/pong",
-						Port: intstr.FromInt(8080),
-					},
-				},
-				InitialDelaySeconds: 120,
-				PeriodSeconds:       10,
-				FailureThreshold:    60,
-			},
 			wantReadiness: &corev1.Probe{
 				Handler: corev1.Handler{
 					HTTPGet: &corev1.HTTPGetAction{
@@ -314,9 +251,8 @@ func TestSetProbes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			liveness, startUp, readiness := setProbes(tt.customLiveness, tt.customStartup, tt.customReadiness)
+			liveness, readiness := setProbes(tt.customLiveness, tt.customReadiness)
 			require.Equal(t, tt.wantLiveness, liveness)
-			require.Equal(t, tt.wantStartup, startUp)
 			require.Equal(t, tt.wantReadiness, readiness)
 		})
 	}

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -429,7 +429,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 	maxUnavailable := intstr.FromInt(defaultMaxUnavailable)
 	maxSurge := intstr.FromInt(defaultMaxSurge)
 
-	liveness, startupProbe, readiness := setProbes(mattermost.Spec.LivenessProbe, mattermost.Spec.StartupProbe, mattermost.Spec.ReadinessProbe)
+	liveness, readiness := setProbes(mattermost.Spec.LivenessProbe, mattermost.Spec.ReadinessProbe)
 
 	replicas := mattermost.Spec.Replicas
 	if replicas < 0 {
@@ -485,7 +485,6 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 							},
 							ReadinessProbe: readiness,
 							LivenessProbe:  liveness,
-							StartupProbe:   startupProbe,
 							VolumeMounts:   volumeMountLicense,
 							Resources:      mattermost.Spec.Resources,
 						},

--- a/vendor/github.com/banzaicloud/k8s-objectmatcher/patch/annotation.go
+++ b/vendor/github.com/banzaicloud/k8s-objectmatcher/patch/annotation.go
@@ -65,6 +65,7 @@ func (a *Annotator) GetOriginalConfiguration(obj runtime.Object) ([]byte, error)
 		if http.DetectContentType(decoded) == "application/zip" {
 			return unZipAnnotation(decoded)
 		}
+		return decoded, nil
 	}
 
 	return []byte(original), nil

--- a/vendor/github.com/pborman/uuid/time.go
+++ b/vendor/github.com/pborman/uuid/time.go
@@ -29,7 +29,7 @@ func GetTime() (Time, uint16, error) { return guuid.GetTime() }
 // for
 func ClockSequence() int { return guuid.ClockSequence() }
 
-// SetClockSeq sets the clock sequence to the lower 14 bits of seq.  Setting to
+// SetClockSequence sets the clock sequence to the lower 14 bits of seq.  Setting to
 // -1 causes a new sequence to be generated.
 func SetClockSequence(seq int) { guuid.SetClockSequence(seq) }
 

--- a/vendor/github.com/pborman/uuid/version4.go
+++ b/vendor/github.com/pborman/uuid/version4.go
@@ -6,7 +6,7 @@ package uuid
 
 import guuid "github.com/google/uuid"
 
-// Random returns a Random (Version 4) UUID or panics.
+// NewRandom returns a Random (Version 4) UUID or panics.
 //
 // The strength of the UUIDs is based on the strength of the crypto/rand
 // package.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,7 +15,7 @@ github.com/Azure/go-autorest/tracing
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
-# github.com/banzaicloud/k8s-objectmatcher v1.4.0
+# github.com/banzaicloud/k8s-objectmatcher v1.4.1
 ## explicit
 github.com/banzaicloud/k8s-objectmatcher/patch
 # github.com/beorn7/perks v1.0.1
@@ -155,7 +155,7 @@ github.com/operator-framework/operator-sdk/pkg/metrics
 github.com/operator-framework/operator-sdk/pkg/test
 github.com/operator-framework/operator-sdk/pkg/test/e2eutil
 github.com/operator-framework/operator-sdk/version
-# github.com/pborman/uuid v1.2.0
+# github.com/pborman/uuid v1.2.1
 ## explicit
 github.com/pborman/uuid
 # github.com/pkg/errors v0.9.1


### PR DESCRIPTION
This change refactors all controller logic related to updating the
state field of a ClusterInstallation's status. This was done to
correct an issue where the state value could be temporarily
incorrect. As part of this refactor, the following changes were
also made:

 - Improved logging of status changes as well as other important
   events. More logging fields added as well.
 - Improved error handling by returning wrapped errors and letting
   the caller log as necessary.
 - Removed false logs that showed up when not using the mysql or
   minio operators.
 - Cherry-pick a change to remove the startup probe being set in
   Mattermost deployments.

Fixes https://mattermost.atlassian.net/browse/MM-28636

```release-note
Refactor ClusterInstallation state logic
```
