### PR TITLE
Update Ingress APIs to work with Kubernetes 1.22

### DIFF
--- a/controllers/mattermost/clusterinstallation/controller.go
+++ b/controllers/mattermost/clusterinstallation/controller.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -47,7 +47,7 @@ func (r *ClusterInstallationReconciler) SetupWithManager(mgr ctrl.Manager) error
 		For(&mattermostv1alpha1.ClusterInstallation{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
-		Owns(&v1beta1.Ingress{}).
+		Owns(&networkingv1.Ingress{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&batchv1.Job{}).
 		Complete(r)

--- a/controllers/mattermost/clusterinstallation/controller_test.go
+++ b/controllers/mattermost/clusterinstallation/controller_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -121,7 +121,7 @@ func TestReconcile(t *testing.T) {
 			require.NoError(t, err)
 		})
 		t.Run("ingress", func(t *testing.T) {
-			ingress := &v1beta1.Ingress{}
+			ingress := &networkingv1.Ingress{}
 			err = c.Get(context.TODO(), ciKey, ingress)
 			require.NoError(t, err)
 		})
@@ -458,8 +458,8 @@ func TestReconcile(t *testing.T) {
 				assert.True(t, k8sErrors.IsNotFound(err))
 			})
 			t.Run("ingress", func(t *testing.T) {
-				blueIngress := &v1beta1.Ingress{}
-				greenIngress := &v1beta1.Ingress{}
+				blueIngress := &networkingv1.Ingress{}
+				greenIngress := &networkingv1.Ingress{}
 				err = c.Get(context.TODO(), blueKey, blueIngress)
 				require.Error(t, err)
 				assert.True(t, k8sErrors.IsNotFound(err))

--- a/controllers/mattermost/clusterinstallation/mattermost.go
+++ b/controllers/mattermost/clusterinstallation/mattermost.go
@@ -13,7 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -154,7 +154,7 @@ func (r *ClusterInstallationReconciler) checkMattermostIngress(mattermost *matte
 		return err
 	}
 
-	current := &v1beta1.Ingress{}
+	current := &networkingv1.Ingress{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
 	if err != nil {
 		return err
@@ -277,7 +277,7 @@ func (r *ClusterInstallationReconciler) deleteMattermostService(mattermost *matt
 }
 
 func (r *ClusterInstallationReconciler) deleteMattermostIngress(mattermost *mattermostv1alpha1.ClusterInstallation, resourceName string, reqLogger logr.Logger) error {
-	return r.deleteMattermostResource(mattermost, resourceName, &v1beta1.Ingress{}, reqLogger)
+	return r.deleteMattermostResource(mattermost, resourceName, &networkingv1.Ingress{}, reqLogger)
 }
 
 func (r *ClusterInstallationReconciler) deleteMattermostResource(mattermost *mattermostv1alpha1.ClusterInstallation, resourceName string, resource k8sClient.Object, reqLogger logr.Logger) error {

--- a/controllers/mattermost/clusterinstallation/mattermost_test.go
+++ b/controllers/mattermost/clusterinstallation/mattermost_test.go
@@ -19,7 +19,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/networking/v1beta1"
+	v1beta1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/controllers/mattermost/mattermost/controller.go
+++ b/controllers/mattermost/mattermost/controller.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -54,7 +54,7 @@ func (r *MattermostReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&mmv1beta.Mattermost{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
-		Owns(&v1beta1.Ingress{}).
+		Owns(&networkingv1.Ingress{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&batchv1.Job{}).
 		Complete(r)

--- a/controllers/mattermost/mattermost/controller_test.go
+++ b/controllers/mattermost/mattermost/controller_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -85,7 +85,7 @@ func TestReconcile(t *testing.T) {
 	// watched resource .
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: mmName, Namespace: mmNamespace}}
 	// Run Reconcile
-	// We expect an error on the first reconciliation due to the deployment pods
+	// We expect health check delay on the first reconciliation due to the deployment pods
 	// not running yet.
 	res, err := r.Reconcile(context.Background(), req)
 	require.NoError(t, err)
@@ -127,7 +127,7 @@ func TestReconcile(t *testing.T) {
 			require.NoError(t, err)
 		})
 		t.Run("ingress", func(t *testing.T) {
-			ingress := &v1beta1.Ingress{}
+			ingress := &networkingv1.Ingress{}
 			err = c.Get(context.TODO(), mmKey, ingress)
 			require.NoError(t, err)
 		})

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -13,7 +13,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -155,7 +155,7 @@ func (r *MattermostReconciler) checkMattermostIngress(mattermost *mmv1beta.Matte
 		return err
 	}
 
-	current := &v1beta1.Ingress{}
+	current := &networkingv1.Ingress{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
 	if err != nil {
 		return err

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -21,7 +21,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/networking/v1beta1"
+	v1beta1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"

--- a/pkg/mattermost/healthcheck/health_check.go
+++ b/pkg/mattermost/healthcheck/health_check.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -145,7 +145,7 @@ func (hc *HealthChecker) CheckServiceLoadBalancer() (string, error) {
 }
 
 func (hc *HealthChecker) CheckIngressLoadBalancer() (string, error) {
-	ingress := &v1beta1.IngressList{
+	ingress := &networkingv1.IngressList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
 			APIVersion: "v1",

--- a/pkg/mattermost/mattermost_test.go
+++ b/pkg/mattermost/mattermost_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 
 	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 	"github.com/mattermost/mattermost-operator/pkg/database"
@@ -97,7 +97,7 @@ func TestGenerateIngress(t *testing.T) {
 			ingress := GenerateIngress(mattermost, "", "", nil)
 			require.NotNil(t, ingress)
 
-			assert.Equal(t, v1beta1.PathTypeImplementationSpecific, *ingress.Spec.Rules[0].HTTP.Paths[0].PathType)
+			assert.Equal(t, networkingv1.PathTypeImplementationSpecific, *ingress.Spec.Rules[0].HTTP.Paths[0].PathType)
 
 			if mattermost.Spec.UseIngressTLS {
 				assert.NotNil(t, ingress.Spec.TLS)

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/mattermost/mattermost-operator/pkg/database"
@@ -95,7 +95,7 @@ func TestGenerateIngress_V1Beta(t *testing.T) {
 			ingress := GenerateIngressV1Beta(mattermost)
 			require.NotNil(t, ingress)
 
-			assert.Equal(t, v1beta1.PathTypeImplementationSpecific, *ingress.Spec.Rules[0].HTTP.Paths[0].PathType)
+			assert.Equal(t, networkingv1.PathTypeImplementationSpecific, *ingress.Spec.Rules[0].HTTP.Paths[0].PathType)
 
 			if mattermost.Spec.UseIngressTLS {
 				assert.NotNil(t, ingress.Spec.TLS)

--- a/pkg/resources/create_resources.go
+++ b/pkg/resources/create_resources.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -121,8 +121,8 @@ func (r *ResourceHelper) CreateServiceIfNotExists(owner v1.Object, service *core
 	return nil
 }
 
-func (r *ResourceHelper) CreateIngressIfNotExists(owner v1.Object, ingress *v1beta1.Ingress, reqLogger logr.Logger) error {
-	foundIngress := &v1beta1.Ingress{}
+func (r *ResourceHelper) CreateIngressIfNotExists(owner v1.Object, ingress *networkingv1.Ingress, reqLogger logr.Logger) error {
+	foundIngress := &networkingv1.Ingress{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: ingress.Name, Namespace: ingress.Namespace}, foundIngress)
 	if err != nil && k8sErrors.IsNotFound(err) {
 		reqLogger.Info("Creating ingress", "name", ingress.Name)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This PR updates K8s APIs for Ingress that are being removed in version 1.22.

There are still issues with MySQL and MinIO operators, but we should decide how to proceed with those separately.

I have tested the change on 1.20 (AWS kops cluster) and 1.22 (Kind) but we should do more throughout testing on release.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-38114

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Update Ingress APIs to work with Kubernetes 1.22
```
