### PR TITLE
Fixed changing service type between headless service and LoadBalancer

### DIFF
--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -104,6 +104,7 @@ func (r *MattermostReconciler) checkMattermostService(
 	}
 
 	if current.Spec.Type != desired.Spec.Type && current.Spec.Type != "" {
+		reqLogger.Info("Recreate service due to service type change", "name", current.Name)
 		err := r.Resources.DeleteService(types.NamespacedName{Namespace: current.Namespace, Name: current.Name}, reqLogger)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete service")

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -104,11 +104,12 @@ func (r *MattermostReconciler) checkMattermostService(
 	}
 
 	if current.Spec.Type != desired.Spec.Type && current.Spec.Type != "" {
-		reqLogger.Info("Recreate service due to service type change", "name", current.Name)
 		err := r.Resources.DeleteService(types.NamespacedName{Namespace: current.Namespace, Name: current.Name}, reqLogger)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete service")
 		}
+		reqLogger.Info("Recreate service due to service type change", "name", current.Name)
+
 		return r.Resources.Create(mattermost, desired, reqLogger)
 	}
 

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -103,6 +103,14 @@ func (r *MattermostReconciler) checkMattermostService(
 		return err
 	}
 
+	if current.Spec.Type != desired.Spec.Type {
+		err := r.Resources.DeleteService(types.NamespacedName{Namespace: current.Namespace, Name: current.Name}, reqLogger)
+		if err != nil {
+			return errors.Wrap(err, "failed to delete service")
+		}
+		return nil
+	}
+
 	resources.CopyServiceEmptyAutoAssignedFields(desired, current)
 
 	return r.Resources.Update(current, desired, reqLogger)

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -103,12 +103,11 @@ func (r *MattermostReconciler) checkMattermostService(
 		return err
 	}
 
-	if current.Spec.Type != desired.Spec.Type {
+	if current.Spec.Type != desired.Spec.Type && current.Spec.Type != "" {
 		err := r.Resources.DeleteService(types.NamespacedName{Namespace: current.Namespace, Name: current.Name}, reqLogger)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete service")
 		}
-		return nil
 	}
 
 	resources.CopyServiceEmptyAutoAssignedFields(desired, current)

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -104,11 +104,12 @@ func (r *MattermostReconciler) checkMattermostService(
 	}
 
 	if current.Spec.Type != desired.Spec.Type && current.Spec.Type != "" {
+		reqLogger.Info("Recreate service due to service type change", "name", current.Name)
 		err := r.Resources.DeleteService(types.NamespacedName{Namespace: current.Namespace, Name: current.Name}, reqLogger)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete service")
 		}
-		reqLogger.Info("Recreate service due to service type change", "name", current.Name)
+		reqLogger.Info("Creating service", "name", desired.Name)
 
 		return r.Resources.Create(mattermost, desired, reqLogger)
 	}

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -104,7 +104,7 @@ func (r *MattermostReconciler) checkMattermostService(
 	}
 
 	if current.Spec.Type != desired.Spec.Type && current.Spec.Type != "" {
-		reqLogger.Info("Recreate service due to service type change", "name", current.Name)
+		reqLogger.Info("Recreating service due to service type change", "name", current.Name)
 		err := r.Resources.DeleteService(types.NamespacedName{Namespace: current.Namespace, Name: current.Name}, reqLogger)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete service")

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -108,6 +108,7 @@ func (r *MattermostReconciler) checkMattermostService(
 		if err != nil {
 			return errors.Wrap(err, "failed to delete service")
 		}
+		return r.Resources.Create(mattermost, desired, reqLogger)
 	}
 
 	resources.CopyServiceEmptyAutoAssignedFields(desired, current)

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -96,21 +96,15 @@ func TestCheckMattermost(t *testing.T) {
 		require.NotNil(t, found)
 
 		original := found.DeepCopy()
-		modified := found.DeepCopy()
-		modified.Labels = nil
-		modified.Annotations = nil
-		modified.Spec = corev1.ServiceSpec{}
-		modified.Spec.Type = corev1.ServiceTypeLoadBalancer
 
-		err = reconciler.Client.Update(context.TODO(), modified)
-		require.NoError(t, err)
+		mm.Spec.UseServiceLoadBalancer = true
 		err = reconciler.checkMattermostService(mm, currentMMStatus, logger)
 		require.NoError(t, err)
 		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
 		assert.Equal(t, original.GetName(), found.GetName())
 		assert.Equal(t, original.GetNamespace(), found.GetNamespace())
-		assert.Equal(t, corev1.ServiceTypeClusterIP, found.Spec.Type)
+		assert.Equal(t, corev1.ServiceTypeLoadBalancer, found.Spec.Type)
 	})
 
 	t.Run("service account", func(t *testing.T) {

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -86,6 +86,33 @@ func TestCheckMattermost(t *testing.T) {
 		assert.Equal(t, original.Spec.Ports, found.Spec.Ports)
 	})
 
+	t.Run("recreate service on type change", func(t *testing.T) {
+		err = reconciler.checkMattermostService(mm, currentMMStatus, logger)
+		assert.NoError(t, err)
+
+		found := &corev1.Service{}
+		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
+		require.NoError(t, err)
+		require.NotNil(t, found)
+
+		original := found.DeepCopy()
+		modified := found.DeepCopy()
+		modified.Labels = nil
+		modified.Annotations = nil
+		modified.Spec = corev1.ServiceSpec{}
+		modified.Spec.Type = corev1.ServiceTypeLoadBalancer
+
+		err = reconciler.Client.Update(context.TODO(), modified)
+		require.NoError(t, err)
+		err = reconciler.checkMattermostService(mm, currentMMStatus, logger)
+		require.NoError(t, err)
+		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
+		require.NoError(t, err)
+		assert.Equal(t, original.GetName(), found.GetName())
+		assert.Equal(t, original.GetNamespace(), found.GetNamespace())
+		assert.Equal(t, corev1.ServiceTypeClusterIP, found.Spec.Type)
+	})
+
 	t.Run("service account", func(t *testing.T) {
 		err = reconciler.checkMattermostSA(mm, logger)
 		assert.NoError(t, err)

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -87,6 +87,7 @@ func configureMattermostService(service *corev1.Service) *corev1.Service {
 		},
 	}
 	service.Spec.ClusterIP = corev1.ClusterIPNone
+	service.Spec.Type = corev1.ServiceTypeClusterIP
 
 	return service
 }

--- a/pkg/resources/create_resources.go
+++ b/pkg/resources/create_resources.go
@@ -177,3 +177,20 @@ func (r *ResourceHelper) DeleteIngress(key types.NamespacedName, reqLogger logr.
 	}
 	return nil
 }
+
+func (r *ResourceHelper) DeleteService(key types.NamespacedName, reqLogger logr.Logger) error {
+	foundService := &corev1.Service{}
+	err := r.client.Get(context.TODO(), key, foundService)
+	if err != nil && k8sErrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Wrap(err, "failed to check if service exists")
+	}
+
+	reqLogger.Info("Deleting service", "name", foundService.Name)
+	err = r.client.Delete(context.TODO(), foundService)
+	if err != nil {
+		return errors.Wrap(err, "failed to delete service")
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
When the service type changes between headless and loadbalancer, the `ClusterIP` field is immutable. This requires the service to be deleted and re-created.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-operator/issues/244

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fixed changing service type between headless service and LoadBalancer
```
