### PR TITLE
Fix reconciliation of Installation with 0 replicas

### DIFF
--- a/controllers/mattermost/mattermost/controller.go
+++ b/controllers/mattermost/mattermost/controller.go
@@ -210,6 +210,7 @@ func (r *MattermostReconciler) startNonReconcilingMMProcessing(ctx context.Conte
 		return false, errors.Wrap(err, "failed to list Mattermosts")
 	}
 
+	reqLogger.Info("Non reconciling being processed", "processing", r.reconcilingRateLimiter.nonReconcilingBeingProcessed)
 	// Check if limit of Mattermosts reconciling at the same time is reached.
 	if countReconciling(mmListInstallations.Items)+r.reconcilingRateLimiter.nonReconcilingBeingProcessed >= r.MaxReconciling {
 		reqLogger.Info(fmt.Sprintf("Reached limit of reconciling or processing installations, requeuing in %s", r.RequeueOnLimitDelay.String()))

--- a/controllers/mattermost/mattermost/health_check.go
+++ b/controllers/mattermost/mattermost/health_check.go
@@ -53,7 +53,7 @@ func (r *MattermostReconciler) checkMattermostHealth(mattermost *mmv1beta.Matter
 		replicas = *mattermost.Spec.Replicas
 	}
 
-	if podsStatus.UpdatedReplicas == 0 {
+	if replicas > 0 && podsStatus.UpdatedReplicas == 0 {
 		return status, fmt.Errorf("mattermost pods not yet updated")
 	}
 
@@ -79,9 +79,11 @@ func (r *MattermostReconciler) checkMattermostHealth(mattermost *mmv1beta.Matter
 		status.Endpoint = endpoint
 	}
 
-	// At least one pod is updated and LB/Ingress is ready therefore we are at
-	// least ready to server traffic.
-	status.State = mmv1beta.Ready
+	if replicas > 0 {
+		// At least one pod is updated and LB/Ingress is ready therefore we are at
+		// least ready to server traffic.
+		status.State = mmv1beta.Ready
+	}
 
 	if podsStatus.UpdatedReplicas != replicas {
 		return status, fmt.Errorf("found %d updated replicas, but wanted %d", podsStatus.UpdatedReplicas, replicas)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Due to changes with `ready` state health check expected at least one pod to be updated which was not the case if replicas are set to 0. This was causing Installation to be stuck in a `reconciling` state.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fix reconciliation of Installation with 0 replicas
```
