### PR TITLE
Add cloud specific sizes for 10 and 100 users

### DIFF
--- a/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
@@ -57,6 +57,80 @@ var size100 = ClusterInstallationSize{
 	},
 }
 
+// CloudSize10String represents estimated Mattermost Cloud installation sizing for 10 users.
+const CloudSize10String = "cloud10users"
+
+var cloudSize10 = ClusterInstallationSize{
+	App: ComponentSize{
+		Replicas: 2,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("200Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+		},
+	},
+	Minio: ComponentSize{
+		Replicas: 4,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+	},
+	Database: ComponentSize{
+		Replicas: 2,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	},
+}
+
+// CloudSize100String represents estimated Mattermost Cloud installation sizing for 100 users.
+const CloudSize100String = "cloud100users"
+
+var cloudSize100 = ClusterInstallationSize{
+	App: ComponentSize{
+		Replicas: 2,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+		},
+	},
+	Minio: ComponentSize{
+		Replicas: 4,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+		},
+	},
+	Database: ComponentSize{
+		Replicas: 2,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+	},
+}
+
 // Size1000String represents estimated installation sizing for 1000 users.
 const Size1000String = "1000users"
 
@@ -282,6 +356,8 @@ var sizeMiniHA = ClusterInstallationSize{
 }
 
 var validSizes = map[string]ClusterInstallationSize{
+	CloudSize10String:       cloudSize10,
+	CloudSize100String:      cloudSize100,
 	Size100String:           size100,
 	Size1000String:          size1000,
 	Size5000String:          size5000,


### PR DESCRIPTION
#### Summary
Looking at our production environment all our installations with 10 or less users average about 3m vCPU and 75Mi per pod so these new requests are still higher than they need to be. Even larger 100 user installations do not use significantly more CPU or memory. We can use these as the starting point for our cloud-specific sizes.

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add cloud specific sizes for 10 and 100 users
```
