### PR TITLE
Fix replicas status reported in Mattermost CR

### DIFF
--- a/controllers/mattermost/clusterinstallation/migration.go
+++ b/controllers/mattermost/clusterinstallation/migration.go
@@ -218,7 +218,7 @@ func (r *ClusterInstallationReconciler) isDeploymentReady(mm *mmv1beta.Mattermos
 
 	healthChecker := healthcheck.NewHealthChecker(r.NonCachedAPIReader, listOptions, logger)
 
-	status, err := healthChecker.CheckPodsRollOut(mm.GetImageName())
+	status, err := healthChecker.CheckReplicaSetRollout(mm.Name, mm.Namespace)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to check if pods are ready")
 	}

--- a/controllers/mattermost/clusterinstallation/migration.go
+++ b/controllers/mattermost/clusterinstallation/migration.go
@@ -218,7 +218,7 @@ func (r *ClusterInstallationReconciler) isDeploymentReady(mm *mmv1beta.Mattermos
 
 	healthChecker := healthcheck.NewHealthChecker(r.NonCachedAPIReader, listOptions, logger)
 
-	status, err := healthChecker.CheckReplicaSetRollout(mm.Name, mm.Namespace)
+	status, err := healthChecker.CheckPodsRollOut(mm.GetImageName())
 	if err != nil {
 		return false, errors.Wrap(err, "failed to check if pods are ready")
 	}

--- a/controllers/mattermost/clusterinstallation/utils.go
+++ b/controllers/mattermost/clusterinstallation/utils.go
@@ -95,14 +95,9 @@ func (r *ClusterInstallationReconciler) checkClusterInstallation(namespace, name
 
 	healthChecker := healthcheck.NewHealthChecker(r.NonCachedAPIReader, listOptions, logger)
 
-	err := healthChecker.AssertDeploymentRolloutStarted(name, namespace)
+	podsStatus, err := healthChecker.CheckReplicaSetRollout(name, namespace)
 	if err != nil {
 		return status, errors.Wrap(err, "rollout not yet started")
-	}
-
-	podsStatus, err := healthChecker.CheckPodsRollOut(imageName)
-	if err != nil {
-		return status, errors.Wrap(err, "failed to check pods status")
 	}
 
 	status.UpdatedReplicas = podsStatus.UpdatedReplicas

--- a/controllers/mattermost/mattermost/controller.go
+++ b/controllers/mattermost/mattermost/controller.go
@@ -169,6 +169,10 @@ func (r *MattermostReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 
 	if !recStatus.ResourcesReady {
 		reqLogger.Info("Mattermost resources not ready, delaying for 10 seconds!")
+		err = r.updateStatusReconciling(mattermost, status, reqLogger)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 		return ctrl.Result{RequeueAfter: resourcesReadyDelay}, nil
 	}
 

--- a/controllers/mattermost/mattermost/controller_test.go
+++ b/controllers/mattermost/mattermost/controller_test.go
@@ -211,7 +211,6 @@ func TestReconcile(t *testing.T) {
 		err = r.Get(context.TODO(), mmKey, &deployment)
 		require.NoError(t, err)
 		deployment.Status.Replicas = replicas
-
 		err = r.Update(context.TODO(), &deployment)
 		require.NoError(t, err)
 
@@ -222,6 +221,12 @@ func TestReconcile(t *testing.T) {
 		})
 
 		// Update ReplicaSet status - Replicas Available
+		err = r.Get(context.TODO(), mmKey, &deployment)
+		require.NoError(t, err)
+		deployment.Status.Replicas = replicas
+		err = r.Update(context.TODO(), &deployment)
+		require.NoError(t, err)
+
 		replicaSet.Status.AvailableReplicas = replicas
 		err = r.Update(context.TODO(), replicaSet)
 		require.NoError(t, err)

--- a/controllers/mattermost/mattermost/health_check.go
+++ b/controllers/mattermost/mattermost/health_check.go
@@ -35,14 +35,9 @@ func (r *MattermostReconciler) checkMattermostHealth(mattermost *mmv1beta.Matter
 
 	healthChecker := healthcheck.NewHealthChecker(r.NonCachedAPIReader, listOptions, logger)
 
-	err := healthChecker.AssertDeploymentRolloutStarted(mattermost.Name, mattermost.Namespace)
+	podsStatus, err := healthChecker.CheckReplicaSetRollout(mattermost.Name, mattermost.Namespace)
 	if err != nil {
 		return status, errors.Wrap(err, "rollout not yet started")
-	}
-
-	podsStatus, err := healthChecker.CheckPodsRollOut(mattermost.GetImageName())
-	if err != nil {
-		return status, errors.Wrap(err, "failed to check pods status")
 	}
 
 	status.UpdatedReplicas = podsStatus.UpdatedReplicas


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Checking ready replicas in Mattermost Operator is not working as intended as it considers old pods that were not yet terminated as `UpdatedReplicas` if the changes to manifest were something else than the Mattermost version. This causes the Operator to improperly report the `ready` state as it relies on `UpdatedReplicas` in the status.

For this check, we do not need to check all pods one by one but rather we can rely on the status of ReplicaSet which already provides this information.

Old `CheckPodsRollOut` is left out only for the purpose of not changing the migration logic that depends on it. After it is removed it can be cleaned up as well.

Additionally, this fixes a small issue that Mattermost CR might have not been set to a `reconciling` state if the initial update failed and the update job has already started.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Fix replicas status reported in Mattermost CR
```
