### PR TITLE
Use FQDN to avoid resolve failures when use option ndots<3

### DIFF
--- a/pkg/mattermost/database_mysql.go
+++ b/pkg/mattermost/database_mysql.go
@@ -60,14 +60,14 @@ func (m *MySQLDBConfig) EnvVars(mattermost *mmv1beta.Mattermost) []corev1.EnvVar
 		{
 			Name: "MM_SQLSETTINGS_DATASOURCEREPLICAS",
 			Value: fmt.Sprintf(
-				"$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql.%s:3306)/%s?readTimeout=30s&writeTimeout=30s",
+				"$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql.%s.svc.cluster.local:3306)/%s?readTimeout=30s&writeTimeout=30s",
 				mysqlName, mattermost.Namespace, m.databaseName,
 			),
 		},
 		{
 			Name: "MM_CONFIG",
 			Value: fmt.Sprintf(
-				"mysql://$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql-master.%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
+				"mysql://$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql-master.%s.svc.cluster.local:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
 				mysqlName, mattermost.Namespace, m.databaseName,
 			),
 		},
@@ -90,7 +90,7 @@ func (m *MySQLDBConfig) InitContainers(mattermost *mmv1beta.Mattermost) []corev1
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command: []string{
 				"sh", "-c",
-				fmt.Sprintf("until curl --max-time 5 http://%s-mysql-master.%s:3306; do echo waiting for mysql; sleep 5; done;",
+				fmt.Sprintf("until curl --max-time 5 http://%s-mysql-master.%s.svc.cluster.local:3306; do echo waiting for mysql; sleep 5; done;",
 					mysqlName, mattermost.Namespace,
 				),
 			},

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -147,7 +147,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 		mysqlName := utils.HashWithPrefix("db", mattermost.Name)
 
 		masterDBEnvVar.Value = fmt.Sprintf(
-			"mysql://$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql-master.%s:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
+			"mysql://$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql-master.%s.cluster.local:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
 			mysqlName, mattermost.Namespace, dbInfo.DatabaseName,
 		)
 
@@ -177,7 +177,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 			{
 				Name: "MM_SQLSETTINGS_DATASOURCEREPLICAS",
 				Value: fmt.Sprintf(
-					"$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql.%s:3306)/%s?readTimeout=30s&writeTimeout=30s",
+					"$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql.%s.cluster.local:3306)/%s?readTimeout=30s&writeTimeout=30s",
 					mysqlName, mattermost.Namespace, dbInfo.DatabaseName,
 				),
 			},
@@ -191,7 +191,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command: []string{
 				"sh", "-c",
-				fmt.Sprintf("until curl --max-time 5 http://%s-mysql-master.%s:3306; do echo waiting for mysql; sleep 5; done;",
+				fmt.Sprintf("until curl --max-time 5 http://%s-mysql-master.%s.cluster.local:3306; do echo waiting for mysql; sleep 5; done;",
 					mysqlName, mattermost.Namespace,
 				),
 			},

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -147,7 +147,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 		mysqlName := utils.HashWithPrefix("db", mattermost.Name)
 
 		masterDBEnvVar.Value = fmt.Sprintf(
-			"mysql://$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql-master.%s.cluster.local:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
+			"mysql://$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql-master.%s.svc.cluster.local:3306)/%s?charset=utf8mb4,utf8&readTimeout=30s&writeTimeout=30s",
 			mysqlName, mattermost.Namespace, dbInfo.DatabaseName,
 		)
 
@@ -177,7 +177,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 			{
 				Name: "MM_SQLSETTINGS_DATASOURCEREPLICAS",
 				Value: fmt.Sprintf(
-					"$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql.%s.cluster.local:3306)/%s?readTimeout=30s&writeTimeout=30s",
+					"$(MYSQL_USERNAME):$(MYSQL_PASSWORD)@tcp(%s-mysql.%s.svc.cluster.local:3306)/%s?readTimeout=30s&writeTimeout=30s",
 					mysqlName, mattermost.Namespace, dbInfo.DatabaseName,
 				),
 			},
@@ -191,7 +191,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command: []string{
 				"sh", "-c",
-				fmt.Sprintf("until curl --max-time 5 http://%s-mysql-master.%s.cluster.local:3306; do echo waiting for mysql; sleep 5; done;",
+				fmt.Sprintf("until curl --max-time 5 http://%s-mysql-master.%s.svc.cluster.local:3306; do echo waiting for mysql; sleep 5; done;",
 					mysqlName, mattermost.Namespace,
 				),
 			},

--- a/pkg/resources/minio.go
+++ b/pkg/resources/minio.go
@@ -70,6 +70,6 @@ func (r *ResourceHelper) GetMinioService(mmName, mmNamespace string) (string, er
 		return "", err
 	}
 
-	connectionString := fmt.Sprintf("%s.%s:%d", minioService.Name, mmNamespace, minioService.Spec.Ports[0].Port)
+	connectionString := fmt.Sprintf("%s.%s.svc.cluster.local:%d", minioService.Name, mmNamespace, minioService.Spec.Ports[0].Port)
 	return connectionString, nil
 }


### PR DESCRIPTION
Issue: CLD-2517

#### Summary
Use FQDN to avoid resolve failures when use option ndots<3
Relevant Info: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-2517

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Use FQDN to avoid resolve failures when use option ndots<3
```
