### PR TITLE
Add `appProtocol` to Service Creation

### DIFF
--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -54,14 +54,16 @@ func GenerateServiceV1Beta(mattermost *mmv1beta.Mattermost) *corev1.Service {
 func configureMattermostLoadBalancerService(service *corev1.Service) *corev1.Service {
 	service.Spec.Ports = []corev1.ServicePort{
 		{
-			Name:       "http",
-			Port:       80,
-			TargetPort: intstr.FromString("app"),
+			Name:        "http",
+			Port:        80,
+			AppProtocol: pkgUtils.NewString("http"),
+			TargetPort:  intstr.FromString("app"),
 		},
 		{
-			Name:       "https",
-			Port:       443,
-			TargetPort: intstr.FromString("app"),
+			Name:        "https",
+			Port:        443,
+			AppProtocol: pkgUtils.NewString("https"),
+			TargetPort:  intstr.FromString("app"),
 		},
 	}
 	service.Spec.Type = corev1.ServiceTypeLoadBalancer
@@ -72,14 +74,16 @@ func configureMattermostLoadBalancerService(service *corev1.Service) *corev1.Ser
 func configureMattermostService(service *corev1.Service) *corev1.Service {
 	service.Spec.Ports = []corev1.ServicePort{
 		{
-			Port:       8065,
-			Name:       "http-app",
-			TargetPort: intstr.FromString("app"),
+			Port:        8065,
+			Name:        "app",
+			AppProtocol: pkgUtils.NewString("http"),
+			TargetPort:  intstr.FromString("app"),
 		},
 		{
-			Port:       8067,
-			Name:       "http-metrics",
-			TargetPort: intstr.FromString("metrics"),
+			Port:        8067,
+			Name:        "metrics",
+			AppProtocol: pkgUtils.NewString("http"),
+			TargetPort:  intstr.FromString("metrics"),
 		},
 	}
 	service.Spec.ClusterIP = corev1.ClusterIPNone

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -56,12 +56,12 @@ func configureMattermostLoadBalancerService(service *corev1.Service) *corev1.Ser
 		{
 			Name:       "http",
 			Port:       80,
-			TargetPort: intstr.FromString("app"),
+			TargetPort: intstr.FromString("http-app"),
 		},
 		{
 			Name:       "https",
 			Port:       443,
-			TargetPort: intstr.FromString("app"),
+			TargetPort: intstr.FromString("http-app"),
 		},
 	}
 	service.Spec.Type = corev1.ServiceTypeLoadBalancer
@@ -73,13 +73,13 @@ func configureMattermostService(service *corev1.Service) *corev1.Service {
 	service.Spec.Ports = []corev1.ServicePort{
 		{
 			Port:       8065,
-			Name:       "app",
-			TargetPort: intstr.FromString("app"),
+			Name:       "http-app",
+			TargetPort: intstr.FromString("http-app"),
 		},
 		{
 			Port:       8067,
-			Name:       "metrics",
-			TargetPort: intstr.FromString("metrics"),
+			Name:       "http-metrics",
+			TargetPort: intstr.FromString("http-metrics"),
 		},
 	}
 	service.Spec.ClusterIP = corev1.ClusterIPNone
@@ -266,11 +266,11 @@ func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8065,
-									Name:          "app",
+									Name:          "http-app",
 								},
 								{
 									ContainerPort: 8067,
-									Name:          "metrics",
+									Name:          "http-metrics",
 								},
 							},
 							ReadinessProbe: readiness,

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -56,12 +56,12 @@ func configureMattermostLoadBalancerService(service *corev1.Service) *corev1.Ser
 		{
 			Name:       "http",
 			Port:       80,
-			TargetPort: intstr.FromString("http-app"),
+			TargetPort: intstr.FromString("app"),
 		},
 		{
 			Name:       "https",
 			Port:       443,
-			TargetPort: intstr.FromString("http-app"),
+			TargetPort: intstr.FromString("app"),
 		},
 	}
 	service.Spec.Type = corev1.ServiceTypeLoadBalancer
@@ -74,12 +74,12 @@ func configureMattermostService(service *corev1.Service) *corev1.Service {
 		{
 			Port:       8065,
 			Name:       "http-app",
-			TargetPort: intstr.FromString("http-app"),
+			TargetPort: intstr.FromString("app"),
 		},
 		{
 			Port:       8067,
 			Name:       "http-metrics",
-			TargetPort: intstr.FromString("http-metrics"),
+			TargetPort: intstr.FromString("metrics"),
 		},
 	}
 	service.Spec.ClusterIP = corev1.ClusterIPNone
@@ -266,11 +266,11 @@ func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8065,
-									Name:          "http-app",
+									Name:          "app",
 								},
 								{
 									ContainerPort: 8067,
-									Name:          "http-metrics",
+									Name:          "metrics",
 								},
 							},
 							ReadinessProbe: readiness,

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -45,7 +45,7 @@ func TestGenerateService_V1Beta(t *testing.T) {
 				if *port.AppProtocol == *appProtocol {
 					return
 				}
-				assert.Fail(t, fmt.Sprintf("failed to find correct appProtocol %s on service, service had %s", *appProtocol, *port.AppProtocol))
+				assert.Fail(t, fmt.Sprintf("failed to find appProtocol %s on port %d", *appProtocol, portNumber))
 			}
 		}
 		assert.Fail(t, fmt.Sprintf("failed to find port %d on service", portNumber))

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -38,11 +38,14 @@ func TestGenerateService_V1Beta(t *testing.T) {
 		},
 	}
 
-	expectPort := func(t *testing.T, service *corev1.Service, portNumber int32) {
+	expectPort := func(t *testing.T, service *corev1.Service, portNumber int32, appProtocol *string) {
 		t.Helper()
 		for _, port := range service.Spec.Ports {
 			if port.Port == portNumber {
-				return
+				if *port.AppProtocol == *appProtocol {
+					return
+				}
+				assert.Fail(t, fmt.Sprintf("failed to find correct appProtocol %s on service, service had %s", *appProtocol, *port.AppProtocol))
 			}
 		}
 		assert.Fail(t, fmt.Sprintf("failed to find port %d on service", portNumber))
@@ -59,11 +62,11 @@ func TestGenerateService_V1Beta(t *testing.T) {
 
 			if mattermost.Spec.UseServiceLoadBalancer {
 				assert.Equal(t, service.Spec.Type, corev1.ServiceTypeLoadBalancer)
-				expectPort(t, service, 80)
-				expectPort(t, service, 443)
+				expectPort(t, service, 80, utils.NewString("http"))
+				expectPort(t, service, 443, utils.NewString("https"))
 			} else {
-				expectPort(t, service, 8065)
-				expectPort(t, service, 8067)
+				expectPort(t, service, 8065, utils.NewString("http"))
+				expectPort(t, service, 8067, utils.NewString("http"))
 			}
 		})
 	}


### PR DESCRIPTION
#### Summary

Adds `appProtocol` to the service definition which helps especially with Istio injection so that sidecars know the right protocol.

#### Ticket Link

Fixes #266 

#### Release Note

```release-note
Service is now created with appProtocol defined
```