### PR TITLE
add image pull policy option to spec

### DIFF
--- a/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -92,7 +92,7 @@ type ClusterInstallationSpec struct {
 	// Defines the probe to check if the application is ready to accept traffic.
 	// +optional
 	ReadinessProbe corev1.Probe `json:"readinessProbe,omitempty"`
-	// Specify deployment pull policy
+	// Specify deployment pull policy.
 	// +optional
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }

--- a/apis/mattermost/v1alpha1/clusterinstallation_types.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_types.go
@@ -92,6 +92,9 @@ type ClusterInstallationSpec struct {
 	// Defines the probe to check if the application is ready to accept traffic.
 	// +optional
 	ReadinessProbe corev1.Probe `json:"readinessProbe,omitempty"`
+	// Specify deployment pull policy
+	// +optional
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 // Canary defines the configuration of Canary deployment for a ClusterInstallation

--- a/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -24,6 +24,8 @@ const (
 	DefaultMinioStorageSize = "50Gi"
 	// DefaultStorageSize is the default Storage size for the Database
 	DefaultStorageSize = "50Gi"
+	// DefaultPullPolicy is ifNotPresetnt
+	DefaultPullPolicy = corev1.PullIfNotPresent
 
 	// ClusterLabel is the label applied across all compoments
 	ClusterLabel = "v1alpha1.mattermost.com/installation"
@@ -53,6 +55,10 @@ func (mattermost *ClusterInstallation) SetDefaults() error {
 	}
 	if mattermost.Spec.Version == "" {
 		mattermost.Spec.Version = DefaultMattermostVersion
+	}
+
+	if mattermost.Spec.ImagePullPolicy == "" {
+		mattermost.Spec.ImagePullPolicy = DefaultPullPolicy
 	}
 
 	mattermost.Spec.Minio.SetDefaults()

--- a/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -270,7 +270,7 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 					},
 					"imagePullPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specify deployment pull policy",
+							Description: "Specify deployment pull policy.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -268,6 +268,13 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
+					"imagePullPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specify deployment pull policy",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"ingressName"},
 			},

--- a/config/crd/bases/mattermost.com_clusterinstallations.yaml
+++ b/config/crd/bases/mattermost.com_clusterinstallations.yaml
@@ -842,6 +842,9 @@ spec:
               image:
                 description: Image defines the ClusterInstallation Docker image.
                 type: string
+              imagePullPolicy:
+                description: Specify deployment pull policy
+                type: string
               ingressAnnotations:
                 additionalProperties:
                   type: string

--- a/config/crd/bases/mattermost.com_clusterinstallations.yaml
+++ b/config/crd/bases/mattermost.com_clusterinstallations.yaml
@@ -843,7 +843,7 @@ spec:
                 description: Image defines the ClusterInstallation Docker image.
                 type: string
               imagePullPolicy:
-                description: Specify deployment pull policy
+                description: Specify deployment pull policy.
                 type: string
               ingressAnnotations:
                 additionalProperties:

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -187,13 +187,6 @@ func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *ma
 		return errors.Wrap(err, "database secret is not valid")
 	}
 
-	var pullPolicy corev1.PullPolicy
-	if mattermost.Spec.ImagePullPolicy != "" {
-		pullPolicy = mattermost.Spec.ImagePullPolicy
-	} else {
-		pullPolicy = corev1.PullIfNotPresent
-	}
-
 	var minioURL string
 	if mattermost.Spec.Minio.IsExternal() {
 		minioURL = mattermost.Spec.Minio.ExternalURL
@@ -211,7 +204,7 @@ func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *ma
 		}
 	}
 
-	desired := mattermostApp.GenerateDeployment(mattermost, dbInfo, resourceName, ingressName, saName, imageName, minioURL, pullPolicy)
+	desired := mattermostApp.GenerateDeployment(mattermost, dbInfo, resourceName, ingressName, saName, imageName, minioURL)
 
 	// TODO: DB setup job is temporarily disabled as `mattermost version` command
 	// does not account for the custom configuration

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -187,6 +187,13 @@ func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *ma
 		return errors.Wrap(err, "database secret is not valid")
 	}
 
+	var pullPolicy corev1.PullPolicy
+	if mattermost.Spec.ImagePullPolicy != "" {
+		pullPolicy = mattermost.Spec.ImagePullPolicy
+	} else {
+		pullPolicy = corev1.PullIfNotPresent
+	}
+
 	var minioURL string
 	if mattermost.Spec.Minio.IsExternal() {
 		minioURL = mattermost.Spec.Minio.ExternalURL
@@ -204,7 +211,7 @@ func (r *ClusterInstallationReconciler) checkMattermostDeployment(mattermost *ma
 		}
 	}
 
-	desired := mattermostApp.GenerateDeployment(mattermost, dbInfo, resourceName, ingressName, saName, imageName, minioURL)
+	desired := mattermostApp.GenerateDeployment(mattermost, dbInfo, resourceName, ingressName, saName, imageName, minioURL, pullPolicy)
 
 	// TODO: DB setup job is temporarily disabled as `mattermost version` command
 	// does not account for the custom configuration

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -98,7 +98,7 @@ func GenerateIngress(mattermost *mattermostv1alpha1.ClusterInstallation, name, i
 }
 
 // GenerateDeployment returns the deployment for Mattermost app.
-func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbInfo *database.Info, deploymentName, ingressName, serviceAccountName, containerImage string, minioURL string, ImagePullPolicy corev1.PullPolicy) *appsv1.Deployment {
+func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbInfo *database.Info, deploymentName, ingressName, serviceAccountName, containerImage string, minioURL string) *appsv1.Deployment {
 	var envVarDB []corev1.EnvVar
 
 	masterDBEnvVar := corev1.EnvVar{
@@ -383,7 +383,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 						{
 							Name:                     mattermostv1alpha1.MattermostAppContainerName,
 							Image:                    containerImage,
-							ImagePullPolicy:          ImagePullPolicy,
+							ImagePullPolicy:          mattermost.Spec.ImagePullPolicy,
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 							Command:                  []string{"mattermost"},
 							Env:                      envVars,

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -98,7 +98,7 @@ func GenerateIngress(mattermost *mattermostv1alpha1.ClusterInstallation, name, i
 }
 
 // GenerateDeployment returns the deployment for Mattermost app.
-func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbInfo *database.Info, deploymentName, ingressName, serviceAccountName, containerImage string, minioURL string) *appsv1.Deployment {
+func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbInfo *database.Info, deploymentName, ingressName, serviceAccountName, containerImage string, minioURL string, ImagePullPolicy corev1.PullPolicy) *appsv1.Deployment {
 	var envVarDB []corev1.EnvVar
 
 	masterDBEnvVar := corev1.EnvVar{
@@ -383,7 +383,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 						{
 							Name:                     mattermostv1alpha1.MattermostAppContainerName,
 							Image:                    containerImage,
-							ImagePullPolicy:          corev1.PullIfNotPresent,
+							ImagePullPolicy:          ImagePullPolicy,
 							TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 							Command:                  []string{"mattermost"},
 							Env:                      envVars,


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR lets the user choose the image pull policy of the mattermost deployment managed by the operator


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
```release-note
Add ImagePullPolicy to ClusterInstallation spec
```
