### PR TITLE
Add e2e tests for external DB and file-store configuration

### DIFF
--- a/resources/minio.yaml
+++ b/resources/minio.yaml
@@ -1,0 +1,95 @@
+# This file contains MinIO manifest than can be applied locally in the cluster and
+# treated as an external file store for Mattermost instance.
+# This manifest is prepared for development and testing purposes and should not be used in production environment.
+
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:RELEASE.2021-10-27T16-29-42Z
+          args: ['server', '/data', '--console-address', ':9001']
+          ports:
+            - name: minio
+              containerPort: 9000
+          volumeMounts:
+            - name: s3-pv-storage
+              mountPath: /data
+          env:
+            - name: MINIO_SERVER_URL
+              value: https://minio.example.com
+            - name: MINIO_BROWSER_REDIRECT_URL
+              value: https://console.minio.example.com
+            - name: MINIO_IDENTITY_OPENID_CONFIG_URL
+              value: https://keycloak.example.com/auth/realms/home/.well-known/openid-configuration
+            - name: MINIO_IDENTITY_OPENID_CLIENT_ID
+              value: minio
+            - name: MINIO_IDENTITY_OPENID_CLIENT_SECRET
+              value: secret
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio
+                  key: MINIO_ROOT_USER
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio
+                  key: MINIO_ROOT_PASSWORD
+      volumes:
+        - name: s3-pv-storage
+          hostPath:
+            path: /minio-data
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - protocol: TCP
+      name: minio
+      port: 9000
+    - protocol: TCP
+      name: minio-console
+      port: 9001
+  selector:
+    app: minio
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-pvc
+spec:
+  storageClassName: local-path
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio
+  labels:
+    app: minio
+data:
+  MINIO_ROOT_USER: bXktYWNjZXNzLWtleQ==
+  MINIO_ROOT_PASSWORD: bXlYWFh4eHgvc2VjcmV0WFhYWHh4eC9rZXlYWHh4eA==

--- a/resources/mm-secrets.yaml
+++ b/resources/mm-secrets.yaml
@@ -1,0 +1,19 @@
+# Secrets that can be referenced in Mattermost CR.
+
+apiVersion: v1
+data:
+  DB_CONNECTION_STRING: cG9zdGdyZXM6Ly9wb3N0Z3JlczpwYXNzd29yZEBwb3N0Z3Jlc3FsOjU0MzIvcG9zdGdyZXM/c3NsbW9kZT1kaXNhYmxl
+kind: Secret
+metadata:
+  name: db-credentials
+type: Opaque
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: file-store-credentials
+type: Opaque
+data:
+  accesskey: bXktYWNjZXNzLWtleQ==
+  secretkey: bXlYWFh4eHgvc2VjcmV0WFhYWHh4eC9rZXlYWHh4eA==

--- a/resources/postgres.yaml
+++ b/resources/postgres.yaml
@@ -1,0 +1,86 @@
+# This file contains Postgres manifest than can be applied locally in the cluster and
+# treated as an external database for Mattermost instance.
+# This manifest is prepared for development and testing purposes and should not be used in production environment.
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgresql
+  labels:
+    app: postgres
+    tier: postgreSQL
+spec:
+  ports:
+    - port: 5432
+  selector:
+    app: postgres
+    tier: postgreSQL
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-claim
+  labels:
+    app: postgres
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  labels:
+    app: postgres
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: postgres
+      tier: postgreSQL
+  template:
+    metadata:
+      labels:
+        app: postgres
+        tier: postgreSQL
+    spec:
+      containers:
+        - image: postgres:12-alpine
+          name: postgresql
+          env:
+            - name: POSTGRES_USER
+              value: postgres
+            - name: POSTGRES_DB
+              value: postgres
+            - name: POSTGRES_PASSWORD
+              value: password
+          ports:
+            - containerPort: 5432
+              name: postgresql
+          volumeMounts:
+            - name: postgresql
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgresql
+          emptyDir: {}
+
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: local-volume-1
+  labels:
+    type: local
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /tmp/data/pv-1
+  persistentVolumeReclaimPolicy: Recycle

