### PR TITLE
MM-29613 - Set MM_FILESETTINGS_AMAZONS3SSL to true when using external file store

### DIFF
--- a/pkg/mattermost/env_var.go
+++ b/pkg/mattermost/env_var.go
@@ -1,6 +1,10 @@
 package mattermost
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+)
 
 func generalMattermostEnvVars(siteURL string) []corev1.EnvVar {
 	return []corev1.EnvVar{
@@ -62,7 +66,7 @@ func fileStoreEnvVars(fileStore *FileStoreInfo) []corev1.EnvVar {
 		},
 		{
 			Name:  "MM_FILESETTINGS_AMAZONS3SSL",
-			Value: "false",
+			Value: strconv.FormatBool(fileStore.useS3SSL),
 		},
 	}
 }

--- a/pkg/mattermost/file_store.go
+++ b/pkg/mattermost/file_store.go
@@ -17,6 +17,7 @@ type FileStoreInfo struct {
 	secretName string
 	bucketName string
 	url        string
+	useS3SSL   bool
 	config     FileStoreConfig
 }
 
@@ -94,6 +95,7 @@ func NewExternalFileStoreInfo(mattermost *mmv1beta.Mattermost, secret corev1.Sec
 		secretName: secret.Name,
 		bucketName: bucket,
 		url:        url,
+		useS3SSL:   true,
 		config:     &ExternalFileStore{},
 	}, nil
 }
@@ -103,6 +105,7 @@ func NewOperatorManagedFileStoreInfo(mattermost *mmv1beta.Mattermost, secret, mi
 		secretName: secret,
 		bucketName: mattermost.Name,
 		url:        minioURL,
+		useS3SSL:   false,
 		config:     &OperatorManagedMinioConfig{minioURL: minioURL, secretName: secret},
 	}
 }

--- a/pkg/mattermost/file_store_test.go
+++ b/pkg/mattermost/file_store_test.go
@@ -34,6 +34,7 @@ func TestFileStore(t *testing.T) {
 		assert.Equal(t, secret, fileStore.secretName)
 		assert.Equal(t, minioURL, fileStore.url)
 		assert.Equal(t, "mm-test", fileStore.bucketName)
+		assert.Equal(t, false, fileStore.useS3SSL)
 	})
 
 	t.Run("external file store", func(t *testing.T) {
@@ -60,5 +61,6 @@ func TestFileStore(t *testing.T) {
 		assert.Equal(t, "external-file-store", fileStore.secretName)
 		assert.Equal(t, minioURL, fileStore.url)
 		assert.Equal(t, "test-bucket", fileStore.bucketName)
+		assert.Equal(t, true, fileStore.useS3SSL)
 	})
 }

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -197,6 +197,23 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 			requiredEnvVals: map[string]string{"MM_FILESETTINGS_AMAZONS3SSL": "false"},
 		},
 		{
+			name: "override envs set by default with ones in MM spec",
+			spec: mmv1beta.MattermostSpec{
+				MattermostEnv: []corev1.EnvVar{
+					{Name: "MM_FILESETTINGS_AMAZONS3SSL", Value: "false"},
+				},
+			},
+			fileStore: &FileStoreInfo{
+				secretName: "file-store-secret",
+				bucketName: "file-store-bucket",
+				url:        "s3.amazon.com",
+				useS3SSL:   true,
+				config:     &ExternalFileStore{},
+			},
+			want:            &appsv1.Deployment{},
+			requiredEnvVals: map[string]string{"MM_FILESETTINGS_AMAZONS3SSL": "false"},
+		},
+		{
 			name: "image pull policy",
 			spec: mmv1beta.MattermostSpec{
 				ImagePullPolicy: corev1.PullAlways,

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -104,12 +104,13 @@ func TestGenerateIngress_V1Beta(t *testing.T) {
 
 func TestGenerateDeployment_V1Beta(t *testing.T) {
 	tests := []struct {
-		name        string
-		spec        mmv1beta.MattermostSpec
-		database    DatabaseConfig
-		fileStore   *FileStoreInfo
-		want        *appsv1.Deployment
-		requiredEnv []string
+		name            string
+		spec            mmv1beta.MattermostSpec
+		database        DatabaseConfig
+		fileStore       *FileStoreInfo
+		want            *appsv1.Deployment
+		requiredEnv     []string
+		requiredEnvVals map[string]string
 	}{
 		{
 			name: "has license",
@@ -134,7 +135,7 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 					},
 				},
 			},
-			requiredEnv: []string{"MM_SERVICESETTINGS_LICENSEFILELOCATION"},
+			requiredEnvVals: map[string]string{"MM_SERVICESETTINGS_LICENSEFILELOCATION": "/mattermost-license/license"},
 		},
 		{
 			name:     "external database",
@@ -176,9 +177,24 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 				secretName: "file-store-secret",
 				bucketName: "file-store-bucket",
 				url:        "s3.amazon.com",
+				useS3SSL:   true,
 				config:     &ExternalFileStore{},
 			},
-			want: &appsv1.Deployment{},
+			want:            &appsv1.Deployment{},
+			requiredEnvVals: map[string]string{"MM_FILESETTINGS_AMAZONS3SSL": "true"},
+		},
+		{
+			name: "operator managed file store",
+			spec: mmv1beta.MattermostSpec{},
+			fileStore: &FileStoreInfo{
+				secretName: "file-store-secret",
+				bucketName: "file-store-bucket",
+				url:        "minio.local.com",
+				useS3SSL:   false,
+				config:     &OperatorManagedMinioConfig{},
+			},
+			want:            &appsv1.Deployment{},
+			requiredEnvVals: map[string]string{"MM_FILESETTINGS_AMAZONS3SSL": "false"},
 		},
 		{
 			name: "image pull policy",
@@ -367,12 +383,12 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 				},
 			},
 			want: &appsv1.Deployment{},
