### PR TITLE
Resource generation for Operator beta spec

### DIFF
--- a/pkg/components/minio/minio.go
+++ b/pkg/components/minio/minio.go
@@ -3,6 +3,8 @@ package minio
 import (
 	"fmt"
 
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 	"github.com/mattermost/mattermost-operator/pkg/components/utils"
 	mattermostApp "github.com/mattermost/mattermost-operator/pkg/mattermost"
@@ -12,7 +14,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Instance returns the Minio component to deploy
@@ -24,50 +25,49 @@ func Instance(mattermost *mattermostv1alpha1.ClusterInstallation) *minioOperator
 		minioName = mattermost.Spec.Minio.Secret
 	}
 
-	return &minioOperator.MinIOInstance{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      minioName,
-			Namespace: mattermost.Namespace,
-			Labels:    mattermostv1alpha1.ClusterInstallationResourceLabels(mattermost.Name),
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(mattermost, schema.GroupVersionKind{
-					Group:   mattermostv1alpha1.GroupVersion.Group,
-					Version: mattermostv1alpha1.GroupVersion.Version,
-					Kind:    "ClusterInstallation",
-				}),
-			},
-		},
-		Spec: minioOperator.MinIOInstanceSpec{
-			Replicas:    mattermost.Spec.Minio.Replicas,
-			Mountpath:   "/export",
-			CredsSecret: &corev1.LocalObjectReference{Name: minioName},
-			VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: minioName,
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					AccessModes: []corev1.PersistentVolumeAccessMode{
-						"ReadWriteOnce",
-					},
-					Resources: corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceStorage: resource.MustParse(mattermost.Spec.Minio.StorageSize),
-						},
-					},
-				},
-			},
-		},
-	}
+	return newMinioInstance(
+		minioName,
+		mattermost.Namespace,
+		mattermostv1alpha1.ClusterInstallationResourceLabels(mattermost.Name),
+		mattermostApp.ClusterInstallationOwnerReference(mattermost),
+		mattermost.Spec.Minio.Replicas,
+		mattermost.Spec.Minio.StorageSize,
+	)
 }
 
 // Secret returns the secret name created to use togehter with Minio deployment
 func Secret(mattermost *mattermostv1alpha1.ClusterInstallation) *corev1.Secret {
 	secretName := DefaultMinioSecretName(mattermost.Name)
-	data := make(map[string][]byte)
-	data["accesskey"] = utils.New16ID()
-	data["secretkey"] = utils.New28ID()
+	data := minioSecretData()
 
 	return mattermostApp.GenerateSecret(
+		mattermost,
+		secretName,
+		mattermostv1alpha1.ClusterInstallationResourceLabels(mattermost.Name),
+		data,
+	)
+}
+
+// Instance returns the Minio component to deploy
+func InstanceV1Beta(mattermost *mattermostv1beta1.Mattermost) *minioOperator.MinIOInstance {
+	minioName := fmt.Sprintf("%s-minio", mattermost.Name)
+
+	return newMinioInstance(
+		minioName,
+		mattermost.Namespace,
+		mattermostv1beta1.MattermostResourceLabels(mattermost.Name),
+		mattermostApp.MattermostOwnerReference(mattermost),
+		*mattermost.Spec.FileStore.OperatorManaged.Replicas,
+		mattermost.Spec.FileStore.OperatorManaged.StorageSize,
+	)
+}
+
+// Secret returns the secret name created to use together with Minio deployment
+func SecretV1Beta(mattermost *mattermostv1beta1.Mattermost) *corev1.Secret {
+	secretName := DefaultMinioSecretName(mattermost.Name)
+	data := minioSecretData()
+
+	return mattermostApp.GenerateSecretV1Beta(
 		mattermost,
 		secretName,
 		mattermostv1alpha1.ClusterInstallationResourceLabels(mattermost.Name),
@@ -79,4 +79,49 @@ func Secret(mattermost *mattermostv1alpha1.ClusterInstallation) *corev1.Secret {
 // the provided installation name.
 func DefaultMinioSecretName(installationName string) string {
 	return fmt.Sprintf("%s-minio", installationName)
+}
+
+func newMinioInstance(
+	name string,
+	namespace string,
+	labels map[string]string,
+	ownerRefs []metav1.OwnerReference,
+	replicas int32,
+	storageSize string,
+) *minioOperator.MinIOInstance {
+	return &minioOperator.MinIOInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			OwnerReferences: ownerRefs,
+		},
+		Spec: minioOperator.MinIOInstanceSpec{
+			Replicas:    replicas,
+			Mountpath:   "/export",
+			CredsSecret: &corev1.LocalObjectReference{Name: name},
+			VolumeClaimTemplate: &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						"ReadWriteOnce",
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse(storageSize),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func minioSecretData() map[string][]byte {
+	data := make(map[string][]byte, 2)
+	data["accesskey"] = utils.New16ID()
+	data["secretkey"] = utils.New28ID()
+	return data
 }

--- a/pkg/components/minio/minio.go
+++ b/pkg/components/minio/minio.go
@@ -35,7 +35,7 @@ func Instance(mattermost *mattermostv1alpha1.ClusterInstallation) *minioOperator
 	)
 }
 
-// Secret returns the secret name created to use togehter with Minio deployment
+// Secret returns the secret name created to use together with Minio deployment
 func Secret(mattermost *mattermostv1alpha1.ClusterInstallation) *corev1.Secret {
 	secretName := DefaultMinioSecretName(mattermost.Name)
 	data := minioSecretData()

--- a/pkg/components/mysql/mysql.go
+++ b/pkg/components/mysql/mysql.go
@@ -3,6 +3,9 @@ package mysql
 import (
 	"fmt"
 
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	mattermostApp "github.com/mattermost/mattermost-operator/pkg/mattermost"
+
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 	"github.com/mattermost/mattermost-operator/pkg/utils"
 	mysqlOperator "github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1"
@@ -61,6 +64,46 @@ func Cluster(mattermost *mattermostv1alpha1.ClusterInstallation) *mysqlOperator.
 
 	if mattermost.Spec.Database.Secret != "" {
 		mysql.Spec.SecretName = mattermost.Spec.Database.Secret
+	}
+
+	return mysql
+}
+
+// Cluster returns the MySQL cluster to deploy
+func ClusterV1Beta(mattermost *mattermostv1beta1.Mattermost) *mysqlOperator.MysqlCluster {
+	mysql := &mysqlOperator.MysqlCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            componentUtils.HashWithPrefix("db", mattermost.Name),
+			Namespace:       mattermost.Namespace,
+			Labels:          mattermostv1beta1.MattermostResourceLabels(mattermost.Name),
+			OwnerReferences: mattermostApp.MattermostOwnerReference(mattermost),
+		},
+		Spec: mysqlOperator.MysqlClusterSpec{
+			MysqlVersion: "5.7",
+			Replicas:     mattermost.Spec.Database.OperatorManaged.Replicas,
+			SecretName:   DefaultDatabaseSecretName(mattermost.Name),
+			VolumeSpec: mysqlOperator.VolumeSpec{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{
+						"ReadWriteOnce",
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse(mattermost.Spec.Database.OperatorManaged.StorageSize),
+						},
+					},
+				},
+			},
+			BackupSchedule:           mattermost.Spec.Database.OperatorManaged.BackupSchedule,
+			BackupURL:                mattermost.Spec.Database.OperatorManaged.BackupURL,
+			BackupSecretName:         mattermost.Spec.Database.OperatorManaged.BackupRestoreSecretName,
+			BackupRemoteDeletePolicy: mysqlOperator.DeletePolicy(mattermost.Spec.Database.OperatorManaged.BackupRemoteDeletePolicy),
+		},
+	}
+
+	if mattermost.Spec.Database.OperatorManaged.InitBucketURL != "" && mattermost.Spec.Database.OperatorManaged.BackupRestoreSecretName != "" {
+		mysql.Spec.InitBucketURL = mattermost.Spec.Database.OperatorManaged.InitBucketURL
+		mysql.Spec.InitBucketSecretName = mattermost.Spec.Database.OperatorManaged.BackupRestoreSecretName
 	}
 
 	return mysql

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -73,7 +73,7 @@ func (db *Info) HasDatabaseCheckURL() bool {
 // the characteristics of the secret.
 func GenerateDatabaseInfoFromSecret(secret *corev1.Secret) *Info {
 	if _, ok := secret.Data["DB_CONNECTION_STRING"]; ok {
-		dbType := getTypeFromConnectionString(string(secret.Data["DB_CONNECTION_STRING"]))
+		dbType := GetTypeFromConnectionString(string(secret.Data["DB_CONNECTION_STRING"]))
 
 		// This is a secret for an external database.
 		databaseInfo := &Info{
@@ -106,7 +106,7 @@ func GenerateDatabaseInfoFromSecret(secret *corev1.Secret) *Info {
 	}
 }
 
-func getTypeFromConnectionString(connectionString string) string {
+func GetTypeFromConnectionString(connectionString string) string {
 	if strings.HasPrefix(connectionString, "mysql") {
 		return MySQLDatabase
 	}

--- a/pkg/mattermost/database_external.go
+++ b/pkg/mattermost/database_external.go
@@ -1,8 +1,7 @@
 package mattermost
 
 import (
-	"fmt"
-
+	"errors"
 	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/mattermost/mattermost-operator/pkg/database"
 	corev1 "k8s.io/api/core/v1"
@@ -17,18 +16,18 @@ type ExternalDBConfig struct {
 
 func NewExternalDBConfig(mattermost *mattermostv1beta1.Mattermost, secret corev1.Secret) (*ExternalDBConfig, error) {
 	if mattermost.Spec.Database.External == nil {
-		return nil, fmt.Errorf("external database config not provided")
+		return nil, errors.New("external database config not provided")
 	}
 	if mattermost.Spec.Database.External.Secret == "" {
-		return nil, fmt.Errorf("external database Secret not provided")
+		return nil, errors.New("external database Secret not provided")
 	}
 
 	connectionStr, ok := secret.Data["DB_CONNECTION_STRING"]
 	if !ok {
-		return nil, fmt.Errorf("external database Secret does not containt DB_CONNECTION_STRING key")
+		return nil, errors.New("external database Secret does not containt DB_CONNECTION_STRING key")
 	}
 	if len(connectionStr) == 0 {
-		return nil, fmt.Errorf("external database connection string is empty")
+		return nil, errors.New("external database connection string is empty")
 	}
 
 	externalDB := &ExternalDBConfig{
@@ -109,7 +108,7 @@ func getDBCheckInitContainer(secretName, dbType string) *corev1.Container {
 				"until pg_isready --dbname=\"$DB_CONNECTION_CHECK_URL\"; do echo waiting for database; sleep 5; done;",
 			},
 		}
-	default:
-		return nil
 	}
+
+	return nil
 }

--- a/pkg/mattermost/database_external.go
+++ b/pkg/mattermost/database_external.go
@@ -49,14 +49,14 @@ func NewExternalDBInfo(mattermost *mattermostv1beta1.Mattermost, secret corev1.S
 func (e *ExternalDBConfig) EnvVars(_ *mattermostv1beta1.Mattermost) []corev1.EnvVar {
 	dbEnvVars := []corev1.EnvVar{
 		{
-			Name: "MM_CONFIG",
+			Name:      "MM_CONFIG",
 			ValueFrom: EnvSourceFromSecret(e.secretName, "DB_CONNECTION_STRING"),
 		},
 	}
 
 	if e.hasReaderEndpoints {
 		dbEnvVars = append(dbEnvVars, corev1.EnvVar{
-			Name: "MM_SQLSETTINGS_DATASOURCEREPLICAS",
+			Name:      "MM_SQLSETTINGS_DATASOURCEREPLICAS",
 			ValueFrom: EnvSourceFromSecret(e.secretName, "MM_SQLSETTINGS_DATASOURCEREPLICAS"),
 		})
 	}
@@ -81,7 +81,7 @@ func (e *ExternalDBConfig) InitContainers(_ *mattermostv1beta1.Mattermost) []cor
 func getDBCheckInitContainer(secretName, dbType string) *corev1.Container {
 	envVars := []corev1.EnvVar{
 		{
-			Name: "DB_CONNECTION_CHECK_URL",
+			Name:      "DB_CONNECTION_CHECK_URL",
 			ValueFrom: EnvSourceFromSecret(secretName, "DB_CONNECTION_CHECK_URL"),
 		},
 	}

--- a/pkg/mattermost/database_external.go
+++ b/pkg/mattermost/database_external.go
@@ -15,7 +15,7 @@ type ExternalDBConfig struct {
 	hasDBCheckURL      bool
 }
 
-func NewExternalDBInfo(mattermost *mattermostv1beta1.Mattermost, secret corev1.Secret) (*ExternalDBConfig, error) {
+func NewExternalDBConfig(mattermost *mattermostv1beta1.Mattermost, secret corev1.Secret) (*ExternalDBConfig, error) {
 	if mattermost.Spec.Database.External == nil {
 		return nil, fmt.Errorf("external database config not provided")
 	}

--- a/pkg/mattermost/database_external.go
+++ b/pkg/mattermost/database_external.go
@@ -1,0 +1,115 @@
+package mattermost
+
+import (
+	"fmt"
+
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/mattermost/mattermost-operator/pkg/database"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ExternalDBConfig struct {
+	secretName         string
+	dbType             string
+	hasReaderEndpoints bool
+	hasDBCheckURL      bool
+}
+
+func NewExternalDBInfo(mattermost *mattermostv1beta1.Mattermost, secret corev1.Secret) (*ExternalDBConfig, error) {
+	if mattermost.Spec.Database.External == nil {
+		return nil, fmt.Errorf("external database config not provided")
+	}
+	if mattermost.Spec.Database.External.Secret == "" {
+		return nil, fmt.Errorf("external database Secret not provided")
+	}
+
+	connectionStr, ok := secret.Data["DB_CONNECTION_STRING"]
+	if !ok {
+		return nil, fmt.Errorf("external database Secret does not containt DB_CONNECTION_STRING key")
+	}
+	if len(connectionStr) == 0 {
+		return nil, fmt.Errorf("external database connection string is empty")
+	}
+
+	externalDB := &ExternalDBConfig{
+		secretName: mattermost.Spec.Database.External.Secret,
+		dbType:     database.GetTypeFromConnectionString(string(connectionStr)),
+	}
+
+	if _, ok := secret.Data["MM_SQLSETTINGS_DATASOURCEREPLICAS"]; ok {
+		externalDB.hasReaderEndpoints = true
+	}
+	if _, ok := secret.Data["DB_CONNECTION_CHECK_URL"]; ok {
+		externalDB.hasDBCheckURL = true
+	}
+
+	return externalDB, nil
+}
+
+func (e *ExternalDBConfig) EnvVars(_ *mattermostv1beta1.Mattermost) []corev1.EnvVar {
+	dbEnvVars := []corev1.EnvVar{
+		{
+			Name: "MM_CONFIG",
+			ValueFrom: EnvSourceFromSecret(e.secretName, "DB_CONNECTION_STRING"),
+		},
+	}
+
+	if e.hasReaderEndpoints {
+		dbEnvVars = append(dbEnvVars, corev1.EnvVar{
+			Name: "MM_SQLSETTINGS_DATASOURCEREPLICAS",
+			ValueFrom: EnvSourceFromSecret(e.secretName, "MM_SQLSETTINGS_DATASOURCEREPLICAS"),
+		})
+	}
+
+	return dbEnvVars
+}
+
+func (e *ExternalDBConfig) InitContainers(_ *mattermostv1beta1.Mattermost) []corev1.Container {
+	var initContainers []corev1.Container
+	if e.hasDBCheckURL {
+		container := getDBCheckInitContainer(e.secretName, e.dbType)
+		if container != nil {
+			initContainers = append(initContainers, *container)
+		}
+	}
+
+	return initContainers
+}
+
+// getDBCheckInitContainer prepares init container that checks database readiness based on db type.
+// Returns nil if database type is unknown.
+func getDBCheckInitContainer(secretName, dbType string) *corev1.Container {
+	envVars := []corev1.EnvVar{
+		{
+			Name: "DB_CONNECTION_CHECK_URL",
+			ValueFrom: EnvSourceFromSecret(secretName, "DB_CONNECTION_CHECK_URL"),
+		},
+	}
+
+	switch dbType {
+	case database.MySQLDatabase:
+		return &corev1.Container{
+			Name:            "init-check-database",
+			Image:           "appropriate/curl:latest",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Env:             envVars,
+			Command: []string{
+				"sh", "-c",
+				"until curl --max-time 5 $DB_CONNECTION_CHECK_URL; do echo waiting for database; sleep 5; done;",
+			},
+		}
+	case database.PostgreSQLDatabase:
+		return &corev1.Container{
+			Name:            "init-check-database",
+			Image:           "postgres:13",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Env:             envVars,
+			Command: []string{
+				"sh", "-c",
+				"until pg_isready --dbname=\"$DB_CONNECTION_CHECK_URL\"; do echo waiting for database; sleep 5; done;",
+			},
+		}
+	default:
+		return nil
+	}
+}

--- a/pkg/mattermost/database_external_test.go
+++ b/pkg/mattermost/database_external_test.go
@@ -1,0 +1,75 @@
+package mattermost
+
+import (
+	"testing"
+
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewExternalDBInfo(t *testing.T) {
+	mattermost := &mattermostv1beta1.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{Name: "mm-test"},
+		Spec: mattermostv1beta1.MattermostSpec{
+			Database: mattermostv1beta1.Database{
+				External: &mattermostv1beta1.ExternalDatabase{Secret: "secret"},
+			},
+		},
+	}
+
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+		Data: map[string][]byte{
+			"DB_CONNECTION_STRING": []byte("postgres://my-postgres"),
+		},
+	}
+
+	t.Run("connection string only", func(t *testing.T) {
+		config, err := NewExternalDBInfo(mattermost, secret)
+		require.NoError(t, err)
+		assert.Equal(t, "secret", config.secretName)
+		assert.Equal(t, "postgres", config.dbType)
+		assert.False(t, config.hasDBCheckURL)
+		assert.False(t, config.hasReaderEndpoints)
+
+		envs := config.EnvVars(mattermost)
+		assert.Equal(t, 1, len(envs))
+
+		initContainers := config.InitContainers(mattermost)
+		assert.Equal(t, 0, len(initContainers))
+	})
+
+	secret.Data["MM_SQLSETTINGS_DATASOURCEREPLICAS"] = []byte("postgres://my-postgres")
+	secret.Data["DB_CONNECTION_CHECK_URL"] = []byte("postgres://my-postgres")
+
+	t.Run("with db check url and reader and endpoints", func(t *testing.T) {
+		config, err := NewExternalDBInfo(mattermost, secret)
+		require.NoError(t, err)
+		assert.Equal(t, "secret", config.secretName)
+		assert.Equal(t, "postgres", config.dbType)
+		assert.True(t, config.hasDBCheckURL)
+		assert.True(t, config.hasReaderEndpoints)
+
+		envs := config.EnvVars(mattermost)
+		assert.Equal(t, 2, len(envs))
+
+		initContainers := config.InitContainers(mattermost)
+		assert.Equal(t, 1, len(initContainers))
+		assert.Equal(t, "postgres:13", initContainers[0].Image)
+	})
+
+	secret.Data["DB_CONNECTION_STRING"] = []byte{}
+	t.Run("fail if connection string is empty", func(t *testing.T) {
+		_, err := NewExternalDBInfo(mattermost, secret)
+		require.Error(t, err)
+	})
+
+	delete(secret.Data, "DB_CONNECTION_STRING")
+	t.Run("fail if connection string not present", func(t *testing.T) {
+		_, err := NewExternalDBInfo(mattermost, secret)
+		require.Error(t, err)
+	})
+}

--- a/pkg/mattermost/database_external_test.go
+++ b/pkg/mattermost/database_external_test.go
@@ -28,7 +28,7 @@ func TestNewExternalDBInfo(t *testing.T) {
 	}
 
 	t.Run("connection string only", func(t *testing.T) {
-		config, err := NewExternalDBInfo(mattermost, secret)
+		config, err := NewExternalDBConfig(mattermost, secret)
 		require.NoError(t, err)
 		assert.Equal(t, "secret", config.secretName)
 		assert.Equal(t, "postgres", config.dbType)
@@ -46,7 +46,7 @@ func TestNewExternalDBInfo(t *testing.T) {
 	secret.Data["DB_CONNECTION_CHECK_URL"] = []byte("postgres://my-postgres")
 
 	t.Run("with db check url and reader and endpoints", func(t *testing.T) {
-		config, err := NewExternalDBInfo(mattermost, secret)
+		config, err := NewExternalDBConfig(mattermost, secret)
 		require.NoError(t, err)
 		assert.Equal(t, "secret", config.secretName)
 		assert.Equal(t, "postgres", config.dbType)
@@ -63,13 +63,13 @@ func TestNewExternalDBInfo(t *testing.T) {
 
 	secret.Data["DB_CONNECTION_STRING"] = []byte{}
 	t.Run("fail if connection string is empty", func(t *testing.T) {
-		_, err := NewExternalDBInfo(mattermost, secret)
+		_, err := NewExternalDBConfig(mattermost, secret)
 		require.Error(t, err)
 	})
 
 	delete(secret.Data, "DB_CONNECTION_STRING")
 	t.Run("fail if connection string not present", func(t *testing.T) {
-		_, err := NewExternalDBInfo(mattermost, secret)
+		_, err := NewExternalDBConfig(mattermost, secret)
 		require.Error(t, err)
 	})
 }

--- a/pkg/mattermost/database_mysql.go
+++ b/pkg/mattermost/database_mysql.go
@@ -1,0 +1,94 @@
+package mattermost
+
+import (
+	"fmt"
+
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/mattermost/mattermost-operator/pkg/components/utils"
+	corev1 "k8s.io/api/core/v1"
+)
+
+type MySQLDBConfig struct {
+	secretName   string
+	rootPassword string
+	userName     string
+	userPassword string
+	databaseName string
+}
+
+func NewMySQLDB(secret corev1.Secret) (*MySQLDBConfig, error) {
+	rootPassword := string(secret.Data["ROOT_PASSWORD"])
+	if rootPassword == "" {
+		return nil, fmt.Errorf("database root password shouldn't be empty")
+	}
+	userName := string(secret.Data["USER"])
+	if userName == "" {
+		return nil, fmt.Errorf("database username shouldn't be empty")
+	}
+	userPassword := string(secret.Data["PASSWORD"])
+	if userPassword == "" {
+		return nil, fmt.Errorf("database password shouldn't be empty")
+	}
+	databaseName := string(secret.Data["DATABASE"])
+	if databaseName == "" {
+		return nil, fmt.Errorf("database name shouldn't be empty")
+	}
+
+	return &MySQLDBConfig{
+		secretName:   secret.Name,
+		rootPassword: rootPassword,
+		userName:     userName,
+		userPassword: userPassword,
+		databaseName: databaseName,
+	}, nil
+
+}
+
+func (m *MySQLDBConfig) EnvVars(mattermost *mattermostv1beta1.Mattermost) []corev1.EnvVar {
+	mysqlName := utils.HashWithPrefix("db", mattermost.Name)
+
+	dbEnvVars := []corev1.EnvVar{
+		{
+			Name: "MYSQL_USERNAME",
+			ValueFrom: EnvSourceFromSecret(m.secretName, "USER"),
+		},
+		{
+			Name: "MYSQL_PASSWORD",
+			ValueFrom: EnvSourceFromSecret(m.secretName, "PASSWORD"),
+		},
+		{
+			Name: "MM_SQLSETTINGS_DATASOURCEREPLICAS",
+			Value: fmt.Sprintf(
+				"$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql.%s:3306)/%s?readTimeout=30s&writeTimeout=30s",
+				mysqlName, mattermost.Namespace, m.databaseName,
+			),
+		},
+		{
+			Name: "MM_CONFIG",
+			Value: fmt.Sprintf(
+				"mysql://$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql-master.%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
+				mysqlName, mattermost.Namespace, m.databaseName,
+			),
+		},
+	}
+
+	return dbEnvVars
+}
+
+func (m *MySQLDBConfig) InitContainers(mattermost *mattermostv1beta1.Mattermost) []corev1.Container {
+	mysqlName := utils.HashWithPrefix("db", mattermost.Name)
+
+	return []corev1.Container{
+		{
+			Name:            "init-check-operator-mysql",
+			Image:           "appropriate/curl:latest",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command: []string{
+				"sh", "-c",
+				fmt.Sprintf("until curl --max-time 5 http://%s-mysql-master.%s:3306; do echo waiting for mysql; sleep 5; done;",
+					mysqlName, mattermost.Namespace,
+				),
+			},
+		},
+	}
+}

--- a/pkg/mattermost/database_mysql.go
+++ b/pkg/mattermost/database_mysql.go
@@ -49,11 +49,11 @@ func (m *MySQLDBConfig) EnvVars(mattermost *mattermostv1beta1.Mattermost) []core
 
 	dbEnvVars := []corev1.EnvVar{
 		{
-			Name: "MYSQL_USERNAME",
+			Name:      "MYSQL_USERNAME",
 			ValueFrom: EnvSourceFromSecret(m.secretName, "USER"),
 		},
 		{
-			Name: "MYSQL_PASSWORD",
+			Name:      "MYSQL_PASSWORD",
 			ValueFrom: EnvSourceFromSecret(m.secretName, "PASSWORD"),
 		},
 		{

--- a/pkg/mattermost/database_mysql.go
+++ b/pkg/mattermost/database_mysql.go
@@ -16,7 +16,7 @@ type MySQLDBConfig struct {
 	databaseName string
 }
 
-func NewMySQLDB(secret corev1.Secret) (*MySQLDBConfig, error) {
+func NewMySQLDBConfig(secret corev1.Secret) (*MySQLDBConfig, error) {
 	rootPassword := string(secret.Data["ROOT_PASSWORD"])
 	if rootPassword == "" {
 		return nil, fmt.Errorf("database root password shouldn't be empty")

--- a/pkg/mattermost/database_mysql.go
+++ b/pkg/mattermost/database_mysql.go
@@ -1,6 +1,7 @@
 package mattermost
 
 import (
+	"errors"
 	"fmt"
 
 	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
@@ -19,19 +20,19 @@ type MySQLDBConfig struct {
 func NewMySQLDBConfig(secret corev1.Secret) (*MySQLDBConfig, error) {
 	rootPassword := string(secret.Data["ROOT_PASSWORD"])
 	if rootPassword == "" {
-		return nil, fmt.Errorf("database root password shouldn't be empty")
+		return nil, errors.New("database root password shouldn't be empty")
 	}
 	userName := string(secret.Data["USER"])
 	if userName == "" {
-		return nil, fmt.Errorf("database username shouldn't be empty")
+		return nil, errors.New("database username shouldn't be empty")
 	}
 	userPassword := string(secret.Data["PASSWORD"])
 	if userPassword == "" {
-		return nil, fmt.Errorf("database password shouldn't be empty")
+		return nil, errors.New("database password shouldn't be empty")
 	}
 	databaseName := string(secret.Data["DATABASE"])
 	if databaseName == "" {
-		return nil, fmt.Errorf("database name shouldn't be empty")
+		return nil, errors.New("database name shouldn't be empty")
 	}
 
 	return &MySQLDBConfig{

--- a/pkg/mattermost/database_mysql_test.go
+++ b/pkg/mattermost/database_mysql_test.go
@@ -1,0 +1,89 @@
+package mattermost
+
+import (
+	"testing"
+
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewMySQLDB(t *testing.T) {
+	mattermost := &mattermostv1beta1.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{Name: "mm-test"},
+		Spec: mattermostv1beta1.MattermostSpec{
+			Database: mattermostv1beta1.Database{
+				OperatorManaged: &mattermostv1beta1.OperatorManagedDatabase{},
+			},
+		},
+	}
+
+	secret := corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+		Data: map[string][]byte{
+			"ROOT_PASSWORD": []byte("root-pass"),
+			"USER":          []byte("user"),
+			"PASSWORD":      []byte("pass"),
+			"DATABASE":      []byte("db"),
+		},
+	}
+
+	t.Run("create config", func(t *testing.T) {
+		config, err := NewMySQLDB(secret)
+		require.NoError(t, err)
+		assert.Equal(t, "secret", config.secretName)
+		assert.Equal(t, "root-pass", config.rootPassword)
+		assert.Equal(t, "user", config.userName)
+		assert.Equal(t, "pass", config.userPassword)
+		assert.Equal(t, "db", config.databaseName)
+
+		envs := config.EnvVars(mattermost)
+		assert.Equal(t, 4, len(envs))
+
+		initContainers := config.InitContainers(mattermost)
+		assert.Equal(t, 1, len(initContainers))
+	})
+
+	t.Run("should fail if missing key", func(t *testing.T) {
+		for _, testCase := range []struct {
+			description string
+			missingKey  string
+		}{
+			{
+				description: "root pass",
+				missingKey:  "ROOT_PASSWORD",
+			},
+			{
+				description: "user",
+				missingKey:  "USER",
+			},
+			{
+				description: "pass",
+				missingKey:  "PASSWORD",
+			},
+			{
+				description: "db",
+				missingKey:  "DATABASE",
+			},
+		} {
+			t.Run(testCase.description, func(t *testing.T) {
+				secret := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+					Data: map[string][]byte{
+						"ROOT_PASSWORD": []byte("root-pass"),
+						"USER":          []byte("user"),
+						"PASSWORD":      []byte("pass"),
+						"DATABASE":      []byte("db"),
+					},
+				}
+
+				delete(secret.Data, testCase.missingKey)
+
+				_, err := NewMySQLDB(secret)
+				require.Error(t, err)
+			})
+		}
+	})
+}

--- a/pkg/mattermost/database_mysql_test.go
+++ b/pkg/mattermost/database_mysql_test.go
@@ -31,7 +31,7 @@ func TestNewMySQLDB(t *testing.T) {
 	}
 
 	t.Run("create config", func(t *testing.T) {
-		config, err := NewMySQLDB(secret)
+		config, err := NewMySQLDBConfig(secret)
 		require.NoError(t, err)
 		assert.Equal(t, "secret", config.secretName)
 		assert.Equal(t, "root-pass", config.rootPassword)
@@ -81,7 +81,7 @@ func TestNewMySQLDB(t *testing.T) {
 
 				delete(secret.Data, testCase.missingKey)
 
-				_, err := NewMySQLDB(secret)
+				_, err := NewMySQLDBConfig(secret)
 				require.Error(t, err)
 			})
 		}

--- a/pkg/mattermost/env_var.go
+++ b/pkg/mattermost/env_var.go
@@ -1,0 +1,93 @@
+package mattermost
+
+import corev1 "k8s.io/api/core/v1"
+
+func generalMattermostEnvVars(siteURL string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "MM_SERVICESETTINGS_SITEURL",
+			Value: siteURL,
+		},
+		{
+			Name:  "MM_PLUGINSETTINGS_ENABLEUPLOADS",
+			Value: "true",
+		},
+		{
+			Name:  "MM_METRICSSETTINGS_ENABLE",
+			Value: "true",
+		},
+		{
+			Name:  "MM_METRICSSETTINGS_LISTENADDRESS",
+			Value: ":8067",
+		},
+		{
+			Name:  "MM_CLUSTERSETTINGS_ENABLE",
+			Value: "true",
+		},
+		{
+			Name:  "MM_CLUSTERSETTINGS_CLUSTERNAME",
+			Value: "production",
+		},
+		{
+			Name:  "MM_INSTALL_TYPE",
+			Value: "kubernetes-operator",
+		},
+	}
+}
+
+func fileStoreEnvVars(fileStore *FileStoreInfo) []corev1.EnvVar {
+	minioAccessEnv := EnvSourceFromSecret(fileStore.secretName, fileStoreSecretAccessKey)
+	minioSecretEnv := EnvSourceFromSecret(fileStore.secretName, fileStoreSecretSecretKey)
+
+	return []corev1.EnvVar{
+		{
+			Name:  "MM_FILESETTINGS_DRIVERNAME",
+			Value: "amazons3",
+		},
+		{
+			Name:      "MM_FILESETTINGS_AMAZONS3ACCESSKEYID",
+			ValueFrom: minioAccessEnv,
+		},
+		{
+			Name:      "MM_FILESETTINGS_AMAZONS3SECRETACCESSKEY",
+			ValueFrom: minioSecretEnv,
+		},
+		{
+			Name:  "MM_FILESETTINGS_AMAZONS3BUCKET",
+			Value: fileStore.bucketName,
+		},
+		{
+			Name:  "MM_FILESETTINGS_AMAZONS3ENDPOINT",
+			Value: fileStore.url,
+		},
+		{
+			Name:  "MM_FILESETTINGS_AMAZONS3SSL",
+			Value: "false",
+		},
+	}
+}
+
+func elasticSearchEnvVars(host, user, password string) []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "MM_ELASTICSEARCHSETTINGS_ENABLEINDEXING",
+			Value: "true",
+		},
+		{
+			Name:  "MM_ELASTICSEARCHSETTINGS_ENABLESEARCHING",
+			Value: "true",
+		},
+		{
+			Name:  "MM_ELASTICSEARCHSETTINGS_CONNECTIONURL",
+			Value: host,
+		},
+		{
+			Name:  "MM_ELASTICSEARCHSETTINGS_USERNAME",
+			Value: user,
+		},
+		{
+			Name:  "MM_ELASTICSEARCHSETTINGS_PASSWORD",
+			Value: password,
+		},
+	}
+}

--- a/pkg/mattermost/file_store.go
+++ b/pkg/mattermost/file_store.go
@@ -1,6 +1,7 @@
 package mattermost
 
 import (
+	"errors"
 	"fmt"
 
 	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
@@ -69,17 +70,17 @@ func (e *OperatorManagedMinioConfig) InitContainers(mattermost *mattermostv1beta
 
 func NewExternalFileStoreInfo(mattermost *mattermostv1beta1.Mattermost, secret corev1.Secret) (*FileStoreInfo, error) {
 	if mattermost.Spec.FileStore.External == nil {
-		return nil, fmt.Errorf("external file store configuration not provided")
+		return nil, errors.New("external file store configuration not provided")
 	}
 
 	bucket := mattermost.Spec.FileStore.External.Bucket
 	if bucket == "" {
-		return nil, fmt.Errorf("external file store bucket is empty")
+		return nil, errors.New("external file store bucket is empty")
 	}
 
 	url := mattermost.Spec.FileStore.External.URL
 	if url == "" {
-		return nil, fmt.Errorf("external file store URL is empty")
+		return nil, errors.New("external file store URL is empty")
 	}
 
 	if _, ok := secret.Data["accesskey"]; !ok {

--- a/pkg/mattermost/file_store.go
+++ b/pkg/mattermost/file_store.go
@@ -1,0 +1,107 @@
+package mattermost
+
+import (
+	"fmt"
+
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	fileStoreSecretAccessKey = "accesskey"
+	fileStoreSecretSecretKey = "secretkey"
+)
+
+type FileStoreInfo struct {
+	secretName string
+	bucketName string
+	url        string
+	config     FileStoreConfig
+}
+
+type ExternalFileStore struct{}
+
+func (e *ExternalFileStore) InitContainers(_ *mattermostv1beta1.Mattermost) []corev1.Container {
+	return []corev1.Container{}
+}
+
+type OperatorManagedMinioConfig struct {
+	secretName string
+	minioURL   string
+}
+
+func (e *OperatorManagedMinioConfig) InitContainers(mattermost *mattermostv1beta1.Mattermost) []corev1.Container {
+	initContainers := []corev1.Container{
+		// Create the init container to create the MinIO bucket
+		corev1.Container{
+			Name:            "create-minio-bucket",
+			Image:           "minio/mc:latest",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command: []string{
+				"/bin/sh", "-c",
+				fmt.Sprintf("mc config host add localminio http://%s $(MINIO_ACCESS_KEY) $(MINIO_SECRET_KEY) && mc mb localminio/%s -q -p", e.minioURL, mattermost.Name),
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:      "MINIO_ACCESS_KEY",
+					ValueFrom: EnvSourceFromSecret(e.secretName, fileStoreSecretAccessKey),
+				},
+				{
+					Name:      "MINIO_SECRET_KEY",
+					ValueFrom: EnvSourceFromSecret(e.secretName, fileStoreSecretSecretKey),
+				},
+			},
+		},
+		// Create the init container to check that MinIO is up and running
+		corev1.Container{
+			Name:            "init-check-minio",
+			Image:           "appropriate/curl:latest",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command: []string{
+				"sh", "-c",
+				fmt.Sprintf("until curl --max-time 5 http://%s/minio/health/ready; do echo waiting for minio; sleep 5; done;", e.minioURL),
+			},
+		},
+	}
+
+	return initContainers
+}
+
+func NewExternalFileStoreInfo(mattermost *mattermostv1beta1.Mattermost, secret corev1.Secret) (*FileStoreInfo, error) {
+	if mattermost.Spec.FileStore.External == nil {
+		return nil, fmt.Errorf("external file store configuration not provided")
+	}
+
+	bucket := mattermost.Spec.FileStore.External.Bucket
+	if bucket == "" {
+		return nil, fmt.Errorf("external file store bucket is empty")
+	}
+
+	url := mattermost.Spec.FileStore.External.URL
+	if url == "" {
+		return nil, fmt.Errorf("external file store URL is empty")
+	}
+
+	if _, ok := secret.Data["accesskey"]; !ok {
+		return nil, fmt.Errorf("external filestore Secret %s does not have an 'accesskey' value", secret.Name)
+	}
+	if _, ok := secret.Data["secretkey"]; !ok {
+		return nil, fmt.Errorf("external filestore Secret %s does not have an 'secretkey' value", secret.Name)
+	}
+
+	return &FileStoreInfo{
+		secretName: secret.Name,
+		bucketName: bucket,
+		url:        url,
+		config:     &ExternalFileStore{},
+	}, nil
+}
+
+func NewOperatorManagedFileStoreInfo(mattermost *mattermostv1beta1.Mattermost, secret, minioURL string) *FileStoreInfo {
+	return &FileStoreInfo{
+		secretName: secret,
+		bucketName: mattermost.Name,
+		url:        minioURL,
+		config:     &OperatorManagedMinioConfig{minioURL: minioURL, secretName: secret},
+	}
+}

--- a/pkg/mattermost/file_store.go
+++ b/pkg/mattermost/file_store.go
@@ -33,7 +33,7 @@ type OperatorManagedMinioConfig struct {
 func (e *OperatorManagedMinioConfig) InitContainers(mattermost *mattermostv1beta1.Mattermost) []corev1.Container {
 	initContainers := []corev1.Container{
 		// Create the init container to create the MinIO bucket
-		corev1.Container{
+		{
 			Name:            "create-minio-bucket",
 			Image:           "minio/mc:latest",
 			ImagePullPolicy: corev1.PullIfNotPresent,
@@ -53,7 +53,7 @@ func (e *OperatorManagedMinioConfig) InitContainers(mattermost *mattermostv1beta
 			},
 		},
 		// Create the init container to check that MinIO is up and running
-		corev1.Container{
+		{
 			Name:            "init-check-minio",
 			Image:           "appropriate/curl:latest",
 			ImagePullPolicy: corev1.PullIfNotPresent,

--- a/pkg/mattermost/file_store_test.go
+++ b/pkg/mattermost/file_store_test.go
@@ -1,0 +1,64 @@
+package mattermost
+
+import (
+	"testing"
+
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFileStore(t *testing.T) {
+	mattermost := &mattermostv1beta1.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{Name: "mm-test"},
+		Spec:       mattermostv1beta1.MattermostSpec{},
+	}
+
+	secret := "file-store-secret"
+	minioURL := "http://minio"
+
+	t.Run("operator managed Minio", func(t *testing.T) {
+		mattermost.Spec.FileStore = mattermostv1beta1.FileStore{
+			OperatorManaged: &mattermostv1beta1.OperatorManagedMinio{
+				StorageSize: "10GB",
+				Replicas:    nil,
+				Resources:   corev1.ResourceRequirements{},
+			},
+		}
+
+		fileStore := NewOperatorManagedFileStoreInfo(mattermost, secret, minioURL)
+		initContainers := fileStore.config.InitContainers(mattermost)
+		assert.Equal(t, 2, len(initContainers))
+		assert.Equal(t, secret, fileStore.secretName)
+		assert.Equal(t, minioURL, fileStore.url)
+		assert.Equal(t, "mm-test", fileStore.bucketName)
+	})
+
+	t.Run("external file store", func(t *testing.T) {
+		mattermost.Spec.FileStore = mattermostv1beta1.FileStore{
+			External: &mattermostv1beta1.ExternalFileStore{
+				URL:    minioURL,
+				Bucket: "test-bucket",
+				Secret: "external-file-store",
+			},
+		}
+
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "external-file-store"},
+			Data: map[string][]byte{
+				"accesskey": []byte("key"),
+				"secretkey": []byte("secret"),
+			},
+		}
+
+		fileStore, err := NewExternalFileStoreInfo(mattermost, secret)
+		require.NoError(t, err)
+		initContainers := fileStore.config.InitContainers(mattermost)
+		assert.Equal(t, 0, len(initContainers))
+		assert.Equal(t, "external-file-store", fileStore.secretName)
+		assert.Equal(t, minioURL, fileStore.url)
+		assert.Equal(t, "test-bucket", fileStore.bucketName)
+	})
+}

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -131,7 +131,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 		}
 
 		if dbInfo.HasDatabaseCheckURL() {
-			dbCheckContainer := getDBCheckInitContainer(dbInfo.SecretName, dbInfo.ExternalDBType)
+			dbCheckContainer := getDBCheckDatabaseConfigInitContainer(dbInfo.SecretName, dbInfo.ExternalDBType)
 			if dbCheckContainer != nil {
 				initContainers = append(initContainers, *dbCheckContainer)
 			}
@@ -513,4 +513,3 @@ func waitForSetupJobContainer() corev1.Container {
 		},
 	}
 }
-

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -131,7 +131,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 		}
 
 		if dbInfo.HasDatabaseCheckURL() {
-			dbCheckContainer := getDBCheckDatabaseConfigInitContainer(dbInfo.SecretName, dbInfo.ExternalDBType)
+			dbCheckContainer := getDBCheckInitContainer(dbInfo.SecretName, dbInfo.ExternalDBType)
 			if dbCheckContainer != nil {
 				initContainers = append(initContainers, *dbCheckContainer)
 			}

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -1,0 +1,376 @@
+package mattermost
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	pkgUtils "github.com/mattermost/mattermost-operator/pkg/utils"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type DatabaseConfig interface {
+	EnvVars(mattermost *mattermostv1beta1.Mattermost) []corev1.EnvVar
+	InitContainers(mattermost *mattermostv1beta1.Mattermost) []corev1.Container
+}
+
+type FileStoreConfig interface {
+	InitContainers(mattermost *mattermostv1beta1.Mattermost) []corev1.Container
+}
+
+// GenerateService returns the service for the Mattermost app.
+func GenerateServiceV1Beta(mattermost *mattermostv1beta1.Mattermost, serviceName, selectorName string) *corev1.Service {
+	baseAnnotations := map[string]string{
+		"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+	}
+
+	if mattermost.Spec.UseServiceLoadBalancer {
+		// Create a LoadBalancer service with additional annotations provided in
+		// the Mattermost Spec. The LoadBalancer is directly accessible from
+		// outside the cluster thus exposes ports 80 and 443.
+		service := newServiceV1Beta(mattermost, serviceName, selectorName,
+			mergeStringMaps(baseAnnotations, mattermost.Spec.ServiceAnnotations),
+		)
+		return configureMattermostLoadBalancerService(service)
+	}
+
+	// Create a headless service which is not directly accessible from outside
+	// the cluster and thus exposes a custom port.
+	service := newServiceV1Beta(mattermost, serviceName, selectorName, baseAnnotations)
+	return configureMattermostService(service)
+}
+
+func configureMattermostLoadBalancerService(service *corev1.Service) *corev1.Service {
+	service.Spec.Ports = []corev1.ServicePort{
+		{
+			Name:       "http",
+			Port:       80,
+			TargetPort: intstr.FromString("app"),
+		},
+		{
+			Name:       "https",
+			Port:       443,
+			TargetPort: intstr.FromString("app"),
+		},
+	}
+	service.Spec.Type = corev1.ServiceTypeLoadBalancer
+
+	return service
+}
+
+func configureMattermostService(service *corev1.Service) *corev1.Service {
+	service.Spec.Ports = []corev1.ServicePort{
+		{
+			Port:       8065,
+			Name:       "app",
+			TargetPort: intstr.FromString("app"),
+		},
+		{
+			Port:       8067,
+			Name:       "metrics",
+			TargetPort: intstr.FromString("metrics"),
+		},
+	}
+	service.Spec.ClusterIP = corev1.ClusterIPNone
+
+	return service
+}
+
+// GenerateIngress returns the ingress for the Mattermost app.
+func GenerateIngressV1Beta(mattermost *mattermostv1beta1.Mattermost, name, ingressName string, ingressAnnotations map[string]string) *v1beta1.Ingress {
+	ingress := &v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       mattermost.Namespace,
+			Labels:          mattermost.MattermostLabels(name),
+			OwnerReferences: MattermostOwnerReference(mattermost),
+			Annotations:     ingressAnnotations,
+		},
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: ingressName,
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: v1beta1.IngressBackend{
+										ServiceName: name,
+										ServicePort: intstr.FromInt(8065),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if mattermost.Spec.UseIngressTLS {
+		ingress.Spec.TLS = []v1beta1.IngressTLS{
+			{
+				Hosts:      []string{ingressName},
+				SecretName: strings.ReplaceAll(ingressName, ".", "-") + "-tls-cert",
+			},
+		}
+	}
+
+	return ingress
+}
+
+// GenerateDeployment returns the deployment for Mattermost app.
+func GenerateDeploymentV1Beta(mattermost *mattermostv1beta1.Mattermost, db DatabaseConfig, fileStore *FileStoreInfo, deploymentName, ingressName, serviceAccountName, containerImage string) *appsv1.Deployment {
+	// DB
+	envVarDB := db.EnvVars(mattermost)
+	initContainers := db.InitContainers(mattermost)
+
+	// File Store
+	envVarFileStore := fileStoreEnvVars(fileStore)
+	initContainers = append(initContainers, fileStore.config.InitContainers(mattermost)...)
+
+	// TODO: DB setup job is temporarily disabled as `mattermost version` command
+	// does not account for the custom configuration
+	// Add init container to wait for DB setup job to complete
+	//initContainers = append(initContainers, waitForSetupJobContainer())
+
+	// ES section vars
+	envVarES := []corev1.EnvVar{}
+	if mattermost.Spec.ElasticSearch.Host != "" {
+		envVarES = elasticSearchEnvVars(
+			mattermost.Spec.ElasticSearch.Host,
+			mattermost.Spec.ElasticSearch.UserName,
+			mattermost.Spec.ElasticSearch.Password,
+		)
+	}
+
+	// General settings
+	siteURL := fmt.Sprintf("https://%s", ingressName)
+	envVarGeneral := generalMattermostEnvVars(siteURL)
+
+	// Determine max file size
+	bodySize := strconv.Itoa(defaultMaxFileSize * sizeMB)
+	if !mattermost.Spec.UseServiceLoadBalancer {
+		bodySize = determineMaxBodySize(mattermost.Spec.IngressAnnotations, bodySize)
+	}
+	envVarGeneral = append(envVarGeneral, corev1.EnvVar{
+		Name:  "MM_FILESETTINGS_MAXFILESIZE",
+		Value: bodySize,
+	})
+
+	// Prepare volumes
+	volumes := mattermost.Spec.Volumes
+	volumeMounts := mattermost.Spec.VolumeMounts
+	podAnnotations := map[string]string{}
+
+	// Mattermost License
+	if len(mattermost.Spec.LicenseSecret) != 0 {
+		env, vMount, volume, annotations := mattermostLicenceConfig(mattermost.Spec.LicenseSecret)
+		envVarGeneral = append(envVarGeneral, env)
+		volumeMounts = append(volumeMounts, vMount)
+		volumes = append(volumes, volume)
+		podAnnotations = annotations
+	}
+
+	// Concat EnvVars
+	envVars := []corev1.EnvVar{}
+	envVars = append(envVars, envVarDB...)
+	envVars = append(envVars, envVarFileStore...)
+	envVars = append(envVars, envVarES...)
+	envVars = append(envVars, envVarGeneral...)
+
+	// Merge our custom env vars in.
+	envVars = mergeEnvVars(envVars, mattermost.Spec.MattermostEnv)
+
+	maxUnavailable := intstr.FromInt(defaultMaxUnavailable)
+	maxSurge := intstr.FromInt(defaultMaxSurge)
+
+	liveness, readiness := setProbes(mattermost.Spec.Probes.LivenessProbe, mattermost.Spec.Probes.ReadinessProbe)
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            deploymentName,
+			Namespace:       mattermost.Namespace,
+			Labels:          mattermost.MattermostLabels(deploymentName),
+			OwnerReferences: MattermostOwnerReference(mattermost),
+		},
+		Spec: appsv1.DeploymentSpec{
+			Strategy: appsv1.DeploymentStrategy{
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: &maxUnavailable,
+					MaxSurge:       &maxSurge,
+				},
+			},
+			RevisionHistoryLimit: pkgUtils.NewInt32(defaultRevHistoryLimit),
+			Replicas:             mattermost.Spec.Replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: mattermostv1beta1.MattermostSelectorLabels(deploymentName),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      mattermost.MattermostLabels(deploymentName),
+					Annotations: podAnnotations,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: serviceAccountName,
+					InitContainers:     initContainers,
+					Containers: []corev1.Container{
+						{
+							Name:                     mattermostv1alpha1.MattermostAppContainerName,
+							Image:                    containerImage,
+							ImagePullPolicy:          corev1.PullIfNotPresent,
+							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
+							Command:                  []string{"mattermost"},
+							Env:                      envVars,
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 8065,
+									Name:          "app",
+								},
+								{
+									ContainerPort: 8067,
+									Name:          "metrics",
+								},
+							},
+							ReadinessProbe: readiness,
+							LivenessProbe:  liveness,
+							VolumeMounts:   volumeMounts,
+							Resources:      mattermost.Spec.Scheduling.Resources,
+						},
+					},
+					Volumes:      volumes,
+					Affinity:     mattermost.Spec.Scheduling.Affinity,
+					NodeSelector: mattermost.Spec.Scheduling.NodeSelector,
+				},
+			},
+		},
+	}
+}
+
+// GenerateSecret returns the secret for Mattermost
+func GenerateSecretV1Beta(mattermost *mattermostv1beta1.Mattermost, secretName string, labels map[string]string, values map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:          labels,
+			Name:            secretName,
+			Namespace:       mattermost.Namespace,
+			OwnerReferences: MattermostOwnerReference(mattermost),
+		},
+		Data: values,
+	}
+}
+
+// GenerateServiceAccount returns the Service Account for Mattermost
+func GenerateServiceAccountV1Beta(mattermost *mattermostv1beta1.Mattermost, saName string) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            saName,
+			Namespace:       mattermost.Namespace,
+			OwnerReferences: MattermostOwnerReference(mattermost),
+		},
+	}
+}
+
+// GenerateRole returns the Role for Mattermost
+func GenerateRoleV1Beta(mattermost *mattermostv1beta1.Mattermost, roleName string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            roleName,
+			Namespace:       mattermost.Namespace,
+			OwnerReferences: MattermostOwnerReference(mattermost),
+		},
+		Rules: mattermostRolePermissions(),
+	}
+}
+
+func mattermostRolePermissions() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			Verbs:         []string{"get", "list", "watch"},
+			APIGroups:     []string{"batch"},
+			Resources:     []string{"jobs"},
+			ResourceNames: []string{SetupJobName},
+		},
+	}
+}
+
+// GenerateRoleBinding returns the RoleBinding for Mattermost
+func GenerateRoleBindingV1Beta(mattermost *mattermostv1beta1.Mattermost, roleName, saName string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            roleName,
+			Namespace:       mattermost.Namespace,
+			OwnerReferences: MattermostOwnerReference(mattermost),
+		},
+		Subjects: []rbacv1.Subject{
+			{Kind: "ServiceAccount", Name: saName, Namespace: mattermost.Namespace},
+		},
+		RoleRef: rbacv1.RoleRef{Kind: "Role", Name: roleName},
+	}
+}
+
+func MattermostOwnerReference(mattermost *mattermostv1beta1.Mattermost) []metav1.OwnerReference {
+	return []metav1.OwnerReference{
+		*metav1.NewControllerRef(mattermost, schema.GroupVersionKind{
+			Group:   mattermostv1beta1.GroupVersion.Group,
+			Version: mattermostv1beta1.GroupVersion.Version,
+			Kind:    "Mattermost",
+		}),
+	}
+}
+
+// newService returns semi-finished service with common parts filled.
+// Returned service is expected to be completed by the caller.
+func newServiceV1Beta(mattermost *mattermostv1beta1.Mattermost, serviceName, selectorName string, annotations map[string]string) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels:          mattermost.MattermostLabels(serviceName),
+			Name:            serviceName,
+			Namespace:       mattermost.Namespace,
+			OwnerReferences: MattermostOwnerReference(mattermost),
+			Annotations:     annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: mattermostv1beta1.MattermostSelectorLabels(selectorName),
+		},
+	}
+}
+
+func mattermostLicenceConfig(secret string) (corev1.EnvVar, corev1.VolumeMount, corev1.Volume, map[string]string) {
+	envVar := corev1.EnvVar{
+		Name:  "MM_SERVICESETTINGS_LICENSEFILELOCATION",
+		Value: "/mattermost-license/license",
+	}
+	volumeMount := corev1.VolumeMount{
+		MountPath: "/mattermost-license",
+		Name:      "mattermost-license",
+		ReadOnly:  true,
+	}
+	volume := corev1.Volume{
+		Name: "mattermost-license",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secret,
+			},
+		},
+	}
+	annotations := map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/path":   "/metrics",
+		"prometheus.io/port":   "8067",
+	}
+	return envVar, volumeMount, volume, annotations
+}

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -1,0 +1,491 @@
+package mattermost
+
+import (
+	"fmt"
+	"testing"
+
+	mattermostv1beta1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/mattermost/mattermost-operator/pkg/database"
+	"github.com/mattermost/mattermost-operator/pkg/utils"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Going forward, when new logic is added for constructing a kubernetes resource
+// to run Mattermost, the test for that resource should be updated to check that
+// the right configuration is present.
+
+func TestGenerateService_V1Beta(t *testing.T) {
+	tests := []struct {
+		name string
+		spec mattermostv1beta1.MattermostSpec
+	}{
+		{
+			name: "type headless",
+			spec: mattermostv1beta1.MattermostSpec{},
+		},
+		{
+			name: "type load-balancer",
+			spec: mattermostv1beta1.MattermostSpec{
+				UseServiceLoadBalancer: true,
+			},
+		},
+	}
+
+	expectPort := func(t *testing.T, service *corev1.Service, portNumber int32) {
+		t.Helper()
+		for _, port := range service.Spec.Ports {
+			if port.Port == portNumber {
+				return
+			}
+		}
+		assert.Fail(t, fmt.Sprintf("failed to find port %d on service", portNumber))
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mattermost := &mattermostv1beta1.Mattermost{
+				Spec: tt.spec,
+			}
+
+			service := GenerateServiceV1Beta(mattermost, "", "")
+			require.NotNil(t, service)
+
+			if mattermost.Spec.UseServiceLoadBalancer {
+				assert.Equal(t, service.Spec.Type, corev1.ServiceTypeLoadBalancer)
+				expectPort(t, service, 80)
+				expectPort(t, service, 443)
+			} else {
+				expectPort(t, service, 8065)
+				expectPort(t, service, 8067)
+			}
+		})
+	}
+}
+
+func TestGenerateIngress_V1Beta(t *testing.T) {
+	tests := []struct {
+		name string
+		spec mattermostv1beta1.MattermostSpec
+	}{
+		{
+			name: "no tls",
+			spec: mattermostv1beta1.MattermostSpec{},
+		},
+		{
+			name: "use tls",
+			spec: mattermostv1beta1.MattermostSpec{
+				UseIngressTLS: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mattermost := &mattermostv1beta1.Mattermost{
+				Spec: tt.spec,
+			}
+
+			ingress := GenerateIngressV1Beta(mattermost, "", "", nil)
+			require.NotNil(t, ingress)
+
+			if mattermost.Spec.UseIngressTLS {
+				assert.NotNil(t, ingress.Spec.TLS)
+			} else {
+				assert.Nil(t, ingress.Spec.TLS)
+			}
+		})
+	}
+}
+
+func TestGenerateDeployment_V1Beta(t *testing.T) {
+	tests := []struct {
+		name        string
+		spec        mattermostv1beta1.MattermostSpec
+		database    DatabaseConfig
+		fileStore   *FileStoreInfo
+		want        *appsv1.Deployment
+		requiredEnv []string
+	}{
+		{
+			name: "has license",
+			spec: mattermostv1beta1.MattermostSpec{
+				LicenseSecret: "license-secret",
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "mattermost-license",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "license-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			requiredEnv: []string{"MM_SERVICESETTINGS_LICENSEFILELOCATION"},
+		},
+		{
+			name:     "external database",
+			spec:     mattermostv1beta1.MattermostSpec{},
+			database: &ExternalDBConfig{secretName: "database-secret"},
+			want:     &appsv1.Deployment{},
+		},
+		{
+			name:        "external database with reader endpoints",
+			spec:        mattermostv1beta1.MattermostSpec{},
+			database:    &ExternalDBConfig{secretName: "database-secret", hasReaderEndpoints: true},
+			want:        &appsv1.Deployment{},
+			requiredEnv: []string{"MM_SQLSETTINGS_DATASOURCEREPLICAS"},
+		},
+		{
+			name: "external known database with check url",
+			spec: mattermostv1beta1.MattermostSpec{},
+			database: &ExternalDBConfig{
+				secretName:    "database-secret",
+				hasDBCheckURL: true,
+				dbType:        database.PostgreSQLDatabase,
+			},
+			want: &appsv1.Deployment{},
+		},
+		{
+			name: "external unknown database with check url",
+			spec: mattermostv1beta1.MattermostSpec{},
+			database: &ExternalDBConfig{
+				secretName:    "database-secret",
+				hasDBCheckURL: true,
+				dbType:        "cockroach",
+			},
+			want: &appsv1.Deployment{},
+		},
+		{
+			name: "external file store",
+			spec: mattermostv1beta1.MattermostSpec{},
+			fileStore: &FileStoreInfo{
+				secretName: "file-store-secret",
+				bucketName: "file-store-bucket",
+				url:        "s3.amazon.com",
+				config:     &ExternalFileStore{},
+			},
+			want: &appsv1.Deployment{},
+		},
+		{
+			name: "node selector 1",
+			spec: mattermostv1beta1.MattermostSpec{
+				Scheduling: mattermostv1beta1.Scheduling{
+					NodeSelector: map[string]string{"type": "compute"},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{"type": "compute"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "node selector 2",
+			spec: mattermostv1beta1.MattermostSpec{
+				Scheduling: mattermostv1beta1.Scheduling{
+					NodeSelector: map[string]string{"type": "compute", "size": "big", "region": "iceland"},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{"type": "compute", "size": "big", "region": "iceland"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "node selector nil",
+			spec: mattermostv1beta1.MattermostSpec{
+				Scheduling: mattermostv1beta1.Scheduling{
+					NodeSelector: nil,
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							NodeSelector: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "affinity 1",
+			spec: mattermostv1beta1.MattermostSpec{
+				Scheduling: mattermostv1beta1.Scheduling{
+					Affinity: &corev1.Affinity{
+						PodAffinity: &corev1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{"key": "value"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Affinity: &corev1.Affinity{
+								PodAffinity: &corev1.PodAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+										{
+											LabelSelector: &metav1.LabelSelector{
+												MatchLabels: map[string]string{"key": "value"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "affinity nil",
+			spec: mattermostv1beta1.MattermostSpec{
+				Scheduling: mattermostv1beta1.Scheduling{
+					Affinity: nil,
+				},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Affinity: nil,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "negative app replica",
+			spec: mattermostv1beta1.MattermostSpec{
+				Replicas: utils.NewInt32(-1),
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: utils.NewInt32(0),
+				},
+			},
+		},
+		{
+			name: "nil replicas",
+			spec: mattermostv1beta1.MattermostSpec{
+				Replicas: nil,
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: utils.NewInt32(0),
+				},
+			},
+		},
+		{
+			name: "volumes",
+			spec: mattermostv1beta1.MattermostSpec{
+				Volumes:      []corev1.Volume{fixVolume()},
+				VolumeMounts: []corev1.VolumeMount{fixVolumeMount()},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{fixVolume()},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "volumes and licence",
+			spec: mattermostv1beta1.MattermostSpec{
+				LicenseSecret: "license-secret",
+				Volumes:       []corev1.Volume{fixVolume()},
+				VolumeMounts:  []corev1.VolumeMount{fixVolumeMount()},
+			},
+			want: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								fixVolume(),
+								{
+									Name: "mattermost-license",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "license-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "elastic search",
+			spec: mattermostv1beta1.MattermostSpec{
+				ElasticSearch: mattermostv1beta1.ElasticSearch{
+					Host:     "http://elastic",
+					UserName: "user",
+					Password: "password",
+				},
+			},
+			want: &appsv1.Deployment{},
+			requiredEnv: []string{
+				"MM_ELASTICSEARCHSETTINGS_ENABLEINDEXING",
+				"MM_ELASTICSEARCHSETTINGS_ENABLESEARCHING",
+				"MM_ELASTICSEARCHSETTINGS_CONNECTIONURL",
+				"MM_ELASTICSEARCHSETTINGS_USERNAME",
+				"MM_ELASTICSEARCHSETTINGS_PASSWORD",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mattermost := &mattermostv1beta1.Mattermost{
+				Spec: tt.spec,
+			}
+			databaseConfig := tt.database
+			if databaseConfig == nil {
+				databaseConfig = &MySQLDBConfig{}
+			}
+			fileStoreInfo := tt.fileStore
+			if fileStoreInfo == nil {
+				fileStoreInfo = NewOperatorManagedFileStoreInfo(mattermost, "minio-secret", "http://minio")
+			}
+
+			deployment := GenerateDeploymentV1Beta(mattermost, databaseConfig, fileStoreInfo, "", "", "service-account", "")
+			require.NotNil(t, deployment)
+
+			assert.Equal(t, "service-account", deployment.Spec.Template.Spec.ServiceAccountName)
+			assert.Equal(t, tt.want.Spec.Template.Spec.NodeSelector, deployment.Spec.Template.Spec.NodeSelector)
+			assert.Equal(t, tt.want.Spec.Template.Spec.Affinity, deployment.Spec.Template.Spec.Affinity)
+			assert.Equal(t, tt.want.Spec.Template.Spec.Volumes, deployment.Spec.Template.Spec.Volumes)
+			assert.Equal(t, len(tt.want.Spec.Template.Spec.Volumes), len(deployment.Spec.Template.Spec.Containers[0].VolumeMounts))
+
+			mattermostAppContainer := mattermostv1beta1.GetMattermostAppContainerFromDeployment(deployment)
+			require.NotNil(t, mattermostAppContainer)
+
+			// Basic env var check to ensure the key exists.
+			assertEnvVarExists(t, "MM_CONFIG", mattermostAppContainer.Env)
+			assertEnvVarExists(t, "MM_SERVICESETTINGS_SITEURL", mattermostAppContainer.Env)
+			assertEnvVarExists(t, "MM_METRICSSETTINGS_LISTENADDRESS", mattermostAppContainer.Env)
+			assertEnvVarExists(t, "MM_METRICSSETTINGS_ENABLE", mattermostAppContainer.Env)
+			assertEnvVarExists(t, "MM_PLUGINSETTINGS_ENABLEUPLOADS", mattermostAppContainer.Env)
+			assertEnvVarExists(t, "MM_CLUSTERSETTINGS_ENABLE", mattermostAppContainer.Env)
+			assertEnvVarExists(t, "MM_CLUSTERSETTINGS_CLUSTERNAME", mattermostAppContainer.Env)
+			assertEnvVarExists(t, "MM_FILESETTINGS_MAXFILESIZE", mattermostAppContainer.Env)
+			assertEnvVarExists(t, "MM_INSTALL_TYPE", mattermostAppContainer.Env)
+
+			for _, env := range tt.requiredEnv {
+				assertEnvVarExists(t, env, mattermostAppContainer.Env)
+			}
+
+			// External db check.
+			expectedInitContainers := 0 // Due to disabling DB setup job we start with 0 init containers
+
+			if externalDB, ok := tt.database.(*ExternalDBConfig); ok {
+				if externalDB.hasDBCheckURL {
+					if externalDB.dbType == database.MySQLDatabase ||
+						externalDB.dbType == database.PostgreSQLDatabase {
+						expectedInitContainers++
+					}
+				}
+				if externalDB.hasReaderEndpoints {
+					assertEnvVarExists(t, "MM_SQLSETTINGS_DATASOURCEREPLICAS", mattermostAppContainer.Env)
+				}
+			} else {
+				expectedInitContainers++
+				assertEnvVarExists(t, "MYSQL_USERNAME", mattermostAppContainer.Env)
+				assertEnvVarExists(t, "MYSQL_PASSWORD", mattermostAppContainer.Env)
+			}
+
+			if tt.fileStore == nil {
+				expectedInitContainers += 2
+			}
+
+			assert.Equal(t, expectedInitContainers, len(deployment.Spec.Template.Spec.InitContainers))
+
+			// Container check.
+			assert.Equal(t, 1, len(deployment.Spec.Template.Spec.Containers))
+		})
+	}
+}
+
+func TestGenerateRBACResources_V1Beta(t *testing.T) {
+	roleName := "role"
+	saName := "service-account"
+	mattermost := &mattermostv1beta1.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mm",
+			Namespace: "test-namespace",
+		},
+	}
+
+	serviceAccount := GenerateServiceAccountV1Beta(mattermost, saName)
+	require.Equal(t, saName, serviceAccount.Name)
+	require.Equal(t, mattermost.Namespace, serviceAccount.Namespace)
+	require.Equal(t, 1, len(serviceAccount.OwnerReferences))
+
+	role := GenerateRoleV1Beta(mattermost, roleName)
+	require.Equal(t, roleName, role.Name)
+	require.Equal(t, mattermost.Namespace, role.Namespace)
+	require.Equal(t, 1, len(role.OwnerReferences))
+	require.Equal(t, 1, len(role.Rules))
+
+	roleBinding := GenerateRoleBindingV1Beta(mattermost, roleName, saName)
+	require.Equal(t, roleName, roleBinding.Name)
+	require.Equal(t, mattermost.Namespace, roleBinding.Namespace)
+	require.Equal(t, 1, len(roleBinding.OwnerReferences))
+	require.Equal(t, 1, len(roleBinding.Subjects))
+	require.Equal(t, saName, roleBinding.Subjects[0].Name)
+	require.Equal(t, roleName, roleBinding.RoleRef.Name)
+}
+
+func fixVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: "test-volume",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "mounted-secret",
+			},
+		},
+	}
+}
+
+func fixVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      "test-volume",
+		MountPath: "/etc/test",
+	}
+}

--- a/pkg/mattermost/util.go
+++ b/pkg/mattermost/util.go
@@ -1,0 +1,14 @@
+package mattermost
+
+import corev1 "k8s.io/api/core/v1"
+
+func EnvSourceFromSecret(secretName, key string) *corev1.EnvVarSource {
+	return &corev1.EnvVarSource{
+		SecretKeyRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: secretName,
+			},
+			Key: key,
+		},
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR introduces code responsible for generating K8s resources based on the new CRD. The logic was reused in places where it was possible without making too messy code. In other places, the code was copied and modified with the assumption the old code will be removed after the migration is done.
- Introduced `DatabaseConfig` and `FileStoreConfig` interfaces.
- Extracted common logic where possible.
- Performed a couple of refactorings.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-30827

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
