### PR TITLE
MM-36993 - Cleanup Mattermost Operator RBAC role

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,20 +8,7 @@ rules:
       - ""
     resources:
       - pods
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods
       - services
-      - endpoints
-      - persistentvolumeclaims
-      - events
       - configmaps
       - secrets
       - serviceaccounts
@@ -43,11 +30,34 @@ rules:
       - apps
     resources:
       - deployments
-      - daemonsets
-      - replicasets
-      - statefulsets
     verbs:
       - '*'
+  - apiGroups:
+      - apps
+    resourceNames:
+      - mattermost-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - create
+      - list
+      - delete
+      - watch
+      - update
   - apiGroups:
       - networking.k8s.io
     resources:
@@ -67,26 +77,9 @@ rules:
       - watch
       - update
   - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - create
-  - apiGroups:
-      - apps
-    resourceNames:
-      - mattermost-operator
-    resources:
-      - deployments/finalizers
-    verbs:
-      - update
-  - apiGroups:
       - mattermost.com
     resources:
       - '*'
-      - clusterinstallations
-      - mattermostrestoredbs
     verbs:
       - '*'
   - apiGroups:
@@ -99,17 +92,6 @@ rules:
       - mysql.presslabs.org
     resources:
       - mysqlbackups
-    verbs:
-      - get
-      - list
-      - watch
-      - create
-      - update
-      - patch
-      - delete
-  - apiGroups:
-      - mysql.presslabs.org
-    resources:
       - mysqlclusters
       - mysqlclusters/status
     verbs:
@@ -123,33 +105,13 @@ rules:
   - apiGroups:
       - miniocontroller.min.io
     resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - minio.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
+      - minioinstances
+      - minioinstances/status
     verbs:
       - get
-      - create
       - list
-      - delete
       - watch
-      - update
-  - apiGroups:
-      - certificates.k8s.io
-    resources:
-      - certificatesigningrequests
-      - certificatesigningrequests/approval
-      - certificatesigningrequests/status
-    verbs:
-      - update
       - create
-      - get
+      - update
+      - patch
+      - delete


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Mattermost Operator RBAC role holds some no longer necessary permissions as well as some duplicated ones.
This PR cleans it up sightly.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-36993

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Cleanup Mattermost Operator RBAC role
```
