### PR TITLE
[GH-216] Add e2e ingress tests

### DIFF
--- a/test/e2e-external/apply_resource.go
+++ b/test/e2e-external/apply_resource.go
@@ -3,7 +3,7 @@ package e2e
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"os"
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/pkg/errors"
@@ -14,7 +14,7 @@ import (
 )
 
 func CreateFromFile(ctx context.Context, k8sClient client.Client, namespace, path string) (func(), error) {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return func() {}, errors.Wrap(err, "failed to read file content")
 	}

--- a/test/e2e-external/ingress_test.go
+++ b/test/e2e-external/ingress_test.go
@@ -1,0 +1,67 @@
+package e2e
+
+import (
+	"testing"
+
+	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	pkgUtils "github.com/mattermost/mattermost-operator/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestMattermostCustomIngressOk Check that setting custom values in the mattermost ingress are
+func TestMattermostCustomIngressOk(t *testing.T) {
+	namespace := "e2e-test-custom-ingress"
+	name := "test-mm"
+
+	testEnv, err := SetupTestEnv(k8sClient, namespace)
+	require.NoError(t, err)
+	defer testEnv.CleanupFunc()
+
+	mattermost := &mmv1beta.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: mmv1beta.MattermostSpec{
+			Ingress: &mmv1beta.Ingress{
+				Host: "e2e-test-ingress.mattermost.dev",
+				Hosts: []mmv1beta.IngressHost{
+					{
+						HostName: "e2e-test-ingress-1.mattermost.dev",
+					},
+					{
+						HostName: "e2e-test-ingress-2.mattermost.dev",
+					},
+				},
+				Annotations: map[string]string{
+					"mattermost.test": "yes",
+				},
+				IngressClass: pkgUtils.NewString("custom-ingress-class"),
+			},
+			Replicas: pkgUtils.NewInt32(1),
+			FileStore: mmv1beta.FileStore{
+				External: &testEnv.FileStoreConfig,
+			},
+			Database: mmv1beta.Database{
+				External: &testEnv.DBConfig,
+			},
+		},
+	}
+
+	instance := NewMattermostInstance(t, k8sClient, mattermost)
+	defer instance.Destroy()
+
+	instance.CreateAndWait()
+
+	clusterMattermost := instance.Get()
+
+	// Check entire ingress object
+	assert.Equal(t, mattermost.Spec.Ingress, clusterMattermost.Spec.Ingress, "Mattermost Ingress spec should be the same as defined")
+
+	// Check specific attributes individually, in case deep equality fails for wathever reason
+	assert.Equal(t, mattermost.Spec.Ingress.Hosts, clusterMattermost.Spec.Ingress.Hosts, "Spec should have same hosts defined")
+	assert.Equal(t, mattermost.Spec.Ingress.Annotations, clusterMattermost.Spec.Ingress.Annotations, "Spec should contain specified annotations")
+	assert.Equal(t, mattermost.Spec.Ingress.IngressClass, clusterMattermost.Spec.Ingress.IngressClass, "Spec should contain the same ingress class")
+}

--- a/test/e2e-external/ingress_test.go
+++ b/test/e2e-external/ingress_test.go
@@ -84,7 +84,7 @@ func TestMattermostIngress(t *testing.T) {
 			mattermostSpecHosts = append(mattermostSpecHosts, host.HostName)
 		}
 
