### PR TITLE
Do not set SiteURL if ingress host is not provided

### DIFF
--- a/pkg/mattermost/env_var.go
+++ b/pkg/mattermost/env_var.go
@@ -7,11 +7,7 @@ import (
 )
 
 func generalMattermostEnvVars(siteURL string) []corev1.EnvVar {
-	return []corev1.EnvVar{
-		{
-			Name:  "MM_SERVICESETTINGS_SITEURL",
-			Value: siteURL,
-		},
+	envs := []corev1.EnvVar{
 		{
 			Name:  "MM_PLUGINSETTINGS_ENABLEUPLOADS",
 			Value: "true",
@@ -37,6 +33,15 @@ func generalMattermostEnvVars(siteURL string) []corev1.EnvVar {
 			Value: "kubernetes-operator",
 		},
 	}
+
+	if siteURL != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "MM_SERVICESETTINGS_SITEURL",
+			Value: siteURL,
+		})
+	}
+
+	return envs
 }
 
 func fileStoreEnvVars(fileStore *FileStoreInfo) []corev1.EnvVar {

--- a/pkg/mattermost/helpers.go
+++ b/pkg/mattermost/helpers.go
@@ -1,6 +1,7 @@
 package mattermost
 
 import (
+	"fmt"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -131,4 +132,11 @@ func setProbes(customLiveness, customReadiness corev1.Probe) (*corev1.Probe, *co
 	}
 
 	return liveness, readiness
+}
+
+func siteURLFromHost(ingressHost string) string {
+	if ingressHost != "" {
+		return fmt.Sprintf("https://%s", ingressHost)
+	}
+	return ""
 }

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -307,8 +307,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 		)
 	}
 
-	siteURL := fmt.Sprintf("https://%s", ingressName)
-	envVarGeneral := generalMattermostEnvVars(siteURL)
+	envVarGeneral := generalMattermostEnvVars(siteURLFromHost(ingressName))
 
 	valueSize := strconv.Itoa(defaultMaxFileSize * sizeMB)
 	if !mattermost.Spec.UseServiceLoadBalancer {

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -1,7 +1,6 @@
 package mattermost
 
 import (
-	"fmt"
 	"strconv"
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
@@ -157,7 +156,7 @@ func GenerateIngressV1Beta(mattermost *mmv1beta.Mattermost) *networkingv1.Ingres
 }
 
 // GenerateDeploymentV1Beta returns the deployment for Mattermost app.
-func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig, fileStore *FileStoreInfo, deploymentName, ingressName, serviceAccountName, containerImage string) *appsv1.Deployment {
+func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig, fileStore *FileStoreInfo, deploymentName, ingressHost, serviceAccountName, containerImage string) *appsv1.Deployment {
 	// DB
 	envVarDB := db.EnvVars(mattermost)
 	initContainers := db.InitContainers(mattermost)
@@ -187,8 +186,7 @@ func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig
 	}
 
 	// General settings
-	siteURL := fmt.Sprintf("https://%s", ingressName)
-	envVarGeneral := generalMattermostEnvVars(siteURL)
+	envVarGeneral := generalMattermostEnvVars(siteURLFromHost(ingressHost))
 
 	// Determine max file size
 	bodySize := strconv.Itoa(defaultMaxFileSize * sizeMB)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
The issue manifests when Ingress is disabled or a Service LoadBalancer is used.

We should not set `MM_SERVICESETTINGS_SITEURL` env var when ingress host is not provided as this prevents MM from working properly.

Instead, the `SiteURL` will not be set which results in prompting the administrator to set it in System Console.
The `SiteURL` can still be set in the manifest by explicitly providing env var.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/MM-39871

Fixes #261

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Do not set SiteURL if ingress host is not provided
```
