### PR TITLE
MM-35994 - Expose Mattermost Operator metrics

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,11 +24,35 @@ spec:
         - /mattermost-operator
         args:
         - --enable-leader-election
+        - --metrics-addr=0.0.0.0:8383
         image: mattermost-operator
         imagePullPolicy: IfNotPresent
         name: mattermost-operator
+        ports:
+          - containerPort: 8383
+            name: metrics
         env:
           - name: "MAX_RECONCILING_INSTALLATIONS"
             value: "20"
           - name: "REQUEUE_ON_LIMIT_DELAY"
             value: "20s"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app: mattermost-operator
+    name: mattermost-operator
+  name: mattermost-operator
+spec:
+  ports:
+    - name: metrics
+      port: 8383
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    name: mattermost-operator
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR adds a Service exposing Mattermost Operator metrics.

Controller Runtime library provides a lot of metrics out of the box but they currently were not accessible for other services like Prometheus. 

Metrics can be accessed under `/metrics` path.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-35994

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Expose Mattermost Operator metrics
```
