### PR TITLE
MM-30448 - Support Init containers waiting for Postgres readiness

### DIFF
--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -27,11 +27,21 @@ func TestDatabaseInfo(t *testing.T) {
 			isValid:             false,
 		},
 		{
-			name: "external",
+			name: "external mysql",
 			secret: &corev1.Secret{Data: map[string][]byte{
 				"DB_CONNECTION_STRING": []byte("mysql://endpoint"),
 			}},
-			expectedInfo:        &Info{External: true},
+			expectedInfo:        &Info{External: true, ExternalDBType: MySQLDatabase},
+			isExternal:          true,
+			hasDatabaseCheckURL: false,
+			isValid:             true,
+		},
+		{
+			name: "external postgres",
+			secret: &corev1.Secret{Data: map[string][]byte{
+				"DB_CONNECTION_STRING": []byte("postgres://endpoint"),
+			}},
+			expectedInfo:        &Info{External: true, ExternalDBType: PostgreSQLDatabase},
 			isExternal:          true,
 			hasDatabaseCheckURL: false,
 			isValid:             true,
@@ -42,7 +52,7 @@ func TestDatabaseInfo(t *testing.T) {
 				"DB_CONNECTION_STRING":    []byte("mysql://endpoint"),
 				"DB_CONNECTION_CHECK_URL": []byte("http://endpoint"),
 			}},
-			expectedInfo:        &Info{External: true, DatabaseCheckURL: true},
+			expectedInfo:        &Info{External: true, DatabaseCheckURL: true, ExternalDBType: MySQLDatabase},
 			isExternal:          true,
 			hasDatabaseCheckURL: true,
 			isValid:             true,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add the possibility to use init containers that wait for database readiness when using Postgres. Currently, it is only possible with MySQL, which makes pods crash when using Postgres and the DB is not ready.
- Init container type is decided based on the connection string.
- If `DB_CONNECTION_CHECK_URL` is not present in the Secret, the Init container is not added to the pods.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-30448

See also: https://github.com/mattermost/mattermost-cloud/pull/364

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Support Init containers waiting for Postgres readiness
```
