### PR TITLE
Introduce the 'ready' state to signal instance readiness

### DIFF
--- a/apis/mattermost/v1beta1/mattermost_types.go
+++ b/apis/mattermost/v1beta1/mattermost_types.go
@@ -335,6 +335,9 @@ type RunningState string
 const (
 	// Reconciling is the state when the Mattermost instance is being updated
 	Reconciling RunningState = "reconciling"
+	// Ready is the state when the Mattermost instance is ready to start serving
+	// traffic but not fully stable.
+	Ready RunningState = "ready"
 	// Stable is the state when the Mattermost instance is fully running
 	Stable RunningState = "stable"
 )

--- a/controllers/mattermost/mattermost/controller.go
+++ b/controllers/mattermost/mattermost/controller.go
@@ -178,7 +178,7 @@ func (r *MattermostReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		if statusErr != nil {
 			reqLogger.Error(statusErr, "Error updating status")
 		}
-		reqLogger.Error(err, "Error checking Mattermost health")
+		reqLogger.Info("Mattermost instance not healthy", "msg", err.Error())
 		return reconcile.Result{RequeueAfter: healthCheckRequeueDelay}, nil
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
An instance is marked as `ready` when at least one pod is updated and all other resources are ready as well.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Introduce the 'ready' state to signal instance readiness
```
