### PR TITLE
Add Job that initializes MM database

### DIFF
--- a/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -47,18 +47,21 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallation(ref
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the Mattermost cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.ClusterInstallationSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recent observed status of the Mattermost cluster. Read-only. Not included when requesting from the apiserver, only from the Mattermost Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status",
+							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.ClusterInstallationStatus"),
 						},
 					},
@@ -109,12 +112,14 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Defines the resource requests and limits for the Mattermost app server pods.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
 					"ingressName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "IngressName defines the name to be used when creating the ingress rules",
+							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -134,8 +139,9 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -149,27 +155,32 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 					},
 					"minio": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Minio"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Minio"),
 						},
 					},
 					"database": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Database"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Database"),
 						},
 					},
 					"blueGreen": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.BlueGreen"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.BlueGreen"),
 						},
 					},
 					"canary": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Canary"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Canary"),
 						},
 					},
 					"elasticSearch": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.ElasticSearch"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.ElasticSearch"),
 						},
 					},
 					"useServiceLoadBalancer": {
@@ -185,8 +196,9 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -205,8 +217,9 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -219,8 +232,9 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Type:   []string{"string"},
-										Format: "",
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
 									},
 								},
 							},
@@ -233,7 +247,8 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("k8s.io/api/core/v1.EnvVar"),
+										Default: map[string]interface{}{},
+										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -242,12 +257,14 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 					"livenessProbe": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Defines the probe to check if the application is up and running.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
 					"readinessProbe": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Defines the probe to check if the application is ready to accept traffic.",
+							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
@@ -283,17 +300,20 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_MattermostRestoreDB(ref
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Default: map[string]interface{}{},
+							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.MattermostRestoreDBSpec"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.MattermostRestoreDBSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.MattermostRestoreDBStatus"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.MattermostRestoreDBStatus"),
 						},
 					},
 				},

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -52,6 +52,7 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - rolebindings
+      - roles
     verbs:
       - get
       - create

--- a/controllers/mattermost/clusterinstallation/bluegreen.go
+++ b/controllers/mattermost/clusterinstallation/bluegreen.go
@@ -22,7 +22,7 @@ func (r *ClusterInstallationReconciler) checkBlueGreen(mattermost *mattermostv1a
 					return err
 				}
 			}
-			err = r.checkMattermostDeployment(mattermost, deployment.Name, deployment.IngressName, deployment.GetDeploymentImageName(), reqLogger)
+			err = r.checkMattermostDeployment(mattermost, deployment.Name, deployment.IngressName, mattermost.Name, deployment.GetDeploymentImageName(), reqLogger)
 			if err != nil {
 				return err
 			}

--- a/controllers/mattermost/clusterinstallation/canary.go
+++ b/controllers/mattermost/clusterinstallation/canary.go
@@ -23,7 +23,7 @@ func (r *ClusterInstallationReconciler) checkCanary(mattermost *mattermostv1alph
 		if err != nil {
 			return err
 		}
-		err = r.checkMattermostDeployment(mattermost, c.Name, mattermost.Spec.IngressName, c.GetDeploymentImageName(), reqLogger)
+		err = r.checkMattermostDeployment(mattermost, c.Name, mattermost.Spec.IngressName, mattermost.Name, c.GetDeploymentImageName(), reqLogger)
 		if err != nil {
 			return err
 		}

--- a/controllers/mattermost/clusterinstallation/controller.go
+++ b/controllers/mattermost/clusterinstallation/controller.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"time"
 
+	batchv1 "k8s.io/api/batch/v1"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -44,6 +46,7 @@ func (r *ClusterInstallationReconciler) SetupWithManager(mgr ctrl.Manager) error
 		Owns(&corev1.Secret{}).
 		Owns(&v1beta1.Ingress{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&batchv1.Job{}).
 		Complete(r)
 }
 

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -92,7 +92,7 @@ func (r *ClusterInstallationReconciler) checkMattermostRBAC(mattermost *mattermo
 	}
 	err = r.checkMattermostRoleBinding(mattermost, roleName, saName, reqLogger)
 	if err != nil {
-		return errors.Wrap(err, "failed to check mattermost Role")
+		return errors.Wrap(err, "failed to check mattermost RoleBinding")
 	}
 
 	return nil
@@ -208,7 +208,7 @@ func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *ma
 
 	err = r.checkMattermostDBSetupJob(mattermost, desired, reqLogger)
 	if err != nil {
-		return errors.Wrap(err, "failed to check mattermost DB setup job.")
+		return errors.Wrap(err, "failed to check mattermost DB setup job")
 	}
 
 	err = r.createDeploymentIfNotExists(mattermost, desired, reqLogger)
@@ -240,7 +240,7 @@ func (r *ClusterInstallationReconciler) checkMattermostDBSetupJob(mattermost *ma
 			reqLogger.Info("Creating DB setup job", "name", desiredJob.Name)
 			return r.create(mattermost, desiredJob, reqLogger)
 		}
-		return errors.Wrapf(err, "failed to get current db setup job")
+		return errors.Wrap(err, "failed to get current db setup job")
 	}
 	// For now, there is no need to perform job update, so just return.
 	return nil

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -232,6 +232,7 @@ func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *ma
 
 func (r *ClusterInstallationReconciler) checkMattermostDBSetupJob(mattermost *mattermostv1alpha1.ClusterInstallation, deployment *appsv1.Deployment, reqLogger logr.Logger) error {
 	desiredJob := prepareJobTemplate(mattermost, deployment, mattermostApp.SetupJobName)
+	desiredJob.OwnerReferences = mattermostApp.ClusterInstallationOwnerReference(mattermost)
 
 	currentJob := &batchv1.Job{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: desiredJob.Name, Namespace: desiredJob.Namespace}, currentJob)

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -310,6 +310,8 @@ func (r *ClusterInstallationReconciler) launchUpdateJob(
 }
 
 func prepareJobTemplate(mm *mattermostv1alpha1.ClusterInstallation, deployment *appsv1.Deployment, name string) *batchv1.Job {
+	backoffLimit := int32(10)
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -322,6 +324,7 @@ func prepareJobTemplate(mm *mattermostv1alpha1.ClusterInstallation, deployment *
 				},
 				Spec: *deployment.Spec.Template.Spec.DeepCopy(),
 			},