--- a/test/e2e-external/apply_resource.go
+++ b/test/e2e-external/apply_resource.go
@@ -1,0 +1,107 @@
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+
+	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func CreateFromFile(ctx context.Context, k8sClient client.Client, namespace, path string) (func(), error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return func() {}, errors.Wrap(err, "failed to read file content")
+	}
+
+	content = filterCommentsAndEmptyLines(content)
+	resources := bytes.Split(content, []byte("\n---"))
+
+	decoder, err := defaultDecoder()
+	if err != nil {
+		return func() {}, errors.Wrap(err, "failed to initialize decoder")
+	}
+
+	objects := []client.Object{}
+
+	for _, res := range resources {
+		if len(res) == 0 {
+			continue
+		}
+
+		runtimeObject, _, err := decoder.Decode(res, nil, nil)
+		if err != nil {
+			return func() {}, errors.Wrap(err, "failed to decode runtimeObject")
+		}
+
+		object, ok := runtimeObject.(client.Object)
+		if !ok {
+			return func() {}, errors.New("failed to get runtimeObject metadata")
+		}
+
+		object.SetNamespace(namespace)
+
+		err = k8sClient.Create(ctx, object)
+		if err != nil {
+			return func() {}, errors.Wrap(err, "failed to apply runtimeObject")
+		}
+
+		objects = append(objects, object)
+	}
+
+	cleanup := func() {
+		for _, obj := range objects {
+			_ = k8sClient.Delete(context.Background(), obj)
+		}
+	}
+
+	return cleanup, nil
+}
+
+func filterCommentsAndEmptyLines(fileContent []byte) []byte {
+	lines := bytes.Split(fileContent, []byte("\n"))
+
+	newLines := make([][]byte, 0, len(lines))
+
+	for _, l := range lines {
+		if !bytes.HasPrefix(l, []byte("#")) && len(bytes.TrimSpace(l)) != 0 {
+			newLines = append(newLines, l)
+		}
+	}
+
+	return bytes.Join(newLines, []byte("\n"))
+}
+
+func defaultScheme() (*runtime.Scheme, error) {
+	resourcesSchema := runtime.NewScheme()
+
+	var addToSchemes = []func(*runtime.Scheme) error{
+		scheme.AddToScheme,
+		mmv1beta.AddToScheme,
+	}
+
+	for _, f := range addToSchemes {
+		err := f(resourcesSchema)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to add types to schema")
+		}
+	}
+
+	return resourcesSchema, nil
+}
+
+func defaultDecoder() (runtime.Decoder, error) {
+	resourceScheme, err := defaultScheme()
+	if err != nil {
+		return nil, err
+	}
+	codecs := serializer.NewCodecFactory(resourceScheme)
+	decoder := codecs.UniversalDeserializer()
+
+	return decoder, nil
+}

--- a/test/e2e-external/external_db_filestore_test.go
+++ b/test/e2e-external/external_db_filestore_test.go
@@ -1,0 +1,64 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	ptrUtil "github.com/mattermost/mattermost-operator/pkg/utils"
+	"github.com/mattermost/mattermost-operator/test/e2e"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_MattermostExternalServices(t *testing.T) {
+	namespace := "e2e-test-external-db-file-store"
+
+	testEnv, err := SetupTestEnv(k8sClient, namespace)
+	require.NoError(t, err)
+	defer testEnv.CleanupFunc()
+
+	mattermost := &mmv1beta.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-mm",
+			Namespace: namespace,
+		},
+		Spec: mmv1beta.MattermostSpec{
+			Ingress: &mmv1beta.Ingress{
+				Host: "e2e-test-example.mattermost.dev",
+			},
+			Replicas: ptrUtil.NewInt32(1),
+			FileStore: mmv1beta.FileStore{
+				External: &testEnv.FileStoreConfig,
+			},
+			Database: mmv1beta.Database{
+				External: &testEnv.DBConfig,
+			},
+		},
+	}
+
+	expectValidMattermostInstance(t, mattermost)
+}
+
+func expectValidMattermostInstance(t *testing.T, mattermost *mmv1beta.Mattermost) {
+	mmNamespaceName := types.NamespacedName{Namespace: mattermost.Namespace, Name: mattermost.Name}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := k8sClient.Create(ctx, mattermost)
+	require.NoError(t, err)
+	defer func() {
+		err = k8sClient.Delete(context.Background(), mattermost)
+		require.NoError(t, err)
+	}()
+
+	err = e2e.WaitForMattermostStable(t, k8sClient, mmNamespaceName, 3*time.Minute)
+	require.NoError(t, err)
+
+	// TODO: Run some basic Mattermost functionality test here
+	// this most likely needs to be done from inside the cluster
+	// by running some job.
+}

