### PR TITLE
Don't return errors waiting for job update

### DIFF
--- a/controllers/mattermost/mattermost/controller.go
+++ b/controllers/mattermost/mattermost/controller.go
@@ -152,7 +152,7 @@ func (r *MattermostReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	}
 
 	if !recStatus.ResourcesReady {
-		reqLogger.Info("Mattermost resources not ready, dealying for 10 seconds!")
+		reqLogger.Info("Mattermost resources not ready, delaying for 10 seconds!")
 		return ctrl.Result{RequeueAfter: resourcesReadyDelay}, nil
 	}
 

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -381,7 +381,6 @@ func (r *MattermostReconciler) checkUpdateJob(
 				return nil, reconcileStatus{}, errors.Wrap(err, "Launching update image job failed")
 			}
 			recStatus.ResourcesReady = false
-			reqLogger.Error(err, "failed to restart update job")
 			return nil, recStatus, nil
 		}
 
@@ -403,8 +402,7 @@ func (r *MattermostReconciler) checkUpdateJob(
 		err = r.Resources.RestartMattermostUpdateJob(mattermost, job, baseDeployment, reqLogger)
 		if err != nil {
 			recStatus.ResourcesReady = false
-			reqLogger.Error(err, "failed to restart update job")
-			return nil, recStatus, nil
+			return nil, recStatus, errors.Wrap(err, "failed to restart update job")
 		}
 
 		recStatus.ResourcesReady = false
@@ -422,8 +420,7 @@ func (r *MattermostReconciler) checkUpdateJob(
 
 	if job.Status.Failed > 0 {
 		recStatus.ResourcesReady = false
-		reqLogger.Info("update image job failed")
-		return job, recStatus, nil
+		return job, recStatus, errors.New("update image job failed")
 	}
 
 	reqLogger.Info("Update image job ran successfully")

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -310,23 +310,22 @@ func (r *MattermostReconciler) checkMattermostDeployment(
 
 	err = r.Resources.CreateDeploymentIfNotExists(mattermost, desired, reqLogger)
 	if err != nil {
-		recStatus.Error = errors.Wrap(err, "failed to create mattermost deployment")
+		recStatus.Error = errors.Wrap(recStatus.Error, "failed to create mattermost deployment")
 		return recStatus
 	}
 
 	current := &appsv1.Deployment{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
 	if err != nil {
-		recStatus.Error = errors.Wrap(err, "failed to get mattermost deployment")
+		recStatus.Error = errors.Wrap(recStatus.Error, "failed to get mattermost deployment")
 		return recStatus
 	}
 
 	recStatus = r.updateMattermostDeployment(mattermost, current, desired, reqLogger)
 	if recStatus.Error != nil {
-		recStatus.Error = errors.Wrap(err, "failed to update mattermost deployment")
+		recStatus.Error = errors.Wrap(recStatus.Error, "failed to update mattermost deployment")
 		return recStatus
 	}
-
 	return recStatus
 }
 

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -39,29 +39,29 @@ func (r *MattermostReconciler) checkMattermost(
 
 	err := r.checkLicence(mattermost)
 	if err != nil {
-		return recStatus, errors.Wrap(err, "failed to check mattermost license secret.")
+		return reconcileStatus{}, errors.Wrap(err, "failed to check mattermost license secret.")
 	}
 
 	err = r.checkMattermostService(mattermost, status, reqLogger)
 	if err != nil {
-		return recStatus, err
+		return reconcileStatus{}, err
 	}
 
 	err = r.checkMattermostRBAC(mattermost, reqLogger)
 	if err != nil {
-		return recStatus, err
+		return reconcileStatus{}, err
 	}
 
 	if !mattermost.Spec.UseServiceLoadBalancer {
 		err = r.checkMattermostIngress(mattermost, reqLogger)
 		if err != nil {
-			return recStatus, err
+			return reconcileStatus{}, err
 		}
 	}
 
 	recStatus, err = r.checkMattermostDeployment(mattermost, dbInfo, fileStoreInfo, status, reqLogger)
 	if err != nil {
-		return recStatus, err
+		return reconcileStatus{}, err
 	}
 
 	return recStatus, nil
@@ -241,18 +241,18 @@ func (r *MattermostReconciler) checkMattermostDeployment(
 
 	err = r.Resources.CreateDeploymentIfNotExists(mattermost, desired, reqLogger)
 	if err != nil {
-		return recStatus, errors.Wrap(err, "failed to create mattermost deployment")
+		return reconcileStatus{}, errors.Wrap(err, "failed to create mattermost deployment")
 	}
 
 	current := &appsv1.Deployment{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
 	if err != nil {
-		return recStatus, errors.Wrap(err, "failed to get mattermost deployment")
+		return reconcileStatus{}, errors.Wrap(err, "failed to get mattermost deployment")
 	}
 
 	recStatus, err = r.updateMattermostDeployment(mattermost, current, desired, reqLogger)
 	if err != nil {
-		return recStatus, errors.Wrap(err, "failed to update mattermost deployment")
+		return reconcileStatus{}, errors.Wrap(err, "failed to update mattermost deployment")
 	}
 
 	return recStatus, nil
@@ -329,7 +329,7 @@ func (r *MattermostReconciler) updateMattermostDeployment(
 	}
 
 	if err != nil {
-		return recStatus, err
+		return reconcileStatus{}, err
 	}
 
 	if sameImage {

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -346,6 +346,7 @@ func (r *MattermostReconciler) updateMattermostDeployment(
 
 	job, err := r.checkUpdateJob(mattermost.Namespace, desired, reqLogger)
 	if job != nil {
+		recStatus.ResourcesReady = true
 		// Job is done, need to cleanup
 		defer r.cleanupUpdateJob(job, reqLogger)
 	}

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -434,6 +434,7 @@ func (r *MattermostReconciler) updateMattermostDeployment(
 	}
 	if err != nil {
 		recStatus.Status = true
+		recStatus.Error = err
 		return recStatus
 	}
 

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -396,7 +396,7 @@ func (r *MattermostReconciler) checkUpdateJob(
 	}
 	if !isSameImage {
 		reqLogger.Info("Mattermost image changed, restarting update job")
-		err := r.Resources.RestartMattermostUpdateJob(mattermost, job, baseDeployment, reqLogger)
+		err = r.Resources.RestartMattermostUpdateJob(mattermost, job, baseDeployment, reqLogger)
 		if err != nil {
 			reqLogger.Error(err, "failed to restart update job")
 			recStatus.ResourcesReady = false

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -271,6 +271,7 @@ func TestCheckMattermost(t *testing.T) {
 		// Update job should be launched, we expect error
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		require.Error(t, err)
+		assert.Equal(t, false, recStatus.ResourcesReady)
 
 		// Assert the job was created
 		job := &batchv1.Job{}

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -268,10 +268,10 @@ func TestCheckMattermost(t *testing.T) {
 		require.NoError(t, err)
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 
-		// Update job should be launched, we expect error
+		// Update job should be launched, we do not expect error
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
-		require.Error(t, err)
-		assert.Equal(t, false, recStatus.ResourcesReady)
+		require.NoError(t, err)
+		assert.Equal(t, true, recStatus.ResourcesReady)
 
 		// Assert the job was created
 		job := &batchv1.Job{}
@@ -337,9 +337,10 @@ func TestCheckMattermost(t *testing.T) {
 		newImage := "mattermost/new-image"
 		mm.Spec.Image = newImage
 
+		// check deployment - update job is not completed, therefore resource is not ready
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "Restarted update image job")
+		assert.NoError(t, err)
+		assert.False(t, recStatus.ResourcesReady)
 
 		// get new job, assert new image and change status to completed
 		restartedUpdateJob := batchv1.Job{}

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -295,11 +295,11 @@ func TestCheckMattermost(t *testing.T) {
 		}
 		err = reconciler.Client.Update(context.TODO(), job)
 		require.NoError(t, err)
-		assert.False(t, recStatus.ResourcesReady)
 
 		// Job is marked as succeeded, should proceed now.
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		require.NoError(t, err)
+		assert.True(t, recStatus.ResourcesReady)
 
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -333,7 +333,7 @@ func TestCheckMattermost(t *testing.T) {
 
 		recStatus = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		assert.Error(t, recStatus.Error)
-		assert.Contains(t, recStatus.Error, "Restarted update image job")
+		assert.Contains(t, recStatus.Error.Error(), "Restarted update image job")
 
 		// get new job, assert new image and change status to completed
 		restartedUpdateJob := batchv1.Job{}

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -36,11 +36,6 @@ import (
 func TestCheckMattermost(t *testing.T) {
 	logger, _, reconciler := setupTestDeps(t)
 
-	recStatus := reconcileStatus{
-		Status: false,
-		Error:  nil,
-	}
-
 	mmName := "foo"
 	mmNamespace := "default"
 	replicas := int32(4)
@@ -65,8 +60,8 @@ func TestCheckMattermost(t *testing.T) {
 	var err error
 
 	t.Run("service", func(t *testing.T) {
-		recStatus = reconciler.checkMattermostService(mm, currentMMStatus, logger)
-		assert.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostService(mm, currentMMStatus, logger)
+		assert.NoError(t, err)
 
 		found := &corev1.Service{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
@@ -81,8 +76,8 @@ func TestCheckMattermost(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostService(mm, currentMMStatus, logger)
-		require.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostService(mm, currentMMStatus, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.GetName(), found.GetName())
@@ -92,8 +87,8 @@ func TestCheckMattermost(t *testing.T) {
 	})
 
 	t.Run("service account", func(t *testing.T) {
-		recStatus = reconciler.checkMattermostSA(mm, logger)
-		assert.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostSA(mm, logger)
+		assert.NoError(t, err)
 
 		found := &corev1.ServiceAccount{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
@@ -102,15 +97,15 @@ func TestCheckMattermost(t *testing.T) {
 
 		err = reconciler.Client.Delete(context.TODO(), found)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostSA(mm, logger)
-		require.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostSA(mm, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 	})
 
 	t.Run("role", func(t *testing.T) {
-		recStatus = reconciler.checkMattermostRole(mm, logger)
-		assert.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostRole(mm, logger)
+		assert.NoError(t, err)
 
 		found := &rbacv1.Role{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
@@ -123,8 +118,8 @@ func TestCheckMattermost(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostRole(mm, logger)
-		require.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostRole(mm, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.GetName(), found.GetName())
@@ -133,8 +128,8 @@ func TestCheckMattermost(t *testing.T) {
 	})
 
 	t.Run("role binding", func(t *testing.T) {
-		recStatus = reconciler.checkMattermostRoleBinding(mm, logger)
-		assert.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostRoleBinding(mm, logger)
+		assert.NoError(t, err)
 
 		found := &rbacv1.RoleBinding{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
@@ -147,8 +142,8 @@ func TestCheckMattermost(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostRoleBinding(mm, logger)
-		require.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostRoleBinding(mm, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.GetName(), found.GetName())
@@ -158,8 +153,8 @@ func TestCheckMattermost(t *testing.T) {
 
 	t.Run("ingress no tls", func(t *testing.T) {
 		mm.Spec.UseIngressTLS = false
-		recStatus = reconciler.checkMattermostIngress(mm, logger)
-		assert.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostIngress(mm, logger)
+		assert.NoError(t, err)
 
 		found := &v1beta1.Ingress{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
@@ -175,8 +170,8 @@ func TestCheckMattermost(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostIngress(mm, logger)
-		require.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostIngress(mm, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.GetAnnotations(), found.GetAnnotations())
@@ -192,8 +187,8 @@ func TestCheckMattermost(t *testing.T) {
 			"test-ingress":                "blabla",
 		}
 
-		recStatus = reconciler.checkMattermostIngress(mm, logger)
-		assert.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostIngress(mm, logger)
+		assert.NoError(t, err)
 
 		found := &v1beta1.Ingress{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
@@ -211,8 +206,8 @@ func TestCheckMattermost(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostIngress(mm, logger)
-		require.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostIngress(mm, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.GetAnnotations(), found.GetAnnotations())
@@ -223,8 +218,8 @@ func TestCheckMattermost(t *testing.T) {
 	})
 
 	t.Run("ingress disabled", func(t *testing.T) {
-		recStatus = reconciler.checkMattermostIngress(mm, logger)
-		assert.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostIngress(mm, logger)
+		assert.NoError(t, err)
 
 		found := &v1beta1.Ingress{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
@@ -233,8 +228,8 @@ func TestCheckMattermost(t *testing.T) {
 
 		mm.Spec.Ingress = &mmv1beta.Ingress{Enabled: false}
 
-		recStatus = reconciler.checkMattermostIngress(mm, logger)
-		require.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostIngress(mm, logger)
+		require.NoError(t, err)
 
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.Error(t, err)
@@ -264,8 +259,9 @@ func TestCheckMattermost(t *testing.T) {
 		err = reconciler.Client.Create(context.TODO(), job)
 		require.NoError(t, err)
 
-		recStatus = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
-		assert.NoError(t, recStatus.Error)
+		recStatus, err := reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		assert.NoError(t, err)
+		assert.Equal(t, true, recStatus.ResourcesReady)
 
 		//dbSetupJob := &batchv1.Job{}
 		//err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mattermost.SetupJobName, Namespace: mmNamespace}, dbSetupJob)
@@ -290,8 +286,8 @@ func TestCheckMattermost(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
-		require.NoError(t, recStatus.Error)
+		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.GetLabels(), found.GetLabels())
@@ -301,8 +297,9 @@ func TestCheckMattermost(t *testing.T) {
 
 	t.Run("restart update job", func(t *testing.T) {
 		// create deployment
-		recStatus = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
-		assert.NoError(t, recStatus.Error)
+		recStatus, err := reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		assert.NoError(t, err)
+		assert.Equal(t, true, recStatus.ResourcesReady)
 
 		// create update job with invalid image
 		updateName := "mattermost-update-check"
@@ -324,16 +321,16 @@ func TestCheckMattermost(t *testing.T) {
 				CompletionTime: &now,
 			},
 		}
-		err := reconciler.Client.Create(context.TODO(), invalidUpdateJob)
+		err = reconciler.Client.Create(context.TODO(), invalidUpdateJob)
 		require.NoError(t, err)
 
 		// should delete update job and create new and return error
 		newImage := "mattermost/new-image"
 		mm.Spec.Image = newImage
 
-		recStatus = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
-		assert.Error(t, recStatus.Error)
-		assert.Contains(t, recStatus.Error.Error(), "Restarted update image job")
+		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Restarted update image job")
 
 		// get new job, assert new image and change status to completed
 		restartedUpdateJob := batchv1.Job{}
@@ -352,18 +349,13 @@ func TestCheckMattermost(t *testing.T) {
 		require.NoError(t, err)
 
 		// should succeed now
-		recStatus = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
-		assert.NoError(t, recStatus.Error)
+		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		assert.NoError(t, err)
 	})
 }
 
 func TestCheckMattermostExternalDBAndFileStore(t *testing.T) {
 	logger, _, reconciler := setupTestDeps(t)
-
-	recStatus := reconcileStatus{
-		Status: false,
-		Error:  nil,
-	}
 
 	mmName := "foo"
 	mmNamespace := "default"
@@ -426,8 +418,8 @@ func TestCheckMattermostExternalDBAndFileStore(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("service", func(t *testing.T) {
-		recStatus = reconciler.checkMattermostService(mm, currentMMStatus, logger)
-		assert.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostService(mm, currentMMStatus, logger)
+		assert.NoError(t, err)
 
 		found := &corev1.Service{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
@@ -442,8 +434,8 @@ func TestCheckMattermostExternalDBAndFileStore(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostService(mm, currentMMStatus, logger)
-		require.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostService(mm, currentMMStatus, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.GetName(), found.GetName())
@@ -453,8 +445,8 @@ func TestCheckMattermostExternalDBAndFileStore(t *testing.T) {
 	})
 
 	t.Run("ingress", func(t *testing.T) {
-		recStatus = reconciler.checkMattermostIngress(mm, logger)
-		assert.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostIngress(mm, logger)
+		assert.NoError(t, err)
 
 		found := &v1beta1.Ingress{}
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
@@ -469,8 +461,8 @@ func TestCheckMattermostExternalDBAndFileStore(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostIngress(mm, logger)
-		require.NoError(t, recStatus.Error)
+		err = reconciler.checkMattermostIngress(mm, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.GetAnnotations(), found.GetAnnotations())
@@ -502,8 +494,9 @@ func TestCheckMattermostExternalDBAndFileStore(t *testing.T) {
 		err := reconciler.Client.Create(context.TODO(), job)
 		require.NoError(t, err)
 
-		recStatus = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
-		assert.NoError(t, recStatus.Error)
+		recStatus, err := reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		assert.NoError(t, err)
+		assert.Equal(t, true, recStatus.ResourcesReady)
 
 		// TODO: uncomment when enabling back the db setup job
 		//dbSetupJob := &batchv1.Job{}
@@ -528,8 +521,8 @@ func TestCheckMattermostExternalDBAndFileStore(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
-		require.NoError(t, recStatus.Error)
+		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.Labels, found.Labels)
@@ -566,24 +559,24 @@ func TestSpecialCases(t *testing.T) {
 	t.Run("service - copy ClusterIP for LoadBalancer service", func(t *testing.T) {
 		// Create the service
 		err := reconciler.checkMattermostService(mm, currentMMStatus, logger)
-		require.NoError(t, err.Error)
+		require.NoError(t, err)
 
 		service := &corev1.Service{}
-		err.Error = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, service)
-		require.NoError(t, err.Error)
+		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, service)
+		require.NoError(t, err)
 
 		service.Spec.ClusterIPs = []string{"10.10.10.10", "10.10.10.11"}
 		service.Spec.ClusterIP = "10.10.10.10"
-		err.Error = reconciler.Client.Update(context.TODO(), service)
-		require.NoError(t, err.Error)
+		err = reconciler.Client.Update(context.TODO(), service)
+		require.NoError(t, err)
 
 		mm.Spec.ResourceLabels = map[string]string{"myLabel": "test"}
 		err = reconciler.checkMattermostService(mm, currentMMStatus, logger)
-		require.NoError(t, err.Error)
+		require.NoError(t, err)
 
 		modified := &corev1.Service{}
-		err.Error = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, modified)
-		require.NoError(t, err.Error)
+		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, modified)
+		require.NoError(t, err)
 		assert.Equal(t, service.Spec.ClusterIPs, modified.Spec.ClusterIPs)
 		assert.Equal(t, service.Spec.ClusterIP, modified.Spec.ClusterIP)
 	})
@@ -686,13 +679,14 @@ func Test_Patches(t *testing.T) {
 
 				dbInfo, fileStoreInfo := fixedDBAndFileStoreInfo(t, mm)
 
-				err := reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, &mmStatus, logger)
-				require.NoError(t, err.Error)
+				recStatus, err := reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, &mmStatus, logger)
+				require.NoError(t, err)
+				assert.Equal(t, true, recStatus.ResourcesReady)
 
 				deployKey := types.NamespacedName{Name: mmName, Namespace: mmNamespace}
 				deploy := appsv1.Deployment{}
-				err.Error = fakeClient.Get(context.Background(), deployKey, &deploy)
-				require.NoError(t, err.Error)
+				err = fakeClient.Get(context.Background(), deployKey, &deploy)
+				require.NoError(t, err)
 
 				testCase.assertFn(t, &deploy, mmStatus)
 			})
@@ -759,12 +753,12 @@ func Test_Patches(t *testing.T) {
 				mm.Spec.ResourcePatch = testCase.patch
 
 				err := reconciler.checkMattermostService(mm, &mmStatus, logger)
-				require.NoError(t, err.Error)
+				require.NoError(t, err)
 
 				deployKey := types.NamespacedName{Name: mmName, Namespace: mmNamespace}
 				svc := corev1.Service{}
-				err.Error = fakeClient.Get(context.Background(), deployKey, &svc)
-				require.NoError(t, err.Error)
+				err = fakeClient.Get(context.Background(), deployKey, &svc)
+				require.NoError(t, err)
 
 				testCase.assertFn(t, &svc, mmStatus)
 			})

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -269,7 +269,7 @@ func TestCheckMattermost(t *testing.T) {
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 
 		// Update job should be launched, we expect error
-		err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		require.Error(t, err)
 
 		// Assert the job was created
@@ -293,7 +293,7 @@ func TestCheckMattermost(t *testing.T) {
 		require.NoError(t, err)
 
 		// Job is marked as succeeded, should proceed now.
-		err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		require.NoError(t, err)
 
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -241,7 +241,7 @@ func TestCheckMattermost(t *testing.T) {
 
 		recStatus, err := reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		assert.NoError(t, err)
-		assert.Equal(t, true, recStatus.ResourcesReady)
+		assert.False(t, recStatus.ResourcesReady)
 
 		//dbSetupJob := &batchv1.Job{}
 		//err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mattermost.SetupJobName, Namespace: mmNamespace}, dbSetupJob)
@@ -268,10 +268,10 @@ func TestCheckMattermost(t *testing.T) {
 		require.NoError(t, err)
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 
-		// Update job should be launched, we do not expect error
+		// Update job should be launched, we expect error
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		require.NoError(t, err)
-		assert.Equal(t, true, recStatus.ResourcesReady)
+		assert.False(t, recStatus.ResourcesReady)
 
 		// Assert the job was created
 		job := &batchv1.Job{}
@@ -308,7 +308,7 @@ func TestCheckMattermost(t *testing.T) {
 		// create deployment
 		recStatus, err := reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		assert.NoError(t, err)
-		assert.Equal(t, true, recStatus.ResourcesReady)
+		assert.False(t, recStatus.ResourcesReady)
 
 		// create update job with invalid image
 		updateName := "mattermost-update-check"

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -333,7 +333,7 @@ func TestCheckMattermost(t *testing.T) {
 
 		recStatus = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		assert.Error(t, recStatus.Error)
-		assert.Contains(t, err.Error(), "Restarted update image job")
+		assert.Contains(t, recStatus.Error, "Restarted update image job")
 
 		// get new job, assert new image and change status to completed
 		restartedUpdateJob := batchv1.Job{}

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -241,7 +241,7 @@ func TestCheckMattermost(t *testing.T) {
 
 		recStatus, err := reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		assert.NoError(t, err)
-		assert.False(t, recStatus.ResourcesReady)
+		assert.True(t, recStatus.ResourcesReady)
 
 		//dbSetupJob := &batchv1.Job{}
 		//err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mattermost.SetupJobName, Namespace: mmNamespace}, dbSetupJob)
@@ -266,9 +266,8 @@ func TestCheckMattermost(t *testing.T) {
 
 		err = reconciler.Client.Update(context.TODO(), modified)
 		require.NoError(t, err)
-		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 
-		// Update job should be launched, we expect error
+		// Update job should be launched, we do not expect error
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		require.NoError(t, err)
 		assert.False(t, recStatus.ResourcesReady)
@@ -284,6 +283,10 @@ func TestCheckMattermost(t *testing.T) {
 		assert.Equal(t, mmName, job.ObjectMeta.OwnerReferences[0].Name)
 		assert.Equal(t, "installation.mattermost.com/v1beta1", job.ObjectMeta.OwnerReferences[0].APIVersion)
 
+		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
+		assert.NoError(t, err)
+		assert.False(t, recStatus.ResourcesReady)
+
 		// Set job status to succeeded so that test can proceed
 		now := metav1.Now()
 		job.Status = batchv1.JobStatus{
@@ -292,6 +295,7 @@ func TestCheckMattermost(t *testing.T) {
 		}
 		err = reconciler.Client.Update(context.TODO(), job)
 		require.NoError(t, err)
+		assert.False(t, recStatus.ResourcesReady)
 
 		// Job is marked as succeeded, should proceed now.
 		recStatus, err = reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
@@ -308,7 +312,7 @@ func TestCheckMattermost(t *testing.T) {
 		// create deployment
 		recStatus, err := reconciler.checkMattermostDeployment(mm, dbInfo, fileStoreInfo, currentMMStatus, logger)
 		assert.NoError(t, err)
-		assert.False(t, recStatus.ResourcesReady)
+		assert.True(t, recStatus.ResourcesReady)
 
 		// create update job with invalid image
 		updateName := "mattermost-update-check"


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

- Use `struct` to indicate status of update job check and sleep for 5 seconds before reconciling

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Fixes #224 

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Don't return errors waiting for job update
```
