### PR TITLE
Update podTemplate to be a pointer

### DIFF
--- a/apis/mattermost/v1beta1/mattermost_types.go
+++ b/apis/mattermost/v1beta1/mattermost_types.go
@@ -115,7 +115,7 @@ type MattermostSpec struct {
 
 	// PodTemplate defines configuration for the template for Mattermost pods.
 	// +optional
-	PodTemplate PodTemplate `json:"podTemplate,omitempty"`
+	PodTemplate *PodTemplate `json:"podTemplate,omitempty"`
 
 	// PodExtensions specify custom extensions for Mattermost pods.
 	// This can be used for custom readiness checks etc.

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -224,9 +224,11 @@ func (mm *Mattermost) MattermostPodLabels(name string) map[string]string {
 	if mm.Spec.ResourceLabels != nil {
 		l = mm.Spec.ResourceLabels
 	}
-	// Overwrite with pod specific labels
-	for k, v := range mm.Spec.PodTemplate.ExtraLabels {
-		l[k] = v
+	if mm.Spec.PodTemplate != nil {
+		// Overwrite with pod specific labels
+		for k, v := range mm.Spec.PodTemplate.ExtraLabels {
+			l[k] = v
+		}
 	}
 	// Overwrite with default labels
 	for k, v := range MattermostResourceLabels(name) {

--- a/apis/mattermost/v1beta1/zz_generated.deepcopy.go
+++ b/apis/mattermost/v1beta1/zz_generated.deepcopy.go
@@ -284,7 +284,11 @@ func (in *MattermostSpec) DeepCopyInto(out *MattermostSpec) {
 	out.ElasticSearch = in.ElasticSearch
 	in.Scheduling.DeepCopyInto(&out.Scheduling)
 	in.Probes.DeepCopyInto(&out.Probes)
-	in.PodTemplate.DeepCopyInto(&out.PodTemplate)
+	if in.PodTemplate != nil {
+		in, out := &in.PodTemplate, &out.PodTemplate
+		*out = new(PodTemplate)
+		(*in).DeepCopyInto(*out)
+	}
 	in.PodExtensions.DeepCopyInto(&out.PodExtensions)
 	if in.ResourcePatch != nil {
 		in, out := &in.ResourcePatch, &out.ResourcePatch

--- a/apis/mattermost/v1beta1/zz_generated.openapi.go
+++ b/apis/mattermost/v1beta1/zz_generated.openapi.go
@@ -296,7 +296,6 @@ func schema_mattermost_operator_apis_mattermost_v1beta1_MattermostSpec(ref commo
 					"podTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PodTemplate defines configuration for the template for Mattermost pods.",
-							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1.PodTemplate"),
 						},
 					},

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -253,12 +253,9 @@ func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig
 	liveness, readiness := setProbes(mattermost.Spec.Probes.LivenessProbe, mattermost.Spec.Probes.ReadinessProbe)
 
 	var containerSecurityContext *corev1.SecurityContext
-	if mattermost.Spec.PodTemplate != nil && mattermost.Spec.PodTemplate.ContainerSecurityContext != nil {
-		containerSecurityContext = mattermost.Spec.PodTemplate.ContainerSecurityContext
-	}
-
 	var podSecurityContext *corev1.PodSecurityContext
-	if mattermost.Spec.PodTemplate != nil && mattermost.Spec.PodTemplate.SecurityContext != nil {
+	if mattermost.Spec.PodTemplate != nil {
+		containerSecurityContext = mattermost.Spec.PodTemplate.ContainerSecurityContext
 		podSecurityContext = mattermost.Spec.PodTemplate.SecurityContext
 	}
 

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -221,7 +221,7 @@ func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig
 	podAnnotations := map[string]string{}
 
 	// Set user specified annotations
-	if mattermost.Spec.PodTemplate.ExtraAnnotations != nil {
+	if mattermost.Spec.PodTemplate != nil && mattermost.Spec.PodTemplate.ExtraAnnotations != nil {
 		podAnnotations = mattermost.Spec.PodTemplate.ExtraAnnotations
 	}
 
@@ -251,6 +251,16 @@ func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig
 	maxSurge := intstr.FromInt(defaultMaxSurge)
 
 	liveness, readiness := setProbes(mattermost.Spec.Probes.LivenessProbe, mattermost.Spec.Probes.ReadinessProbe)
+
+	var containerSecurityContext *corev1.SecurityContext
+	if mattermost.Spec.PodTemplate != nil && mattermost.Spec.PodTemplate.ContainerSecurityContext != nil {
+		containerSecurityContext = mattermost.Spec.PodTemplate.ContainerSecurityContext
+	}
+
+	var podSecurityContext *corev1.PodSecurityContext
+	if mattermost.Spec.PodTemplate != nil && mattermost.Spec.PodTemplate.SecurityContext != nil {
+		podSecurityContext = mattermost.Spec.PodTemplate.SecurityContext
+	}
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -302,7 +312,7 @@ func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig
 							LivenessProbe:   liveness,
 							VolumeMounts:    volumeMounts,
 							Resources:       mattermost.Spec.Scheduling.Resources,
-							SecurityContext: mattermost.Spec.PodTemplate.ContainerSecurityContext,
+							SecurityContext: containerSecurityContext,
 						},
 					},
 					ImagePullSecrets: mattermost.Spec.ImagePullSecrets,
@@ -312,7 +322,7 @@ func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig
 					Affinity:         mattermost.Spec.Scheduling.Affinity,
 					NodeSelector:     mattermost.Spec.Scheduling.NodeSelector,
 					Tolerations:      mattermost.Spec.Scheduling.Tolerations,
-					SecurityContext:  mattermost.Spec.PodTemplate.SecurityContext,
+					SecurityContext:  podSecurityContext,
 				},
 			},
 		},

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -41,7 +41,7 @@ func TestGenerateService_V1Beta(t *testing.T) {
 				ResourceLabels: map[string]string{
 					"resource": "label",
 				},
-				PodTemplate: mmv1beta.PodTemplate{
+				PodTemplate: &mmv1beta.PodTemplate{
 					ExtraLabels: map[string]string{
 						"pod": "label",
 					},
@@ -100,7 +100,7 @@ func TestGenerateService_V1Beta(t *testing.T) {
 				expectPort(t, service, 8067, utils.NewString("http"))
 			}
 
-			if mattermost.Spec.ResourceLabels != nil || mattermost.Spec.PodTemplate.ExtraLabels != nil {
+			if mattermost.Spec.ResourceLabels != nil || (mattermost.Spec.PodTemplate != nil && mattermost.Spec.PodTemplate.ExtraLabels != nil) {
 				expectLabels(t, service, mattermost.Spec)
 			}
 		})
@@ -602,7 +602,7 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 		{
 			name: "precedence order of labels",
 			spec: mmv1beta.MattermostSpec{
-				PodTemplate: mmv1beta.PodTemplate{
+				PodTemplate: &mmv1beta.PodTemplate{
 					ExtraLabels: map[string]string{
 						"app": "extraLabels",
 						"pod": "extraLabels",
@@ -633,7 +633,7 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 			name: "precedence order of annotations",
 			spec: mmv1beta.MattermostSpec{
 				LicenseSecret: "license-secret", // Add license for Prometheus annotations
-				PodTemplate: mmv1beta.PodTemplate{
+				PodTemplate: &mmv1beta.PodTemplate{
 					ExtraAnnotations: map[string]string{
 						"prometheus.io/path": "/notmetrics",
 						"owner":              "test",


### PR DESCRIPTION
Signed-off-by: Micah Nagel <micah.nagel@parsons.com>

#### Summary

Follow on to the discussion in https://github.com/mattermost/mattermost-operator/pull/301#discussion_r961601601

This changes the `podTemplate` in the MM spec to be a pointer (and updates all respective places to ensure nil checks are in place).

#### Release Note

```release-note
Update podTemplate to be a pointer
```