+			BackoffLimit: &backoffLimit,
 		},
 	}
 

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,6 +34,11 @@ func (r *ClusterInstallationReconciler) checkMattermost(mattermost *mattermostv1
 		return err
 	}
 
+	err = r.checkMattermostRBAC(mattermost, mattermost.Name, mattermost.Name, reqLogger)
+	if err != nil {
+		return err
+	}
+
 	if !mattermost.Spec.UseServiceLoadBalancer {
 		ingressAnnotations := map[string]string{
 			"kubernetes.io/ingress.class":                 "nginx",
@@ -48,7 +55,7 @@ func (r *ClusterInstallationReconciler) checkMattermost(mattermost *mattermostv1
 	}
 
 	if !mattermost.Spec.BlueGreen.Enable {
-		err = r.checkMattermostDeployment(mattermost, mattermost.Name, mattermost.Spec.IngressName, mattermost.GetImageName(), reqLogger)
+		err = r.checkMattermostDeployment(mattermost, mattermost.Name, mattermost.Spec.IngressName, mattermost.Name, mattermost.GetImageName(), reqLogger)
 		if err != nil {
 			return err
 		}
@@ -74,6 +81,71 @@ func (r *ClusterInstallationReconciler) checkMattermostService(mattermost *matte
 	return r.update(current, desired, reqLogger)
 }
 
+func (r *ClusterInstallationReconciler) checkMattermostRBAC(mattermost *mattermostv1alpha1.ClusterInstallation, roleName, saName string, reqLogger logr.Logger) error {
+	err := r.checkMattermostSA(mattermost, saName, reqLogger)
+	if err != nil {
+		return errors.Wrap(err, "failed to check mattermost ServiceAccount")
+	}
+	err = r.checkMattermostRole(mattermost, roleName, reqLogger)
+	if err != nil {
+		return errors.Wrap(err, "failed to check mattermost Role")
+	}
+	err = r.checkMattermostRoleBinding(mattermost, roleName, saName, reqLogger)
+	if err != nil {
+		return errors.Wrap(err, "failed to check mattermost Role")
+	}
+
+	return nil
+}
+
+func (r *ClusterInstallationReconciler) checkMattermostSA(mattermost *mattermostv1alpha1.ClusterInstallation, saName string, reqLogger logr.Logger) error {
+	desired := mattermostApp.GenerateServiceAccount(mattermost, saName)
+	err := r.createServiceAccountIfNotExists(mattermost, desired, reqLogger)
+	if err != nil {
+		return err
+	}
+
+	current := &corev1.ServiceAccount{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
+	if err != nil {
+		return err
+	}
+
+	return r.update(current, desired, reqLogger)
+}
+
+func (r *ClusterInstallationReconciler) checkMattermostRole(mattermost *mattermostv1alpha1.ClusterInstallation, roleName string, reqLogger logr.Logger) error {
+	desired := mattermostApp.GenerateRole(mattermost, roleName)
+	err := r.createRoleIfNotExists(mattermost, desired, reqLogger)
+	if err != nil {
+		return err
+	}
+
+	current := &rbacv1.Role{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
+	if err != nil {
+		return err
+	}
+
+	return r.update(current, desired, reqLogger)
+}
+
+func (r *ClusterInstallationReconciler) checkMattermostRoleBinding(mattermost *mattermostv1alpha1.ClusterInstallation, roleName, saName string, reqLogger logr.Logger) error {
+	desired := mattermostApp.GenerateRoleBinding(mattermost, roleName, saName)
+	err := r.createRoleBindingIfNotExists(mattermost, desired, reqLogger)
+	if err != nil {
+		return err
+	}
+
+	current := &rbacv1.RoleBinding{}
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
+	if err != nil {
+		return err
+	}
+
+	return r.update(current, desired, reqLogger)
+}
+
 func (r *ClusterInstallationReconciler) checkMattermostIngress(mattermost *mattermostv1alpha1.ClusterInstallation, resourceName, ingressName string, ingressAnnotations map[string]string, reqLogger logr.Logger) error {
 	desired := mattermostApp.GenerateIngress(mattermost, resourceName, ingressName, ingressAnnotations)
 
@@ -91,7 +163,7 @@ func (r *ClusterInstallationReconciler) checkMattermostIngress(mattermost *matte
 	return r.update(current, desired, reqLogger)
 }
 
-func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, resourceName, ingressName, imageName string, reqLogger logr.Logger) error {
+func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, resourceName, ingressName, saName, imageName string, reqLogger logr.Logger) error {
 	var err error
 	dbInfo := &database.Info{}
 
@@ -132,7 +204,13 @@ func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *ma
 		}
 	}
 
-	desired := mattermostApp.GenerateDeployment(mattermost, dbInfo, resourceName, ingressName, imageName, minioURL)
+	desired := mattermostApp.GenerateDeployment(mattermost, dbInfo, resourceName, ingressName, saName, imageName, minioURL)
+
+	err = r.checkMattermostDBSetupJob(mattermost, desired, reqLogger)
+	if err != nil {
+		return errors.Wrap(err, "failed to check mattermost DB setup job.")
+	}
+
 	err = r.createDeploymentIfNotExists(mattermost, desired, reqLogger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create mattermost deployment")
@@ -149,6 +227,22 @@ func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *ma
 		return errors.Wrap(err, "failed to update mattermost deployment")
 	}
 
+	return nil
+}
+
+func (r *ClusterInstallationReconciler) checkMattermostDBSetupJob(mattermost *mattermostv1alpha1.ClusterInstallation, deployment *appsv1.Deployment, reqLogger logr.Logger) error {
+	desiredJob := prepareJobTemplate(mattermost, deployment, mattermostApp.SetupJobName)
+
+	currentJob := &batchv1.Job{}
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: desiredJob.Name, Namespace: desiredJob.Namespace}, currentJob)
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			reqLogger.Info("Creating DB setup job", "name", desiredJob.Name)
+			return r.create(mattermost, desiredJob, reqLogger)
+		}
+		return errors.Wrapf(err, "failed to get current db setup job")
+	}
+	// For now, there is no need to perform job update, so just return.
 	return nil
 }
 
