### PR TITLE
Image healthcheck with sidecar fix

### DIFF
--- a/controllers/mattermost/clusterinstallation/controller_test.go
+++ b/controllers/mattermost/clusterinstallation/controller_test.go
@@ -173,6 +173,7 @@ func TestReconcile(t *testing.T) {
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
+						Name:  mmv1beta.MattermostAppContainerName,
 						Image: ci.GetImageName(),
 					},
 				},
@@ -326,6 +327,7 @@ func TestReconcile(t *testing.T) {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
+							Name:  mmv1beta.MattermostAppContainerName,
 							Image: deployment.GetDeploymentImageName(),
 						},
 					},
@@ -747,6 +749,7 @@ func TestMigration(t *testing.T) {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
+					Name:  mmv1beta.MattermostAppContainerName,
 					Image: ci1.GetImageName(),
 				},
 			},

--- a/controllers/mattermost/mattermost/controller_test.go
+++ b/controllers/mattermost/mattermost/controller_test.go
@@ -192,6 +192,7 @@ func TestReconcile(t *testing.T) {
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
+						Name:  mmv1beta.MattermostAppContainerName,
 						Image: mm.GetImageName(),
 					},
 				},

--- a/pkg/mattermost/healthcheck/health_check.go
+++ b/pkg/mattermost/healthcheck/health_check.go
@@ -66,7 +66,12 @@ func (hc *HealthChecker) CheckPodsRollOut(desiredImage string) (PodRolloutStatus
 			hc.logger.Info(fmt.Sprintf("mattermost pod %s has no containers", pod.Name))
 			continue
 		}
-		if v1beta.GetMattermostAppContainer(pod.Spec.Containers).Image != desiredImage {
+		mmContainer := v1beta.GetMattermostAppContainer(pod.Spec.Containers)
+		if mmContainer == nil {
+				hc.logger.Info(fmt.Sprintf("mattermost container not found in the pod %s", pod.Name))
+				continue
+		}
+		if mmContainer.Image != desiredImage {
 			hc.logger.Info(fmt.Sprintf("mattermost pod %s is running incorrect image", pod.Name))
 			continue
 		}

--- a/pkg/mattermost/healthcheck/health_check.go
+++ b/pkg/mattermost/healthcheck/health_check.go
@@ -68,9 +68,9 @@ func (hc *HealthChecker) CheckPodsRollOut(desiredImage string) (PodRolloutStatus
 		}
 		var mattermostContainer corev1.Container
 		for _, container := range pod.Spec.Containers {
-			if container.Name == mattermostv1alpha1.MattermostAppContainerName {
+			if container.Name == mattermostv1alpha1.MattermostAppContainerName || container.Name == "" {
 				mattermostContainer = container
-				continue
+				break
 			}
 		}
 		if mattermostContainer.Image != desiredImage {

--- a/pkg/mattermost/healthcheck/health_check.go
+++ b/pkg/mattermost/healthcheck/health_check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -65,9 +66,13 @@ func (hc *HealthChecker) CheckPodsRollOut(desiredImage string) (PodRolloutStatus
 			hc.logger.Info(fmt.Sprintf("mattermost pod %s has no containers", pod.Name))
 			continue
 		}
-		if pod.Spec.Containers[0].Image != desiredImage {
-			hc.logger.Info(fmt.Sprintf("mattermost pod %s is running incorrect image", pod.Name))
-			continue
+		for _, container := range pod.Spec.Containers {
+			if container.Name == mattermostv1alpha1.MattermostAppContainerName {
+				if container.Image != desiredImage {
+					hc.logger.Info(fmt.Sprintf("mattermost pod %s is running incorrect image", pod.Name))
+					continue
+				}
+			}
 		}
 		if !isPodReady(pod) {
 			hc.logger.Info(fmt.Sprintf("mattermost pod %s is not ready", pod.Name))

--- a/pkg/mattermost/healthcheck/health_check.go
+++ b/pkg/mattermost/healthcheck/health_check.go
@@ -68,8 +68,8 @@ func (hc *HealthChecker) CheckPodsRollOut(desiredImage string) (PodRolloutStatus
 		}
 		mmContainer := v1beta.GetMattermostAppContainer(pod.Spec.Containers)
 		if mmContainer == nil {
-				hc.logger.Info(fmt.Sprintf("mattermost container not found in the pod %s", pod.Name))
-				continue
+			hc.logger.Info(fmt.Sprintf("mattermost container not found in the pod %s", pod.Name))
+			continue
 		}
 		if mmContainer.Image != desiredImage {
 			hc.logger.Info(fmt.Sprintf("mattermost pod %s is running incorrect image", pod.Name))

--- a/pkg/mattermost/healthcheck/health_check.go
+++ b/pkg/mattermost/healthcheck/health_check.go
@@ -66,13 +66,16 @@ func (hc *HealthChecker) CheckPodsRollOut(desiredImage string) (PodRolloutStatus
 			hc.logger.Info(fmt.Sprintf("mattermost pod %s has no containers", pod.Name))
 			continue
 		}
+		var mattermostContainer corev1.Container
 		for _, container := range pod.Spec.Containers {
 			if container.Name == mattermostv1alpha1.MattermostAppContainerName {
-				if container.Image != desiredImage {
-					hc.logger.Info(fmt.Sprintf("mattermost pod %s is running incorrect image", pod.Name))
-					continue
-				}
+				mattermostContainer = container
+				continue
 			}
+		}
+		if mattermostContainer.Image != desiredImage {
+			hc.logger.Info(fmt.Sprintf("mattermost pod %s is running incorrect image", pod.Name))
+			continue
 		}
 		if !isPodReady(pod) {
 			hc.logger.Info(fmt.Sprintf("mattermost pod %s is not ready", pod.Name))

--- a/pkg/mattermost/healthcheck/health_check.go
+++ b/pkg/mattermost/healthcheck/health_check.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	mattermostv1alpha1 "github.com/mattermost/mattermost-operator/apis/mattermost/v1alpha1"
+	v1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -66,14 +66,7 @@ func (hc *HealthChecker) CheckPodsRollOut(desiredImage string) (PodRolloutStatus
 			hc.logger.Info(fmt.Sprintf("mattermost pod %s has no containers", pod.Name))
 			continue
 		}
-		var mattermostContainer corev1.Container
-		for _, container := range pod.Spec.Containers {
-			if container.Name == mattermostv1alpha1.MattermostAppContainerName || container.Name == "" {
-				mattermostContainer = container
-				break
-			}
-		}
-		if mattermostContainer.Image != desiredImage {
+		if v1beta.GetMattermostAppContainer(pod.Spec.Containers).Image != desiredImage {
 			hc.logger.Info(fmt.Sprintf("mattermost pod %s is running incorrect image", pod.Name))
 			continue
 		}


### PR DESCRIPTION
#### Summary

Modifies the health check to look specifically at the Mattermost container rather than just container 0.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-operator/issues/279

#### Release Note

```release-note
NONE?
```