-		require.Equal(t, mattermostSpecHosts, mmIngressHosts, "Ingress should contain rules for each specified host")
+		require.ElementsMatch(t, mattermostSpecHosts, mmIngressHosts, "Ingress should contain rules for each specified host")
 		require.Equal(t, mattermost.Spec.Ingress.IngressClass, mmIngress.Spec.IngressClassName, "Ingress should have same ingress class defined")
 		for key, value := range mattermost.Spec.Ingress.Annotations {
 			require.Contains(t, mmIngress.Annotations, key, "Ingress should contain specified annotation")

--- a/test/e2e-external/ingress_test.go
+++ b/test/e2e-external/ingress_test.go
@@ -1,13 +1,15 @@
 package e2e
 
 import (
+	"context"
 	"testing"
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	pkgUtils "github.com/mattermost/mattermost-operator/pkg/utils"
 	"github.com/mattermost/mattermost-operator/test/e2e"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -59,10 +61,68 @@ func TestMattermostCustomIngressOk(t *testing.T) {
 	clusterMattermost := instance.Get()
 
 	// Check entire ingress object
-	assert.Equal(t, mattermost.Spec.Ingress, clusterMattermost.Spec.Ingress, "Mattermost Ingress spec should be the same as defined")
+	require.Equal(t, mattermost.Spec.Ingress, clusterMattermost.Spec.Ingress, "Mattermost Ingress spec should be the same as defined")
 
 	// Check specific attributes individually, in case deep equality fails for wathever reason
-	assert.Equal(t, mattermost.Spec.Ingress.Hosts, clusterMattermost.Spec.Ingress.Hosts, "Spec should have same hosts defined")
-	assert.Equal(t, mattermost.Spec.Ingress.Annotations, clusterMattermost.Spec.Ingress.Annotations, "Spec should contain specified annotations")
-	assert.Equal(t, mattermost.Spec.Ingress.IngressClass, clusterMattermost.Spec.Ingress.IngressClass, "Spec should contain the same ingress class")
+	require.Equal(t, mattermost.Spec.Ingress.Hosts, clusterMattermost.Spec.Ingress.Hosts, "Spec should have same hosts defined")
+	require.Equal(t, mattermost.Spec.Ingress.Annotations, clusterMattermost.Spec.Ingress.Annotations, "Spec should contain specified annotations")
+	require.Equal(t, mattermost.Spec.Ingress.IngressClass, clusterMattermost.Spec.Ingress.IngressClass, "Spec should contain the same ingress class")
+}
+
+func TestMattermostIngressDisableOk(t *testing.T) {
+	namespace := "e2e-test-ingress-disable"
+	name := "test-mm"
+
+	testEnv, err := SetupTestEnv(k8sClient, namespace)
+	require.NoError(t, err)
+	defer testEnv.CleanupFunc()
+
+	mattermost := &mmv1beta.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: mmv1beta.MattermostSpec{
+			Ingress: &mmv1beta.Ingress{
+				Enabled: true,
+				Host:    namespace + ".mattermost.dev",
+			},
+			Replicas: pkgUtils.NewInt32(1),
+			FileStore: mmv1beta.FileStore{
+				External: &testEnv.FileStoreConfig,
+			},
+			Database: mmv1beta.Database{
+				External: &testEnv.DBConfig,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	instance := e2e.NewMattermostInstance(t, k8sClient, mattermost)
+	defer instance.Destroy()
+
+	instance.CreateAndWait()
+
+	// Ensure the instance is created and with the ingress enabled and ingress object created
+	clusterMattermost := instance.Get()
+	require.NotNil(t, clusterMattermost.Spec.Ingress, "ingress should be defined")
+	require.True(t, clusterMattermost.IngressEnabled(), "ingress should be enabled at the beginning")
+
+	// Check that the ingress object is created
+	var mmIngress networkingv1.Ingress
+	err = k8sClient.Get(ctx, instance.Namespace(), &mmIngress)
+	require.NoError(t, err, "Ingress should be present in cluster")
+	require.Equal(t, name, mmIngress.Name)
+
+	// Disable the ingress and update the instance
+	clusterMattermost.Spec.Ingress.Enabled = false
+	instance.UpdateAndWait(&clusterMattermost)
+
+	// Ensure the ingress object has been removed
+	err = k8sClient.Get(ctx, instance.Namespace(), &mmIngress)
+	require.True(t, k8serrors.IsNotFound(err), "Ingress should be deleted after object update")
+
+	// Ensure the mattermost instance has the ingress disabled
+	clusterMattermost = instance.Get()
+	require.False(t, clusterMattermost.IngressEnabled(), "ingress should be disabled after resource update")
 }

--- a/test/e2e-external/ingress_test.go
+++ b/test/e2e-external/ingress_test.go
@@ -5,6 +5,7 @@ import (
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	pkgUtils "github.com/mattermost/mattermost-operator/pkg/utils"
+	"github.com/mattermost/mattermost-operator/test/e2e"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,7 +51,7 @@ func TestMattermostCustomIngressOk(t *testing.T) {
 		},
 	}
 
-	instance := NewMattermostInstance(t, k8sClient, mattermost)
+	instance := e2e.NewMattermostInstance(t, k8sClient, mattermost)
 	defer instance.Destroy()
 
 	instance.CreateAndWait()

--- a/test/e2e-external/instance.go
+++ b/test/e2e-external/instance.go
@@ -1,0 +1,125 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/mattermost/mattermost-operator/test/e2e"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	mattermostInstanceCreationTimeout = 15 * time.Second
+	mattermostInstanceWaitTimeout     = 3 * time.Minute
+	mattermostInstanceGetTimeout      = 60 * time.Second
+)
+
+// mattermostInstance defines a mattermost instance that is created in the test k8s cluster in order to ease the creation,
+// destruction and testing of the defined spec.
+// TODO: Ensure creation and deletion only happen once using sync.Once ? Not sure this is necessary since this is a testing
+// tool.
+type mattermostInstance struct {
+	t              *testing.T
+	mattermostSpec *mmv1beta.Mattermost
+	timeoutCreate  time.Duration
+	timeoutWait    time.Duration
+	timeoutGet     time.Duration
+	k8sClient      client.Client
+	namespaceName  types.NamespacedName
+	created        bool
+}
+
+// Namespace returns the NamespacedName in order to retrieve the object easily
+func (m *mattermostInstance) Namespace() types.NamespacedName {
+	return m.namespaceName
+}
+
+// Create creates the instance within the cluster
+func (m *mattermostInstance) Create() {
+	m.namespaceName = types.NamespacedName{
+		Namespace: m.mattermostSpec.Namespace,
+		Name:      m.mattermostSpec.Name,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), m.timeoutCreate)
+	defer cancel()
+
+	err := m.k8sClient.Create(ctx, m.mattermostSpec)
+	require.NoError(m.t, err)
+
+	m.created = true
+}
+
+// CreateAndWait Creates the instance within the cluster and waits until is a stable instance (failing if not)
+func (m *mattermostInstance) CreateAndWait() {
+	m.Create()
+
+	err := e2e.WaitForMattermostStable(m.t, m.k8sClient, m.Namespace(), m.timeoutWait)
+	require.NoError(m.t, err)
+}
+
+// Destroy destroys the created instance
+func (m *mattermostInstance) Destroy() {
+	if !m.created {
+		return
+	}
+
+	err := m.k8sClient.Delete(context.Background(), m.mattermostSpec)
+	require.NoError(m.t, err)
+}
+
+// Get retrieves the mattermost instance spec from the cluster
+func (m *mattermostInstance) Get() mmv1beta.Mattermost {
+	ctx, cancel := context.WithTimeout(context.Background(), m.timeoutGet)
+	defer cancel()
+
+	var mattermost mmv1beta.Mattermost
+	err := m.k8sClient.Get(ctx, m.Namespace(), &mattermost)
+	require.NoError(m.t, err, "Error retrieving created mattermost instance from cluster")
+
+	return mattermost
+}
+
+func NewMattermostInstance(t *testing.T, k8sClient client.Client, mattermost *mmv1beta.Mattermost) *mattermostInstance {
+	return &mattermostInstance{
+		t:              t,
+		k8sClient:      k8sClient,
+		mattermostSpec: mattermost,
+		timeoutCreate:  mattermostInstanceCreationTimeout,
+		timeoutWait:    mattermostInstanceWaitTimeout,
+		timeoutGet:     mattermostInstanceGetTimeout,
+	}
+}
+
+func ExampleMattermostInstance() {
+	var t testing.T
+	var k8sClient client.Client
+	specName := "mm-provided-name"
+
+	mattermost := &mmv1beta.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: specName,
+		},
+		// ...
+	}
+
+	// Setup the test instance
+	instance := NewMattermostInstance(&t, k8sClient, mattermost)
+	defer instance.Destroy()
+
+	// Create the instance on the cluster and wait for creation
+	instance.CreateAndWait()
+
+	// Retrieve the instance to check against it
+	clusterMattermost := instance.Get()
+
+	// Tests here
+	if clusterMattermost.Name != specName {
+		t.Errorf("Name should be `%s`", specName)
+	}
+}