--- a/test/e2e-external/main_test.go
+++ b/test/e2e-external/main_test.go
@@ -4,14 +4,13 @@ import (
 	"os"
 	"testing"
 
-	"k8s.io/client-go/rest"
+	"github.com/mattermost/mattermost-operator/test/e2e"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 
@@ -38,12 +37,11 @@ func TestMain(m *testing.M) {
 }
 
 func setup() error {
-	env, err := SetupTest()
+	env, err := e2e.SetupTest()
 	if err != nil {
 		return err
 	}
 
-	cfg = env.Cfg
 	k8sClient = env.K8sClient
 	testEnv = env.TestEnv
 

--- a/test/e2e-external/setup_external_resources.go
+++ b/test/e2e-external/setup_external_resources.go
@@ -1,0 +1,76 @@
+package e2e
+
+import (
+	"context"
+
+	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type TestEnv struct {
+	DBConfig        mmv1beta.ExternalDatabase
+	FileStoreConfig mmv1beta.ExternalFileStore
+
+	CleanupFunc func()
+}
+
+type cleanupFunctions []func()
+
+func (cf cleanupFunctions) Cleanup() {
+	// Run in reverse order -- the same as defer.
+	for i := len(cf) - 1; i >= 0; i-- {
+		cf[i]()
+	}
+}
+
+// SetupTestEnv sets up Minio and Postgres in given namespace.
+func SetupTestEnv(k8sClient client.Client, namespace string) (TestEnv, error) {
+	ctx := context.Background()
+	var cleanupFuncs cleanupFunctions
+
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}
+	err := k8sClient.Create(ctx, ns)
+	if err != nil {
+		return TestEnv{}, errors.Wrap(err, "failed to create namespace")
+	}
+	cleanupNamespace := func() {
+		_ = k8sClient.Delete(context.Background(), ns)
+	}
+	cleanupFuncs = append(cleanupFuncs, cleanupNamespace)
+
+	cleanupPostgres, err := CreateFromFile(ctx, k8sClient, namespace, "../../resources/postgres.yaml")
+	if err != nil {
+		cleanupFuncs.Cleanup()
+		return TestEnv{}, errors.Wrap(err, "failed to apply Postgres")
+	}
+	cleanupFuncs = append(cleanupFuncs, cleanupPostgres)
+
+	cleanupMinio, err := CreateFromFile(ctx, k8sClient, namespace, "../../resources/minio.yaml")
+	if err != nil {
+		cleanupFuncs.Cleanup()
+		return TestEnv{}, errors.Wrap(err, "failed to apply Minio")
+	}
+	cleanupFuncs = append(cleanupFuncs, cleanupMinio)
+
+	cleanupSecrets, err := CreateFromFile(ctx, k8sClient, namespace, "../../resources/mm-secrets.yaml")
+	if err != nil {
+		cleanupFuncs.Cleanup()
+		return TestEnv{}, errors.Wrap(err, "failed to apply MM secrets")
+	}
+	cleanupFuncs = append(cleanupFuncs, cleanupSecrets)
+
+	return TestEnv{
+		DBConfig: mmv1beta.ExternalDatabase{Secret: "db-credentials"},
+		FileStoreConfig: mmv1beta.ExternalFileStore{
+			URL:    "minio:9000",
+			Bucket: "test-bucket",
+			Secret: "file-store-credentials",
+		},
+		CleanupFunc: cleanupFuncs.Cleanup,
+	}, nil
+}

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -85,6 +85,9 @@ main() {
     echo "Starting Operator Testing..."
     docker_exec go test ./test/e2e -timeout 50m -v
 
+    echo "Starting External DB and File Store tests..."
+    docker_exec go test ./test/e2e-external -timeout 20m -v
+
     echo "Done Testing!"
 }
 

--- a/test/e2e/mattermost_test.go
+++ b/test/e2e/mattermost_test.go
@@ -80,6 +80,7 @@ func mattermostScaleTest(t *testing.T, k8sClient client.Client, k8sTypedClient k
 			Database:  testDatabaseConfig(1),
 		},
 	}
+	mmNamespaceName := types.NamespacedName{Namespace: exampleMattermost.Namespace, Name: exampleMattermost.Name}
 
 	err := k8sClient.Create(context.TODO(), exampleMattermost)
 	require.NoError(t, err)
@@ -105,7 +106,7 @@ func mattermostScaleTest(t *testing.T, k8sClient client.Client, k8sTypedClient k
 	err = waitForDeployment(t, k8sTypedClient, mmNamespace, "test-mm", 2, retryInterval, timeout)
 	require.NoError(t, err)
 
-	err = waitForReconcilicationComplete(t, k8sClient, mmNamespace, "test-mm", retryInterval, timeout)
+	err = WaitForMattermostStable(t, k8sClient, mmNamespaceName, timeout)
 	require.NoError(t, err)
 
 	// scale down again
@@ -120,7 +121,7 @@ func mattermostScaleTest(t *testing.T, k8sClient client.Client, k8sTypedClient k
 	err = waitForDeployment(t, k8sTypedClient, mmNamespace, "test-mm", 1, retryInterval, timeout)
 	require.NoError(t, err)
 
-	err = waitForReconcilicationComplete(t, k8sClient, mmNamespace, "test-mm", retryInterval, timeout)
+	err = WaitForMattermostStable(t, k8sClient, mmNamespaceName, timeout)
 	require.NoError(t, err)
 
 	err = k8sClient.Delete(context.TODO(), exampleMattermost)
@@ -147,6 +148,7 @@ func mattermostUpgradeTest(t *testing.T, k8sClient client.Client, k8sTypedClient
 			Database:  testDatabaseConfig(1),
 		},
 	}
+	mmNamespaceName := types.NamespacedName{Namespace: exampleMattermost.Namespace, Name: exampleMattermost.Name}
 
 	err := k8sClient.Create(context.TODO(), exampleMattermost)
 	require.NoError(t, err)
@@ -192,7 +194,7 @@ func mattermostUpgradeTest(t *testing.T, k8sClient client.Client, k8sTypedClient
 	err = waitForDeployment(t, k8sTypedClient, mmNamespace, testName, 1, retryInterval, timeout)
 	require.NoError(t, err)
 
-	err = waitForReconcilicationComplete(t, k8sClient, mmNamespace, testName, retryInterval, timeout)
+	err = WaitForMattermostStable(t, k8sClient, mmNamespaceName, timeout)
 	require.NoError(t, err)
 
 	var updatedMattermost operator.Mattermost

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -1,0 +1,64 @@
+package e2e
+
+import (
+	"path/filepath"
+
+	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	v1beta1Minio "github.com/minio/minio-operator/pkg/apis/miniocontroller/v1beta1"
+	v1alpha1MySQL "github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+type TestEnvironment struct {
+	TestEnv   *envtest.Environment
+	Cfg       *rest.Config
+	K8sClient client.Client
+}
+
+func SetupTest() (TestEnvironment, error) {
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "config", "crd", "bases"),
+			filepath.Join("..", "crds"),
+		},
+		UseExistingCluster: boolPtr(true),
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		return TestEnvironment{}, err
+	}
+
+	err = mmv1beta.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return TestEnvironment{}, err
+	}
+
+	err = v1beta1Minio.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return TestEnvironment{}, err
+	}
+
+	err = v1alpha1MySQL.SchemeBuilder.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return TestEnvironment{}, err
+	}
+
+	k8sClient, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		return TestEnvironment{}, err
+	}
+
+	return TestEnvironment{
+		TestEnv:   testEnv,
+		Cfg:       cfg,
+		K8sClient: k8sClient,
+	}, nil
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -39,15 +39,15 @@ func waitForMySQLStatusReady(t *testing.T, dynclient client.Client, namespace, n
 	return nil
 }
 
