### PR TITLE
[MM-29303] add release script

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ make install
 ```
 
 ### 3.2 Building mattermost-operator
-To start contributing to mattermost-operator you need to clone this repo to your local workspace. 
+To start contributing to mattermost-operator you need to clone this repo to your local workspace.
 
 ```bash
 $ mkdir -p $GOPATH/src/github.com/mattermost
@@ -105,8 +105,27 @@ $ kind load docker-image mattermost/mattermost-operator:test
 
 ### 4.1 Installation Size
 
-The `spec.Size` field was modified to be treated as a write-only field. 
-After adjusting values according to the size, the value of `spec.Size` is erased. 
+The `spec.Size` field was modified to be treated as a write-only field.
+After adjusting values according to the size, the value of `spec.Size` is erased.
 
-Replicas and resource requests/limits values can be overridden manually but setting new Size will override those values again regardless if set by the previous Size or adjusted manually. 
+Replicas and resource requests/limits values can be overridden manually but setting new Size will override those values again regardless if set by the previous Size or adjusted manually.
 
+## 5 Release
+
+To release a new version of Mattermost Operator you need to:
+
+- Have the repository up-to-date
+- Have the remote upstream configured
+- Have a clean repo, not pending commits and changes
+
+We have a script that changes some files, commit those changes and then tag the main branch.
+
+To run you can issue the following command:
+
+```console
+./scripts --tag=<DESIRED_TAG>
+````
+
+where:
+
+- <DESIRED_TAG> can be 1.10.1 for example

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+export OPERATOR_TAG=""
+
+check_github() {
+  local valid_upstream
+  local valid_repo
+
+  valid_repo="mattermost/mattermost-operator"
+
+  valid_upstream=$(git config --get remote.upstream.url)
+
+  echo "$valid_upstream"
+  if [[ "$valid_upstream" =~ .*"$valid_repo".* ]]; then
+    echo "It is using upstream repo. valid!"
+  else
+    echo "Please set the upstream"
+    exit 1
+  fi
+}
+
+check_status() {
+  if [[ $(git diff --stat) != '' ]]; then
+  echo 'Git repo is dirty, please use a clean repo'
+  exit 1
+  fi
+}
+
+bump_version() {
+  echo "Bumping the version file"
+  sed -i.bak -e "s/var version = .*/var version = \"$OPERATOR_TAG\"/g" -- version/version.go && rm -- version/version.go.bak
+
+  echo "Bumping the image template"
+  sed -i.bak -e "s/image: .*/image: mattermost\/mattermost-operator:v$OPERATOR_TAG/g" docs/mattermost-operator/mattermost-operator.yaml && rm -- docs/mattermost-operator/mattermost-operator.yaml.bak
+
+  echo "Commiting and pushing to upstream"
+  git commit -am "Bump operator to version $OPERATOR_TAG"
+  git push upstream master
+}
+
+tag_version() {
+  echo "pushing tag $OPERATOR_TAG"
+  git tag v$OPERATOR_TAG
+  git push upstream v$OPERATOR_TAG
+}
+
+# setup kind, build kubernetes, create a cluster, run the e2es
+main() {
+  while test $# -gt 0; do
+    case "$1" in
+      -h|--help)
+        echo "release mattermost operator script"
+        echo " "
+        echo "release.sh [options]"
+        echo " "
+        echo "options:"
+        echo "-h, --help                show brief help"
+        echo "-t, --tag=TAG             new tag to release the operator"
+        exit 0
+        ;;
+      -t)
+        shift
+        if test $# -gt 0; then
+        OPERATOR_TAG=$1
+        else
+          echo "no tag specified"
+          exit 1
+        fi
+        shift
+        ;;
+      --tag*)
+        OPERATOR_TAG=$(sed -e 's/^[^=]*=//g' <<< "$1" )
+        shift
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  if [ "$OPERATOR_TAG" == "" ]; then
+    echo 'A TAG is required, use -t <TAG> or --tag=<TAG>' >&2
+    exit 1
+  fi
+
+  OPERATOR_TAG=$( echo "$OPERATOR_TAG" | tr -d v)
+
+  echo "Will release Mattermost Operator TAG ${OPERATOR_TAG}"
+
+  check_github
+
+  check_status
+
+  bump_version
+
+  tag_version
+
+  echo "Done. Watch CircleCI job now :)"
+}
+
+main "$@"


### PR DESCRIPTION
#### Summary
Add release script to help in the release cut

now, you need to run `./scripts/release.sh --tag=1.3.4`  and it will:

- bump the version in `version/version.go`
- update the image in `docs/mattermost-operator/mattermost-operator.yaml`
- commit and push to upstream
- tag and push to upstream

#### Ticket Link
Jira:
- https://mattermost.atlassian.net/browse/MM-29303
- https://mattermost.atlassian.net/browse/MM-29601


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
add release script
```