-			requiredEnv: []string{
-				"MM_ELASTICSEARCHSETTINGS_ENABLEINDEXING",
-				"MM_ELASTICSEARCHSETTINGS_ENABLESEARCHING",
-				"MM_ELASTICSEARCHSETTINGS_CONNECTIONURL",
-				"MM_ELASTICSEARCHSETTINGS_USERNAME",
-				"MM_ELASTICSEARCHSETTINGS_PASSWORD",
+			requiredEnvVals: map[string]string{
+				"MM_ELASTICSEARCHSETTINGS_ENABLEINDEXING":  "true",
+				"MM_ELASTICSEARCHSETTINGS_ENABLESEARCHING": "true",
+				"MM_ELASTICSEARCHSETTINGS_CONNECTIONURL":   "http://elastic",
+				"MM_ELASTICSEARCHSETTINGS_USERNAME":        "user",
+				"MM_ELASTICSEARCHSETTINGS_PASSWORD":        "password",
 			},
 		},
 	}
@@ -422,6 +438,10 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 				assertEnvVarExists(t, env, mattermostAppContainer.Env)
 			}
 
+			for env, val := range tt.requiredEnvVals {
+				assertEnvVarEqual(t, env, val, mattermostAppContainer.Env)
+			}
+
 			// External db check.
 			expectedInitContainers := 0 // Due to disabling DB setup job we start with 0 init containers
 
@@ -432,16 +452,13 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 						expectedInitContainers++
 					}
 				}
-				if externalDB.hasReaderEndpoints {
-					assertEnvVarExists(t, "MM_SQLSETTINGS_DATASOURCEREPLICAS", mattermostAppContainer.Env)
-				}
 			} else {
 				expectedInitContainers++
 				assertEnvVarExists(t, "MYSQL_USERNAME", mattermostAppContainer.Env)
 				assertEnvVarExists(t, "MYSQL_PASSWORD", mattermostAppContainer.Env)
 			}
 
-			if tt.fileStore == nil {
+			if _, ok := fileStoreInfo.config.(*OperatorManagedMinioConfig); ok {
 				expectedInitContainers += 2
 			}
 
@@ -499,4 +516,15 @@ func fixVolumeMount() corev1.VolumeMount {
 		Name:      "test-volume",
 		MountPath: "/etc/test",
 	}
+}
+
+func assertEnvVarEqual(t *testing.T, name, val string, env []corev1.EnvVar) {
+	for _, e := range env {
+		if e.Name == name {
+			assert.Equal(t, e.Value, val)
+			return
+		}
+	}
+
+	assert.Fail(t, fmt.Sprintf("failed to find env var %s", name))
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
`MM_FILESETTINGS_AMAZONS3SSL` will be set to `true` by default when using the external file store and to `false` in case Minio managed by the Minio Operator. User can still override it by explicitly setting `MM_FILESETTINGS_AMAZONS3SSL` in the Mattermost `spec.MattermostEnv` array.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-29613

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Breaking change: Set MM_FILESETTINGS_AMAZONS3SSL to true when using external file store
```