-func waitForReconcilicationComplete(t *testing.T, dynclient client.Client, namespace, name string, retryInterval, timeout time.Duration) error {
+func WaitForMattermostStable(t *testing.T, k8sClient client.Client, mmKey types.NamespacedName, timeout time.Duration) error {
 	newMattermost := &operator.Mattermost{}
-	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		errClient := dynclient.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, newMattermost)
+	err := wait.Poll(3*time.Second, timeout, func() (done bool, err error) {
+		errClient := k8sClient.Get(context.TODO(), mmKey, newMattermost)
 		if errClient != nil {
 			return false, errClient
 		}
 
-		if newMattermost.Status.State == "stable" {
+		if newMattermost.Status.State == operator.Stable {
 			return true, nil
 		}
 		t.Logf("Waiting for Reconcilication finish (Status:%s)\n", newMattermost.Status.State)

--- a/test/e2e_local.sh
+++ b/test/e2e_local.sh
@@ -2,7 +2,7 @@
 
 ## Run e2e tests on local machine
 ## Requirement:
-## - kind 0.9.0
+## - kind 0.11.0
 ## - kustomize
 
 set -Eeuxo pipefail
@@ -22,4 +22,8 @@ source "${DIR}"/setup_test.sh
 # Deploy Mattermost Operator
 make deploy
 
+echo "Running operators e2e..."
 go test ./test/e2e --timeout 45m -v
+
+echo "Running external DB and File Store e2e..."
+go test ./test/e2e-extenal --timeout 15m -v


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

This PR adds a new e2e test that uses external database and file store configuration instead of Minio and MySQL operators. 
Test deploys Postgres and MinIO locally in the cluster but those are used as an external in CR configuration. 

Tests are more lightweight as they do not require other operators. PR provides a simple framework to easily set up additional tests in isolated namespaces. We can leverage that to implement more e2e tests for more specific configuration options. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add e2e tests for external DB and file-store configuration
```
