### PR TITLE
MM-30712 - Restart update job if image changed

### DIFF
--- a/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -152,8 +152,7 @@ func getContainerByName(containers []corev1.Container, containerName string) *co
 	return nil
 }
 
-// GetMattermostAppContainerFromDeployment gets container from Deployment which runs Mattermost application
-// from a deployment.
+// GetMattermostAppContainerFromDeployment gets container which runs Mattermost application from a deployment.
 func (mattermost *ClusterInstallation) GetMattermostAppContainerFromDeployment(deployment *appsv1.Deployment) *corev1.Container {
 	// Check new-style - fixed name
 	container := mattermost.getDeploymentContainerByName(deployment, MattermostAppContainerName)

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -318,7 +318,7 @@ func (r *ClusterInstallationReconciler) restartUpdateJob(
 ) error {
 	err := r.Client.Delete(context.TODO(), currentJob, k8sClient.PropagationPolicy(metav1.DeletePropagationBackground))
 	if err != nil && !k8sErrors.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to delete outdated update job")
+		return errors.Wrap(err, "failed to delete outdated update job")
 	}
 
 	job := prepareJobTemplate(mi, deployment, updateJobName)

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -310,6 +310,27 @@ func (r *ClusterInstallationReconciler) launchUpdateJob(
 	return nil
 }
 
+// restartUpdateJob removes existing update job if it exists and creates new one.
+func (r *ClusterInstallationReconciler) restartUpdateJob(
+	mi *mattermostv1alpha1.ClusterInstallation,
+	currentJob *batchv1.Job,
+	deployment *appsv1.Deployment,
+) error {
+	err := r.Client.Delete(context.TODO(), currentJob, k8sClient.PropagationPolicy(metav1.DeletePropagationBackground))
+	if err != nil && !k8sErrors.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to delete outdated update job")
+	}
+
+	job := prepareJobTemplate(mi, deployment, updateJobName)
+
+	err = r.Client.Create(context.TODO(), job)
+	if err != nil && !k8sErrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	return nil
+}
+
 func prepareJobTemplate(mm *mattermostv1alpha1.ClusterInstallation, deployment *appsv1.Deployment, name string) *batchv1.Job {
 	backoffLimit := int32(10)
 
@@ -352,8 +373,8 @@ func prepareJobTemplate(mm *mattermostv1alpha1.ClusterInstallation, deployment *
 	return job
 }
 
-// isMainContainerImageSame checks whether main containers of specified deployments are the same or not.
-func (r *ClusterInstallationReconciler) isMainContainerImageSame(
+// isMainDeploymentContainerImageSame checks whether main containers of specified deployments are the same or not.
+func (r *ClusterInstallationReconciler) isMainDeploymentContainerImageSame(
 	mattermost *mattermostv1alpha1.ClusterInstallation,
 	a *appsv1.Deployment,
 	b *appsv1.Deployment,
@@ -363,14 +384,32 @@ func (r *ClusterInstallationReconciler) isMainContainerImageSame(
 		return false, errors.New("failed to find main container, no deployment provided")
 	}
 
+	isSameImage, err := r.isMainContainerImageSame(
+		mattermost,
+		a.Spec.Template.Spec.Containers,
+		b.Spec.Template.Spec.Containers,
+	)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to compare deployment images, deployments: %s/%s, %s/%s", a.Namespace, a.Name, b.Namespace, b.Name)
+	}
+
+	return isSameImage, nil
+}
+
+// isMainContainerImageSame checks whether main containers of specified Pod spec are the same or not.
+func (r *ClusterInstallationReconciler) isMainContainerImageSame(
+	mattermost *mattermostv1alpha1.ClusterInstallation,
+	a []corev1.Container,
+	b []corev1.Container,
+) (bool, error) {
 	// Fetch containers to compare
 	containerA := mattermost.GetMattermostAppContainer(a)
 	if containerA == nil {
-		return false, errors.Errorf("failed to find main container, incorrect deployment %s/%s", a.Namespace, a.Name)
+		return false, errors.Errorf("failed to find main container in a list while comparing images")
 	}
 	containerB := mattermost.GetMattermostAppContainer(b)
 	if containerB == nil {
-		return false, errors.Errorf("failed to find main container, incorrect deployment %s/%s", b.Namespace, b.Name)
+		return false, errors.Errorf("failed to find main container in a list while comparing images")
 	}
 
 	// Both containers fetched, can compare images
@@ -386,7 +425,7 @@ func (r *ClusterInstallationReconciler) updateMattermostDeployment(
 	imageName string,
 	reqLogger logr.Logger,
 ) error {
-	sameImage, err := r.isMainContainerImageSame(mattermost, current, desired)
+	sameImage, err := r.isMainDeploymentContainerImageSame(mattermost, current, desired)
 	if err != nil {
 		return err
 	}
@@ -424,7 +463,7 @@ func (r *ClusterInstallationReconciler) checkUpdateJob(
 	desired *appsv1.Deployment,
 	reqLogger logr.Logger,
 ) (*batchv1.Job, error) {
-	reqLogger.Info(fmt.Sprintf("Running Mattermost update image job check for image %s", mattermost.GetMattermostAppContainer(desired).Image))
+	reqLogger.Info(fmt.Sprintf("Running Mattermost update image job check for image %s", mattermost.GetMattermostAppContainerFromDeployment(desired).Image))
 	job, err := r.fetchRunningUpdateJob(mattermost)
 	if err != nil {
 		// Unable to fetch job
@@ -441,6 +480,25 @@ func (r *ClusterInstallationReconciler) checkUpdateJob(
 	}
 
 	// Job is either running or completed
+
+	// If desired deployment image does not match the one used by update job, restart it.
+	isSameImage, err := r.isMainContainerImageSame(
+		mattermost,
+		desired.Spec.Template.Spec.Containers,
+		job.Spec.Template.Spec.Containers,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compare image of update job and desired deployment")
+	}
+	if !isSameImage {
+		reqLogger.Info("Mattermost image changed, restarting update job")
+		err := r.restartUpdateJob(mattermost, job, desired)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to restart update job")
+		}
+
+		return nil, errors.New("Restarted update image job")
+	}
 
 	if job.Status.CompletionTime == nil {
 		return nil, errors.New("update image job still running")

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -324,7 +324,7 @@ func (r *ClusterInstallationReconciler) restartUpdateJob(
 	job := prepareJobTemplate(mi, deployment, updateJobName)
 
 	err = r.Client.Create(context.TODO(), job)
-	if err != nil && !k8sErrors.IsAlreadyExists(err) {
+	if err != nil {
 		return err
 	}
 
@@ -396,7 +396,7 @@ func (r *ClusterInstallationReconciler) isMainDeploymentContainerImageSame(
 	return isSameImage, nil
 }
 
-// isMainContainerImageSame checks whether main containers of specified Pod spec are the same or not.
+// isMainContainerImageSame checks whether main containers of specified slices are the same or not.
 func (r *ClusterInstallationReconciler) isMainContainerImageSame(
 	mattermost *mattermostv1alpha1.ClusterInstallation,
 	a []corev1.Container,

--- a/controllers/mattermost/clusterinstallation/mattermost_test.go
+++ b/controllers/mattermost/clusterinstallation/mattermost_test.go
@@ -235,7 +235,7 @@ func TestCheckMattermost(t *testing.T) {
 				CompletionTime: &now,
 			},
 		}
-		err := r.Client.Create(context.TODO(), job)
+		err = r.Client.Create(context.TODO(), job)
 		require.NoError(t, err)
 
 		err = r.checkMattermostDeployment(ci, ci.Name, ci.Spec.IngressName, ci.Name, ci.GetImageName(), logger)
@@ -276,7 +276,7 @@ func TestCheckMattermost(t *testing.T) {
 	t.Run("final check", func(t *testing.T) {
 		t.Run("database secret", func(t *testing.T) {
 			dbSecret := &corev1.Secret{}
-			err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mattermostmysql.DefaultDatabaseSecretName(ciName), Namespace: ciNamespace}, dbSecret)
+			err = r.Client.Get(context.TODO(), types.NamespacedName{Name: mattermostmysql.DefaultDatabaseSecretName(ciName), Namespace: ciNamespace}, dbSecret)
 			require.NoError(t, err)
 
 			dbInfo := database.GenerateDatabaseInfoFromSecret(dbSecret)

--- a/controllers/mattermost/clusterinstallation/mattermost_test.go
+++ b/controllers/mattermost/clusterinstallation/mattermost_test.go
@@ -223,6 +223,13 @@ func TestCheckMattermost(t *testing.T) {
 				Name:      updateName,
 				Namespace: ci.GetNamespace(),
 			},
+			Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: mattermostv1alpha1.MattermostAppContainerName, Image: ci.GetImageName()},
+					},
+				},
+			}},
 			Status: batchv1.JobStatus{
 				Succeeded:      1,
 				CompletionTime: &now,
@@ -275,6 +282,61 @@ func TestCheckMattermost(t *testing.T) {
 			dbInfo := database.GenerateDatabaseInfoFromSecret(dbSecret)
 			require.NoError(t, dbInfo.IsValid())
 		})
+	})
+
+	t.Run("restart update job", func(t *testing.T) {
+		// create deployment
+		err = r.checkMattermostDeployment(ci, ci.Name, ci.Spec.IngressName, ci.Name, ci.GetImageName(), logger)
+		assert.NoError(t, err)
+
+		// create update job with invalid image
+		updateName := "mattermost-update-check"
+		now := metav1.Now()
+		invalidUpdateJob := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      updateName,
+				Namespace: ci.GetNamespace(),
+			},
+			Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: mattermostv1alpha1.MattermostAppContainerName, Image: "invalid-image"},
+					},
+				},
+			}},
+			Status: batchv1.JobStatus{
+				Succeeded:      1,
+				CompletionTime: &now,
+			},
+		}
+		err := r.Client.Create(context.TODO(), invalidUpdateJob)
+		require.NoError(t, err)
+
+		// should delete update job and create new and return error
+		newImage := "mattermost/new-image"
+		err = r.checkMattermostDeployment(ci, ci.Name, ci.Spec.IngressName, ci.Name, newImage, logger)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Restarted update image job")
+
+		// get new job, assert new image and change status to completed
+		restartedUpdateJob := batchv1.Job{}
+		updateJobKey := types.NamespacedName{Namespace: ci.GetNamespace(), Name: updateJobName}
+		err = r.Client.Get(context.TODO(), updateJobKey, &restartedUpdateJob)
+		require.NoError(t, err)
+		assert.Equal(t, newImage, restartedUpdateJob.Spec.Template.Spec.Containers[0].Image)
+		assert.Equal(t, int32(0), restartedUpdateJob.Status.Succeeded)
+
+		restartedUpdateJob.Status = batchv1.JobStatus{
+			Succeeded:      1,
+			CompletionTime: &now,
+		}
+
+		err = r.Client.Update(context.TODO(), &restartedUpdateJob)
+		require.NoError(t, err)
+
+		// should succeed now
+		err = r.checkMattermostDeployment(ci, ci.Name, ci.Spec.IngressName, ci.Name, newImage, logger)
+		assert.NoError(t, err)
 	})
 }
 
