### PR TITLE
Refactor mattermost ingress resource generation

### DIFF
--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -148,16 +148,7 @@ func (r *MattermostReconciler) checkMattermostRoleBinding(mattermost *mmv1beta.M
 }
 
 func (r *MattermostReconciler) checkMattermostIngress(mattermost *mmv1beta.Mattermost, reqLogger logr.Logger) error {
-	ingressAnnotations := map[string]string{
-		"kubernetes.io/ingress.class":                 "nginx",
-		"nginx.ingress.kubernetes.io/proxy-body-size": "1000M",
-	}
-	ingressHost := mattermost.Spec.IngressName
-	for k, v := range mattermost.Spec.IngressAnnotations {
-		ingressAnnotations[k] = v
-	}
-
-	desired := mattermostApp.GenerateIngressV1Beta(mattermost, mattermost.Name, ingressHost, ingressAnnotations)
+	desired := mattermostApp.GenerateIngressV1Beta(mattermost)
 
 	err := r.Resources.CreateIngressIfNotExists(mattermost, desired, reqLogger)
 	if err != nil {

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -90,7 +90,7 @@ func TestGenerateIngress_V1Beta(t *testing.T) {
 				Spec: tt.spec,
 			}
 
-			ingress := GenerateIngressV1Beta(mattermost, "", "", nil)
+			ingress := GenerateIngressV1Beta(mattermost)
 			require.NotNil(t, ingress)
 
 			if mattermost.Spec.UseIngressTLS {


### PR DESCRIPTION
This change contains a small amount of cleanup in the way that
ingress resources are generated.

Fixes https://mattermost.atlassian.net/browse/MM-32560

```release-note
Refactor mattermost ingress resource generation
```