@@ -205,10 +299,21 @@ func (r *ClusterInstallationReconciler) launchUpdateJob(
 	mi *mattermostv1alpha1.ClusterInstallation,
 	deployment *appsv1.Deployment,
 ) error {
+	job := prepareJobTemplate(mi, deployment, updateJobName)
+
+	err := r.Client.Create(context.TODO(), job)
+	if err != nil && !k8sErrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
+func prepareJobTemplate(mm *mattermostv1alpha1.ClusterInstallation, deployment *appsv1.Deployment, name string) *batchv1.Job {
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      updateJobName,
-			Namespace: mi.GetNamespace(),
+			Name:      name,
+			Namespace: mm.GetNamespace(),
 		},
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
@@ -218,6 +323,14 @@ func (r *ClusterInstallationReconciler) launchUpdateJob(
 				Spec: *deployment.Spec.Template.Spec.DeepCopy(),
 			},
 		},
+	}
+
+	// Remove init container that waits for db setup job.
+	containerToRemove, found := findContainer(mattermostApp.WaitForDBSetupContainerName, job.Spec.Template.Spec.InitContainers)
+	if found {
+		job.Spec.Template.Spec.InitContainers = append(
+			job.Spec.Template.Spec.InitContainers[:containerToRemove],
+			job.Spec.Template.Spec.InitContainers[containerToRemove+1:]...)
 	}
 
 	// We dont need to validate the readiness/liveness for this short lived job.
