### PR TITLE
Set Observed Generation status value

### DIFF
--- a/apis/mattermost/v1beta1/mattermost_types.go
+++ b/apis/mattermost/v1beta1/mattermost_types.go
@@ -260,6 +260,9 @@ type MattermostStatus struct {
 	// that are running with the desired image.
 	// +optional
 	UpdatedReplicas int32 `json:"updatedReplicas,omitempty"`
+	// The last observed Generation of the Mattermost resource that was acted on.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +genclient

--- a/config/crd/bases/installation.mattermost.com_mattermosts.yaml
+++ b/config/crd/bases/installation.mattermost.com_mattermosts.yaml
@@ -1795,6 +1795,10 @@ spec:
               image:
                 description: The image running on the pods in the Mattermost instance
                 type: string
+              observedGeneration:
+                description: The last observed Generation of the Mattermost resource that was acted on.
+                format: int64
+                type: integer
               replicas:
                 description: Total number of non-terminated pods targeted by this Mattermost deployment
                 format: int32

--- a/controllers/mattermost/mattermost/controller.go
+++ b/controllers/mattermost/mattermost/controller.go
@@ -96,6 +96,9 @@ func (r *MattermostReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		}
 	}
 
+	// Indicate that the newest generation of the resource has been observed.
+	mattermost.Status.ObservedGeneration = mattermost.Generation
+
 	// Set a new Mattermost's state to reconciling.
 	if len(mattermost.Status.State) == 0 {
 		err = r.setStateReconciling(mattermost, reqLogger)

--- a/controllers/mattermost/mattermost/health_check.go
+++ b/controllers/mattermost/mattermost/health_check.go
@@ -18,9 +18,10 @@ import (
 // should be. Over time, more types of checks should be added here as needed.
 func (r *MattermostReconciler) checkMattermostHealth(mattermost *mmv1beta.Mattermost, logger logr.Logger) (mmv1beta.MattermostStatus, error) {
 	status := mmv1beta.MattermostStatus{
-		State:           mmv1beta.Reconciling,
-		Replicas:        0,
-		UpdatedReplicas: 0,
+		State:              mmv1beta.Reconciling,
+		ObservedGeneration: mattermost.Generation,
+		Replicas:           0,
+		UpdatedReplicas:    0,
 	}
 
 	labels := mattermost.MattermostLabels(mattermost.Name)


### PR DESCRIPTION
This change adds an observed generation value to the status object
of the v1beta1 mattermost resource. This value can be used to
determine if the controller has taken action on the latest
generation of the resource or not when the resource state is stable.

This can be used by external clients to ensure that the desired
changes have been properly applied which will avoid possible
race conditions.

Fixes https://mattermost.atlassian.net/browse/MM-37903

```release-note
Set Observed Generation status value
```