@@ -387,6 +449,13 @@ func TestCheckMattermostExternalDB(t *testing.T) {
 				Name:      updateName,
 				Namespace: ci.GetNamespace(),
 			},
+			Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: mattermostv1alpha1.MattermostAppContainerName, Image: ci.GetImageName()},
+					},
+				},
+			}},
 			Status: batchv1.JobStatus{
 				Succeeded:      1,
 				CompletionTime: &now,

--- a/pkg/mattermost/mattermost_test.go
+++ b/pkg/mattermost/mattermost_test.go
@@ -283,7 +283,7 @@ func TestGenerateDeployment(t *testing.T) {
 			assert.Equal(t, tt.want.Spec.Template.Spec.NodeSelector, deployment.Spec.Template.Spec.NodeSelector)
 			assert.Equal(t, tt.want.Spec.Template.Spec.Affinity, deployment.Spec.Template.Spec.Affinity)
 
-			mattermostAppContainer := mattermost.GetMattermostAppContainer(deployment)
+			mattermostAppContainer := mattermost.GetMattermostAppContainerFromDeployment(deployment)
 			require.NotNil(t, mattermostAppContainer)
 
 			// Basic env var check to ensure the key exists.


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When updating Cluster Installation with an invalid image and the update job fails it needs to be cleaned up manually.
To remove a need for manual deletion, the Operator will now handle the scenario when the desired image changed.
Changes in the PR:
- Check if the job image matches the desired one
- Restart job if image changed

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-30712

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Restart update job if image name changed
```
