### PR TITLE
expose metrics port for prometheus operator

### DIFF
--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -54,7 +54,13 @@ func GenerateService(mattermost *mattermostv1alpha1.ClusterInstallation, service
 	service.Spec.Ports = []corev1.ServicePort{
 		{
 			Port:       8065,
+			Name:       "app",
 			TargetPort: intstr.FromString("app"),
+		},
+		{
+			Port:       8067,
+			Name:       "metrics",
+			TargetPort: intstr.FromString("metrics"),
 		},
 	}
 	service.Spec.ClusterIP = corev1.ClusterIPNone
@@ -499,6 +505,10 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 								{
 									ContainerPort: 8065,
 									Name:          "app",
+								},
+								{
+									ContainerPort: 8067,
+									Name:          "metrics",
 								},
 							},
 							ReadinessProbe: readiness,

--- a/pkg/mattermost/mattermost_test.go
+++ b/pkg/mattermost/mattermost_test.go
@@ -63,6 +63,7 @@ func TestGenerateService(t *testing.T) {
 				expectPort(t, service, 443)
 			} else {
 				expectPort(t, service, 8065)
+				expectPort(t, service, 8067)
 			}
 		})
 	}


### PR DESCRIPTION
#### Summary
Using the Prometheus operator and the ServiceMonitor it expected the svc exposes the metric port that prometheus can scrape

This PR add this port in the deployment and in the svc to allow prometheus to scrapes 


For MM-cloud we will need a new operator release and deploy that in test to unblock the work that Stelios is doing for the new prometheus

#### Ticket Link
n/a

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
expose metrics port for prometheus operator
```
