### PR TITLE
Do not return error if health check fails

### DIFF
--- a/controllers/mattermost/clusterinstallation/controller.go
+++ b/controllers/mattermost/clusterinstallation/controller.go
@@ -22,6 +22,8 @@ import (
 	"github.com/mattermost/mattermost-operator/pkg/database"
 )
 
+const healthCheckRequeueDelay = 6 * time.Second
+
 // ClusterInstallationReconciler reconciles a ClusterInstallation object
 type ClusterInstallationReconciler struct {
 	client.Client
@@ -135,7 +137,8 @@ func (r *ClusterInstallationReconciler) Reconcile(request ctrl.Request) (ctrl.Re
 	if err != nil {
 		r.setStateReconcilingAndLogError(mattermost, reqLogger)
 		r.updateStatus(mattermost, status, reqLogger)
-		return reconcile.Result{RequeueAfter: time.Second * 3}, err
+		reqLogger.Error(err, "Error checking ClusterInstallation health")
+		return reconcile.Result{RequeueAfter: healthCheckRequeueDelay}, nil
 	}
 
 	err = r.updateStatus(mattermost, status, reqLogger)

--- a/controllers/mattermost/clusterinstallation/controller_test.go
+++ b/controllers/mattermost/clusterinstallation/controller_test.go
@@ -79,8 +79,8 @@ func TestReconcile(t *testing.T) {
 	// We expect an error on the first reconciliation due to the deployment pods
 	// not running yet.
 	res, err := r.Reconcile(req)
-	require.Error(t, err)
-	require.Equal(t, res, reconcile.Result{RequeueAfter: time.Second * 3})
+	require.NoError(t, err)
+	require.Equal(t, res, reconcile.Result{RequeueAfter: 6 * time.Second})
 
 	// Define the NamespacedName objects that will be used to lookup the
 	// cluster resources.
@@ -155,7 +155,8 @@ func TestReconcile(t *testing.T) {
 
 		t.Run("pods not ready", func(t *testing.T) {
 			res, err = r.Reconcile(req)
-			require.Error(t, err)
+			require.NoError(t, err)
+			require.Equal(t, res, reconcile.Result{RequeueAfter: 6 * time.Second})
 		})
 
 		// Make pods ready
@@ -201,7 +202,8 @@ func TestReconcile(t *testing.T) {
 
 		t.Run("pods not running", func(t *testing.T) {
 			res, err = r.Reconcile(req)
-			require.Error(t, err)
+			require.NoError(t, err)
+			require.Equal(t, res, reconcile.Result{RequeueAfter: 6 * time.Second})
 		})
 
 		// Make pods running


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
To prevent the exponential backoff when Cluster Installation health check fails, do not return reconciliation error but requeue the request with a constant delay.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Do not return reconciliation error if the health check fails.
```
