### PR TITLE
MM-32818 - Set default pathType in Ingress

### DIFF
--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -25,6 +25,8 @@ const (
 	WaitForDBSetupContainerName = "init-wait-for-db-setup"
 )
 
+var defaultIngressPathType = v1beta1.PathTypeImplementationSpecific
+
 // GenerateService returns the service for the Mattermost app.
 func GenerateService(mattermost *mattermostv1alpha1.ClusterInstallation, serviceName, selectorName string) *corev1.Service {
 	baseAnnotations := map[string]string{
@@ -76,6 +78,7 @@ func GenerateIngress(mattermost *mattermostv1alpha1.ClusterInstallation, name, i
 										ServiceName: name,
 										ServicePort: intstr.FromInt(8065),
 									},
+									PathType: &defaultIngressPathType,
 								},
 							},
 						},

--- a/pkg/mattermost/mattermost_test.go
+++ b/pkg/mattermost/mattermost_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"k8s.io/api/networking/v1beta1"
+
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 	"github.com/mattermost/mattermost-operator/pkg/database"
 	"github.com/mattermost/mattermost-operator/pkg/utils"
@@ -94,6 +96,8 @@ func TestGenerateIngress(t *testing.T) {
 
 			ingress := GenerateIngress(mattermost, "", "", nil)
 			require.NotNil(t, ingress)
+
+			assert.Equal(t, v1beta1.PathTypeImplementationSpecific, *ingress.Spec.Rules[0].HTTP.Paths[0].PathType)
 
 			if mattermost.Spec.UseIngressTLS {
 				assert.NotNil(t, ingress.Spec.TLS)

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -116,6 +116,7 @@ func GenerateIngressV1Beta(mattermost *mmv1beta.Mattermost) *v1beta1.Ingress {
 										ServiceName: mattermost.Name,
 										ServicePort: intstr.FromInt(8065),
 									},
+									PathType: &defaultIngressPathType,
 								},
 							},
 						},

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"k8s.io/api/networking/v1beta1"
+
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/mattermost/mattermost-operator/pkg/database"
 	"github.com/mattermost/mattermost-operator/pkg/utils"
@@ -92,6 +94,8 @@ func TestGenerateIngress_V1Beta(t *testing.T) {
 
 			ingress := GenerateIngressV1Beta(mattermost)
 			require.NotNil(t, ingress)
+
+			assert.Equal(t, v1beta1.PathTypeImplementationSpecific, *ingress.Spec.Rules[0].HTTP.Paths[0].PathType)
 
 			if mattermost.Spec.UseIngressTLS {
 				assert.NotNil(t, ingress.Spec.TLS)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
As of Kubernetes 1.18 the default `pathType` in Ingress is set automatically, which causes the Operator to update it every time the resource is reconciled.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-32818

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Set Ingress `pathType` to `ImplementationSpecific` for Ingress resource.
```