@@ -232,12 +345,7 @@ func (r *ClusterInstallationReconciler) launchUpdateJob(
 		job.Spec.Template.Spec.Containers[i].Command = []string{"mattermost", "version"}
 	}
 
-	err := r.Client.Create(context.TODO(), job)
-	if err != nil && !k8sErrors.IsAlreadyExists(err) {
-		return err
-	}
-
-	return nil
+	return job
 }
 
 // isMainContainerImageSame checks whether main containers of specified deployments are the same or not.
@@ -383,4 +491,13 @@ func (r *ClusterInstallationReconciler) fetchRunningUpdateJob(mi *mattermostv1al
 		job,
 	)
 	return job, err
+}
+
+func findContainer(name string, containers []corev1.Container) (int, bool) {
+	for i, cont := range containers {
+		if cont.Name == name {
+			return i, true
+		}
+	}
+	return -1, false
 }

--- a/docs/mattermost-operator/mattermost-operator.yaml
+++ b/docs/mattermost-operator/mattermost-operator.yaml
@@ -1509,6 +1509,7 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
+  - roles
   verbs:
   - get
   - create

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -239,17 +239,6 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 
 	envVarDB = append(envVarDB, masterDBEnvVar)
 
-	// Add init container to wait for DB setup job to complete
-	initContainers = append(initContainers, corev1.Container{
-		Name:            WaitForDBSetupContainerName,
-		Image:           "bitnami/kubectl:1.17",
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command: []string{
-			"sh", "-c",
-			fmt.Sprintf("kubectl wait --for=condition=complete --timeout 5m job/%s", SetupJobName),
-		},
-	})
-
 	minioName := fmt.Sprintf("%s-minio", mattermost.Name)
 
 	// Check if custom secret was passed
@@ -341,6 +330,17 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 			Value: "false",
 		},
 	}
+
+	// Add init container to wait for DB setup job to complete
+	initContainers = append(initContainers, corev1.Container{
+		Name:            WaitForDBSetupContainerName,
+		Image:           "bitnami/kubectl:1.17",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command: []string{
+			"sh", "-c",
+			fmt.Sprintf("kubectl wait --for=condition=complete --timeout 5m job/%s", SetupJobName),
+		},
+	})
 
 	// ES section vars
 	envVarES := []corev1.EnvVar{}

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -570,7 +570,7 @@ func GenerateServiceAccount(mattermost *mattermostv1alpha1.ClusterInstallation, 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            saName,
 			Namespace:       mattermost.Namespace,
-			OwnerReferences: clusterInstallationOwerReference(mattermost),
+			OwnerReferences: ClusterInstallationOwnerReference(mattermost),
 		},
 	}
 }
@@ -581,7 +581,7 @@ func GenerateRole(mattermost *mattermostv1alpha1.ClusterInstallation, roleName s
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            roleName,
 			Namespace:       mattermost.Namespace,
-			OwnerReferences: clusterInstallationOwerReference(mattermost),
+			OwnerReferences: ClusterInstallationOwnerReference(mattermost),
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -600,7 +600,7 @@ func GenerateRoleBinding(mattermost *mattermostv1alpha1.ClusterInstallation, rol
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            roleName,
 			Namespace:       mattermost.Namespace,
-			OwnerReferences: clusterInstallationOwerReference(mattermost),
+			OwnerReferences: ClusterInstallationOwnerReference(mattermost),
 		},
 		Subjects: []rbacv1.Subject{
 			{Kind: "ServiceAccount", Name: saName, Namespace: mattermost.Namespace},
@@ -609,7 +609,7 @@ func GenerateRoleBinding(mattermost *mattermostv1alpha1.ClusterInstallation, rol
 	}
 }
 
-func clusterInstallationOwerReference(mattermost *mattermostv1alpha1.ClusterInstallation) []metav1.OwnerReference {
+func ClusterInstallationOwnerReference(mattermost *mattermostv1alpha1.ClusterInstallation) []metav1.OwnerReference {
 	return []metav1.OwnerReference{
 		*metav1.NewControllerRef(mattermost, schema.GroupVersionKind{
 			Group:   mattermostv1alpha1.GroupVersion.Group,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
To avoid a race condition when two Mattermost pods try to initialize the DB at the same time it should be done before pods startup.

Changes in PR:
- Add a Job that initializes the Mattermost database
- Add init container to Mattermost pod to wait for setup Job to finish
- Adjust RBAC of Mattermost and Operator

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add Job that initializes Mattermost database
```