--- a/test/e2e/instance.go
+++ b/test/e2e/instance.go
@@ -7,7 +7,6 @@ import (
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -113,33 +112,5 @@ func NewMattermostInstance(t *testing.T, k8sClient client.Client, mattermost *mm
 		timeoutWait:    mattermostInstanceWaitTimeout,
 		timeoutGet:     mattermostInstanceGetTimeout,
 		timeoutUpdate:  mattermostInstanceUpdateTimeout,
-	}
-}
-
-func ExampleMattermostInstance() {
-	var t testing.T
-	var k8sClient client.Client
-	specName := "mm-provided-name"
-
-	mattermost := &mmv1beta.Mattermost{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: specName,
-		},
-		// ...
-	}
-
-	// Setup the test instance
-	instance := NewMattermostInstance(&t, k8sClient, mattermost)
-	defer instance.Destroy()
-
-	// Create the instance on the cluster and wait for creation
-	instance.CreateAndWait()
-
-	// Retrieve the instance to check against it
-	clusterMattermost := instance.Get()
-
-	// Tests here
-	if clusterMattermost.Name != specName {
-		t.Errorf("Name should be `%s`", specName)
 	}
 }

--- a/test/e2e/instance.go
+++ b/test/e2e/instance.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
-	"github.com/mattermost/mattermost-operator/test/e2e"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -59,7 +58,7 @@ func (m *mattermostInstance) Create() {
 func (m *mattermostInstance) CreateAndWait() {
 	m.Create()
 
-	err := e2e.WaitForMattermostStable(m.t, m.k8sClient, m.Namespace(), m.timeoutWait)
+	err := WaitForMattermostStable(m.t, m.k8sClient, m.Namespace(), m.timeoutWait)
 	require.NoError(m.t, err)
 }
 

--- a/test/e2e/instance.go
+++ b/test/e2e/instance.go
@@ -62,10 +62,10 @@ func (m *mattermostInstance) CreateAndWait() {
 	m.Wait()
 }
 
-// Wait wait for the mattermost to be stable
+// Wait waits for the mattermost instance to be stable
 func (m *mattermostInstance) Wait() {
 	err := WaitForMattermostStable(m.t, m.k8sClient, m.Namespace(), m.timeoutWait)
-	require.NoError(m.t, err)
+	require.NoError(m.t, err, "Timed out waiting for a stable mattermost instance")
 }
 
 // Destroy destroys the created instance

--- a/test/e2e_local.sh
+++ b/test/e2e_local.sh
@@ -26,4 +26,4 @@ echo "Running operators e2e..."
 go test ./test/e2e --timeout 45m -v
 
 echo "Running external DB and File Store e2e..."
-go test ./test/e2e-extenal --timeout 15m -v
+go test ./test/e2e-external --timeout 15m -v


### PR DESCRIPTION
#### Summary

- Fixed a typo in `tests/e2e_local.sh` causing external tests to not run due to an incorrect path.
- Added a helper mattermost instance manager to the e2e suite to avoid repeating creation an deletion operations in tests.
  - Only implemented in this new test, a follow up PR could use it in the other tests as well (but I'm avoiding making this PR very big).
- Added an Ingress test to check that custom values for a Mattermost ingress are kept on instance creation by the operator
- Added an ingress test to check that disabling the ingress after having it enabled correctly disables the ingress on the resource and removes the ingress object from the cluster  

#### Ticket Link

https://github.com/mattermost/mattermost-operator/issues/216

#### Release Note

```release-note
NONE
```

#### Output

```
$ go test ./test/e2e-external --timeout 15m -v -run TestMattermostCustomIngressOk
=== RUN   TestMattermostCustomIngressOk
    utils.go:53: Waiting for Reconcilication finish (Status:reconciling)
    [...]
    utils.go:53: Waiting for Reconcilication finish (Status:reconciling)
    utils.go:59: Reconcilication completed (stable)
--- PASS: TestMattermostCustomIngressOk (43.82s)
PASS
ok  	github.com/mattermost/mattermost-operator/test/e2e-external	46.205s

$ go test ./test/e2e-external --timeout 15m -v -run TestMattermostIngressDisableOk
=== RUN   TestMattermostIngressDisableOk
    utils.go:53: Waiting for Reconcilication finish (Status:reconciling)
    [...]
    utils.go:53: Waiting for Reconcilication finish (Status:reconciling)
    utils.go:59: Reconcilication completed (stable)
    utils.go:59: Reconcilication completed (stable)
--- PASS: TestMattermostIngressDisableOk (40.26s)
PASS
ok  	github.com/mattermost/mattermost-operator/test/e2e-external	42.505s
```