### PR TITLE
Disable DB setup job until we can do it while respecting custom configuration

### DIFF
--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -206,10 +206,12 @@ func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *ma
 
 	desired := mattermostApp.GenerateDeployment(mattermost, dbInfo, resourceName, ingressName, saName, imageName, minioURL)
 
-	err = r.checkMattermostDBSetupJob(mattermost, desired, reqLogger)
-	if err != nil {
-		return errors.Wrap(err, "failed to check mattermost DB setup job")
-	}
+	// TODO: DB setup job is temporarily disabled as `mattermost version` command
+	// does not account for the custom configuration
+	//err = r.checkMattermostDBSetupJob(mattermost, desired, reqLogger)
+	//if err != nil {
+	//	return errors.Wrap(err, "failed to check mattermost DB setup job")
+	//}
 
 	err = r.createDeploymentIfNotExists(mattermost, desired, reqLogger)
 	if err != nil {

--- a/controllers/mattermost/clusterinstallation/mattermost_test.go
+++ b/controllers/mattermost/clusterinstallation/mattermost_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mattermost/mattermost-operator/pkg/mattermost"
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -241,13 +240,14 @@ func TestCheckMattermost(t *testing.T) {
 		err = r.checkMattermostDeployment(ci, ci.Name, ci.Spec.IngressName, ci.Name, ci.GetImageName(), logger)
 		assert.NoError(t, err)
 
-		dbSetupJob := &batchv1.Job{}
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: mattermost.SetupJobName, Namespace: ciNamespace}, dbSetupJob)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(dbSetupJob.Spec.Template.Spec.Containers))
-		require.Equal(t, ci.GetImageName(), dbSetupJob.Spec.Template.Spec.Containers[0].Image)
-		_, containerFound := findContainer(mattermost.WaitForDBSetupContainerName, dbSetupJob.Spec.Template.Spec.InitContainers)
-		require.False(t, containerFound)
+		// TODO: uncomment when enabling back the db setup job
+		//dbSetupJob := &batchv1.Job{}
+		//err = r.Client.Get(context.TODO(), types.NamespacedName{Name: mattermost.SetupJobName, Namespace: ciNamespace}, dbSetupJob)
+		//require.NoError(t, err)
+		//require.Equal(t, 1, len(dbSetupJob.Spec.Template.Spec.Containers))
+		//require.Equal(t, ci.GetImageName(), dbSetupJob.Spec.Template.Spec.Containers[0].Image)
+		//_, containerFound := findContainer(mattermost.WaitForDBSetupContainerName, dbSetupJob.Spec.Template.Spec.InitContainers)
+		//require.False(t, containerFound)
 
 		found := &appsv1.Deployment{}
 		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: ciName, Namespace: ciNamespace}, found)

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -313,16 +313,10 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 		},
 	}
 
+	// TODO: DB setup job is temporarily disabled as `mattermost version` command
+	// does not account for the custom configuration
 	// Add init container to wait for DB setup job to complete
-	initContainers = append(initContainers, corev1.Container{
-		Name:            WaitForDBSetupContainerName,
-		Image:           "bitnami/kubectl:1.17",
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command: []string{
-			"sh", "-c",
-			fmt.Sprintf("kubectl wait --for=condition=complete --timeout 5m job/%s", SetupJobName),
-		},
-	})
+	//initContainers = append(initContainers, waitForSetupJobContainer())
 
 	// ES section vars
 	envVarES := []corev1.EnvVar{}
@@ -620,6 +614,18 @@ func newService(mattermost *mattermostv1alpha1.ClusterInstallation, serviceName,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: mattermostv1alpha1.ClusterInstallationSelectorLabels(selectorName),
+		},
+	}
+}
+
+func waitForSetupJobContainer() corev1.Container {
+	return corev1.Container{
+		Name:            WaitForDBSetupContainerName,
+		Image:           "bitnami/kubectl:1.17",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command: []string{
+			"sh", "-c",
+			fmt.Sprintf("kubectl wait --for=condition=complete --timeout 5m job/%s", SetupJobName),
 		},
 	}
 }

--- a/pkg/mattermost/mattermost_test.go
+++ b/pkg/mattermost/mattermost_test.go
@@ -307,7 +307,7 @@ func TestGenerateDeployment(t *testing.T) {
 			}
 
 			// Init container check.
-			expectedInitContainers := 1
+			expectedInitContainers := 0 // Due to disabling DB setup job we start with 0 init containers
 			if !databaseInfo.IsExternal() {
 				expectedInitContainers++
 			} else if databaseInfo.IsExternal() && databaseInfo.HasDatabaseCheckURL() {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Due to `mattermost version` command not taking into account custom configuration, we need to disable DB setup job, until the command is implemented or another solution is proposed.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-31036

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Disable DB setup job
```
