### PR TITLE
Bump default Mattermost version to 5.34.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ SHADOW_BIN := shadow
 SHADOW_VER := master
 SHADOW_GEN := $(TOOLS_BIN_DIR)/$(SHADOW_BIN)
 
-OPENAPI_VER := master
+OPENAPI_VER := release-1.18
 OPENAPI_BIN := openapi-gen
 OPENAPI_GEN := $(TOOLS_BIN_DIR)/$(OPENAPI_BIN)
 

--- a/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -15,7 +15,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "5.28.0"
+	DefaultMattermostVersion = "5.34.2"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/apis/mattermost/v1alpha1/zz_generated.openapi.go
+++ b/apis/mattermost/v1alpha1/zz_generated.openapi.go
@@ -47,21 +47,18 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallation(ref
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the Mattermost cluster. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.ClusterInstallationSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recent observed status of the Mattermost cluster. Read-only. Not included when requesting from the apiserver, only from the Mattermost Operator API itself. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#spec-and-status",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.ClusterInstallationStatus"),
 						},
 					},
@@ -112,14 +109,12 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 					"resources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Defines the resource requests and limits for the Mattermost app server pods.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ResourceRequirements"),
 						},
 					},
 					"ingressName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "IngressName defines the name to be used when creating the ingress rules",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -139,9 +134,8 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -155,32 +149,27 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 					},
 					"minio": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Minio"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Minio"),
 						},
 					},
 					"database": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Database"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Database"),
 						},
 					},
 					"blueGreen": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.BlueGreen"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.BlueGreen"),
 						},
 					},
 					"canary": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Canary"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.Canary"),
 						},
 					},
 					"elasticSearch": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.ElasticSearch"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.ElasticSearch"),
 						},
 					},
 					"useServiceLoadBalancer": {
@@ -196,9 +185,8 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -217,9 +205,8 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -232,9 +219,8 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -247,8 +233,7 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -257,14 +242,12 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_ClusterInstallationSpec
 					"livenessProbe": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Defines the probe to check if the application is up and running.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
 					"readinessProbe": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Defines the probe to check if the application is ready to accept traffic.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.Probe"),
 						},
 					},
@@ -314,20 +297,17 @@ func schema_mattermost_operator_apis_mattermost_v1alpha1_MattermostRestoreDB(ref
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.MattermostRestoreDBSpec"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.MattermostRestoreDBSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.MattermostRestoreDBStatus"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1.MattermostRestoreDBStatus"),
 						},
 					},
 				},

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -18,7 +18,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "5.28.0"
+	DefaultMattermostVersion = "5.34.2"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/apis/mattermost/v1beta1/zz_generated.openapi.go
+++ b/apis/mattermost/v1beta1/zz_generated.openapi.go
@@ -44,20 +44,17 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_Mattermost(ref common.Re
 					},
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
 						},
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.MattermostSpec"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.MattermostSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.MattermostStatus"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.MattermostStatus"),
 						},
 					},
 				},
@@ -110,8 +107,7 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.EnvVar"),
+										Ref: ref("k8s.io/api/core/v1.EnvVar"),
 									},
 								},
 							},
@@ -127,7 +123,6 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 					"ingressName": {
 						SchemaProps: spec.SchemaProps{
 							Description: "IngressName defines the name to be used when creating the ingress rules",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -139,9 +134,8 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -166,9 +160,8 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -181,9 +174,8 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: "",
-										Type:    []string{"string"},
-										Format:  "",
+										Type:   []string{"string"},
+										Format: "",
 									},
 								},
 							},
@@ -196,8 +188,7 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.Volume"),
+										Ref: ref("k8s.io/api/core/v1.Volume"),
 									},
 								},
 							},
@@ -210,8 +201,7 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.VolumeMount"),
+										Ref: ref("k8s.io/api/core/v1.VolumeMount"),
 									},
 								},
 							},
@@ -231,8 +221,7 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("k8s.io/api/core/v1.LocalObjectReference"),
+										Ref: ref("k8s.io/api/core/v1.LocalObjectReference"),
 									},
 								},
 							},
@@ -241,33 +230,28 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 					"database": {
 						SchemaProps: spec.SchemaProps{
 							Description: "External Services",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.Database"),
 						},
 					},
 					"fileStore": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.FileStore"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.FileStore"),
 						},
 					},
 					"elasticSearch": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.ElasticSearch"),
+							Ref: ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.ElasticSearch"),
 						},
 					},
 					"scheduling": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Scheduling defines the configuration related to scheduling of the Mattermost pods as well as resource constraints. These settings generally don't need to be changed.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.Scheduling"),
 						},
 					},
 					"probes": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Probes defines configuration of liveness and readiness probe for Mattermost pods. These settings generally don't need to be changed.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.Probes"),
 						},
 					},


### PR DESCRIPTION
Just catching us up.

Fixes https://mattermost.atlassian.net/browse/MM-35442

```release-note
Bump default Mattermost version to 5.34.2
```
