### PR TITLE
DOPS-216: Add MM_INSTALL_TYPE=kubernetes

### DIFF
--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -373,7 +373,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 		},
 		{
 			Name:  "MM_INSTALL_TYPE",
-			Value: "kubernetes",
+			Value: "kubernetes-operator",
 		},
 	}
 

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -371,6 +371,10 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 			Name:  "MM_CLUSTERSETTINGS_CLUSTERNAME",
 			Value: "production",
 		},
+		{
+			Name:  "MM_INSTALL_TYPE",
+			Value: "operator",
+		},
 	}
 
 	valueSize := strconv.Itoa(defaultMaxFileSize * sizeMB)
@@ -402,16 +406,10 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 	volumeMountLicense := []corev1.VolumeMount{}
 	podAnnotations := map[string]string{}
 	if len(mattermost.Spec.MattermostLicenseSecret) != 0 {
-		envVarGeneral = append(
-			envVarGeneral,
-			corev1.EnvVar{
-				Name:  "MM_SERVICESETTINGS_LICENSEFILELOCATION",
-				Value: "/mattermost-license/license",
-			},
-			corev1.EnvVar{
-				Name:  "MM_INSTALL_TYPE",
-				Value: "operator",
-			})
+		envVarGeneral = append(envVarGeneral, corev1.EnvVar{
+			Name:  "MM_SERVICESETTINGS_LICENSEFILELOCATION",
+			Value: "/mattermost-license/license",
+		})
 
 		volumeMountLicense = append(volumeMountLicense, corev1.VolumeMount{
 			MountPath: "/mattermost-license",

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -373,7 +373,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 		},
 		{
 			Name:  "MM_INSTALL_TYPE",
-			Value: "operator",
+			Value: "kubernetes",
 		},
 	}
 

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -402,10 +402,16 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 	volumeMountLicense := []corev1.VolumeMount{}
 	podAnnotations := map[string]string{}
 	if len(mattermost.Spec.MattermostLicenseSecret) != 0 {
-		envVarGeneral = append(envVarGeneral, corev1.EnvVar{
-			Name:  "MM_SERVICESETTINGS_LICENSEFILELOCATION",
-			Value: "/mattermost-license/license",
-		})
+		envVarGeneral = append(
+			envVarGeneral,
+			corev1.EnvVar{
+				Name:  "MM_SERVICESETTINGS_LICENSEFILELOCATION",
+				Value: "/mattermost-license/license",
+			},
+			corev1.EnvVar{
+				Name:  "MM_INSTALL_TYPE",
+				Value: "operator",
+			})
 
 		volumeMountLicense = append(volumeMountLicense, corev1.VolumeMount{
 			MountPath: "/mattermost-license",

--- a/pkg/mattermost/mattermost_test.go
+++ b/pkg/mattermost/mattermost_test.go
@@ -283,6 +283,7 @@ func TestGenerateDeployment(t *testing.T) {
 			assertEnvVarExists(t, "MM_CLUSTERSETTINGS_ENABLE", mattermostAppContainer.Env)
 			assertEnvVarExists(t, "MM_CLUSTERSETTINGS_CLUSTERNAME", mattermostAppContainer.Env)
 			assertEnvVarExists(t, "MM_FILESETTINGS_MAXFILESIZE", mattermostAppContainer.Env)
+			assertEnvVarExists(t, "MM_INSTALL_TYPE", mattermostAppContainer.Env)
 
 			if databaseInfo.HasReaderEndpoints() {
 				assertEnvVarExists(t, "MM_SQLSETTINGS_DATASOURCEREPLICAS", mattermostAppContainer.Env)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
--> Sets an environment variable to get an idea of the preferred installation type. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/jira/software/projects/DOPS/boards/66/backlog?selectedIssue=DOPS-216

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
