### PR TITLE
Support parallel reconciliation

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,8 @@ spec:
             value: "20"
           - name: "REQUEUE_ON_LIMIT_DELAY"
             value: "20s"
+          - name: "MAX_RECONCILE_CONCURRENCY"
+            value: "10"
 ---
 apiVersion: v1
 kind: Service

--- a/controllers/mattermost/mattermost/controller.go
+++ b/controllers/mattermost/mattermost/controller.go
@@ -3,7 +3,10 @@ package mattermost
 import (
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sync"
 	"time"
 
 	"github.com/mattermost/mattermost-operator/pkg/resources"
@@ -13,7 +16,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -30,12 +32,13 @@ const resourcesReadyDelay = 10 * time.Second
 // MattermostReconciler reconciles a Mattermost object
 type MattermostReconciler struct {
 	client.Client
-	NonCachedAPIReader  client.Reader
-	Log                 logr.Logger
-	Scheme              *runtime.Scheme
-	MaxReconciling      int
-	RequeueOnLimitDelay time.Duration
-	Resources           *resources.ResourceHelper
+	NonCachedAPIReader     client.Reader
+	Log                    logr.Logger
+	Scheme                 *runtime.Scheme
+	MaxReconciling         int
+	RequeueOnLimitDelay    time.Duration
+	Resources              *resources.ResourceHelper
+	reconcilingRateLimiter unstableInstallationsRateLimiter
 }
 
 func NewMattermostReconciler(mgr ctrl.Manager, maxReconciling int, requeueOnLimitDelay time.Duration) *MattermostReconciler {
@@ -47,10 +50,14 @@ func NewMattermostReconciler(mgr ctrl.Manager, maxReconciling int, requeueOnLimi
 		MaxReconciling:      maxReconciling,
 		RequeueOnLimitDelay: requeueOnLimitDelay,
 		Resources:           resources.NewResourceHelper(mgr.GetClient(), mgr.GetScheme()),
+		reconcilingRateLimiter: unstableInstallationsRateLimiter{
+			nonReconcilingBeingProcessed: 0,
+			Mutex:                        sync.Mutex{},
+		},
 	}
 }
 
-func (r *MattermostReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *MattermostReconciler) SetupWithManager(mgr ctrl.Manager, maxConcurrency int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mmv1beta.Mattermost{}).
 		Owns(&corev1.Service{}).
@@ -58,6 +65,9 @@ func (r *MattermostReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&networkingv1.Ingress{}).
 		Owns(&appsv1.Deployment{}).
 		Owns(&batchv1.Job{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: maxConcurrency,
+		}).
 		Complete(r)
 }
 
@@ -84,17 +94,22 @@ func (r *MattermostReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	}
 
 	if mattermost.Status.State != mmv1beta.Reconciling {
-		var mmListInstallations mmv1beta.MattermostList
-		err = r.Client.List(ctx, &mmListInstallations)
+		canProcess, err := r.startNonReconcilingMMProcessing(ctx, reqLogger)
 		if err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "failed to list Mattermosts")
+			return reconcile.Result{}, errors.Wrap(err, "failed to verify reconciliation limit")
 		}
-
-		// Check if limit of Mattermosts reconciling at the same time is reached.
-		if countReconciling(mmListInstallations.Items) >= r.MaxReconciling {
+		if !canProcess {
 			reqLogger.Info(fmt.Sprintf("Reached limit of reconciling installations, requeuing in %s", r.RequeueOnLimitDelay.String()))
-			return ctrl.Result{RequeueAfter: r.RequeueOnLimitDelay}, nil
+			return reconcile.Result{RequeueAfter: r.RequeueOnLimitDelay}, nil
 		}
+		defer func() {
+			// We only count MMs that are being processed but are not in
+			// `reconciling` state, therefore when the function exists,
+			// regardless if the MM will be marked as `reconciling` or not we
+			// can decrement the counter. Status update will occur before
+			// decrement, so we are not risking races.
+			r.reconcilingRateLimiter.decrementProcessing()
+		}()
 	}
 
 	// We copy status to not to refetch the resource
@@ -178,6 +193,45 @@ func (r *MattermostReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 func (r *MattermostReconciler) updateSpec(ctx context.Context, reqLogger logr.Logger, updated *mmv1beta.Mattermost) error {
 	reqLogger.Info("Updating Mattermost spec")
 	return r.Client.Update(ctx, updated)
+}
+
+// startNonReconcilingMMProcessing verifies if the new Mattermost in
+// non-reconciling state can be currently processed by the Operator by checking
+// if the rate limit has been reached.
+// Returns false when rate limit is reached and processing cannot be started.
+func (r *MattermostReconciler) startNonReconcilingMMProcessing(ctx context.Context, reqLogger logr.Logger) (bool, error) {
+	r.reconcilingRateLimiter.Lock()
+	defer r.reconcilingRateLimiter.Unlock()
+
+	var mmListInstallations mmv1beta.MattermostList
+	err := r.Client.List(ctx, &mmListInstallations)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to list Mattermosts")
+	}
+
+	// Check if limit of Mattermosts reconciling at the same time is reached.
+	if countReconciling(mmListInstallations.Items)+r.reconcilingRateLimiter.nonReconcilingBeingProcessed >= r.MaxReconciling {
+		reqLogger.Info(fmt.Sprintf("Reached limit of reconciling or processing installations, requeuing in %s", r.RequeueOnLimitDelay.String()))
+		return false, nil
+	}
+
+	r.reconcilingRateLimiter.nonReconcilingBeingProcessed += 1
+
+	return true, nil
+}
+
+type unstableInstallationsRateLimiter struct {
+	// Number of CRs that are being actively processed by the reconciler but are
+	// not (yet) in Reconciling state. To respect the rate limit with multiple
+	// reconcilers we need to sync with mutex.
+	nonReconcilingBeingProcessed int
+	sync.Mutex
+}
+
+func (rl *unstableInstallationsRateLimiter) decrementProcessing() {
+	rl.Lock()
+	defer rl.Unlock()
+	rl.nonReconcilingBeingProcessed -= 1
 }
 
 func countReconciling(mattermosts []mmv1beta.Mattermost) int {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Support parallel reconciliation of Mattermost custom resources.

Given that we have a custom mechanism for rate-limiting reconciling Mattermost instances, this needs to be done carefully so that we do not exceed the limit due to a race condition between different workers.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Support parallel reconciliation
```
