### PR TITLE
Update Go deps to mitigate CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/emicklei/go-restful v2.9.5+incompatible // indirect
+	github.com/emicklei/go-restful v2.16.0+incompatible // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/go-logr/zapr v1.2.0 // indirect
@@ -60,7 +60,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_golang v1.11.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,7 @@ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.16.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -22,7 +22,7 @@ github.com/cespare/xxhash/v2
 # github.com/davecgh/go-spew v1.1.1
 ## explicit
 github.com/davecgh/go-spew/spew
-# github.com/emicklei/go-restful v2.9.5+incompatible
+# github.com/emicklei/go-restful v2.16.0+incompatible
 ## explicit
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
@@ -153,7 +153,7 @@ github.com/pmezard/go-difflib/difflib
 # github.com/presslabs/mysql-operator v0.5.0-rc.2
 ## explicit; go 1.16
 github.com/presslabs/mysql-operator/pkg/apis/mysql/v1alpha1
-# github.com/prometheus/client_golang v1.11.0
+# github.com/prometheus/client_golang v1.11.1
 ## explicit; go 1.13
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/collectors


### PR DESCRIPTION
#### Summary
This PR fixes CVEs reported by `Trivy` scans so that self-hosted customers can get approval to run it in regulated environments. 

`Trivy` version used: `0.32.1`

`Trivy` scan results from the latest image of the operator as published on docker hub:

```trivy image --security-checks vuln --ignore-unfixed --severity HIGH,CRITICAL mattermost/mattermost-operator:v1.18.1
2022-10-11T18:54:18.858-0700    INFO     Need to update DB
2022-10-11T18:54:18.858-0700    INFO     DB Repository: ghcr.io/aquasecurity/trivy-db
2022-10-11T18:54:18.858-0700    INFO     Downloading DB...
34.34 MiB / 34.34 MiB [------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 5.54 MiB p/s 6.4s
2022-10-11T18:54:26.738-0700    INFO     Vulnerability scanning is enabled
2022-10-11T18:54:28.879-0700    INFO     Detected OS: debian
2022-10-11T18:54:28.879-0700    INFO     Detecting Debian vulnerabilities...
2022-10-11T18:54:28.880-0700    INFO     Number of language-specific files: 1
2022-10-11T18:54:28.880-0700    INFO     Detecting gobinary vulnerabilities...

mattermost/mattermost-operator:v1.18.1 (debian 11.3)

Total: 0 (HIGH: 0, CRITICAL: 0)

mattermost-operator (gobinary)

Total: 4 (HIGH: 3, CRITICAL: 1)

┌─────────────────────────────────────┬────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│               Library               │ Vulnerability  │ Severity │         Installed Version          │           Fixed Version           │                            Title                             │
├─────────────────────────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/emicklei/go-restful      │ CVE-2022-1996  │ CRITICAL │ v2.9.5+incompatible                │ 2.16.0                            │ go-restful: Authorization Bypass Through User-Controlled Key │
│                                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-1996                    │
├─────────────────────────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ github.com/prometheus/client_golang │ CVE-2022-21698 │ HIGH     │ v1.11.0                            │ 1.11.1                            │ prometheus/client_golang: Denial of service using            │
│                                     │                │          │                                    │                                   │ InstrumentHandlerCounter                                     │
│                                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-21698                   │
├─────────────────────────────────────┼────────────────┤          ├────────────────────────────────────┼───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ golang.org/x/net                    │ CVE-2021-44716 │          │ v0.0.0-20210825183410-e898025ed96a │ 0.0.0-20211209124913-491a49abca63 │ golang: net/http: limit growth of header canonicalization    │
│                                     │                │          │                                    │                                   │ cache                                                        │
│                                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-44716                   │
│                                     ├────────────────┤          │                                    ├───────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                     │ CVE-2022-27664 │          │                                    │ 0.0.0-20220906165146-f3363e06e74c │ golang: net/http: handle server errors after sending GOAWAY  │
│                                     │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27664                   │
└─────────────────────────────────────┴────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴──────────────────────────────────────────────────────────────┘
```

Trivy scan after the Go dep updates. 

```
trivy image --security-checks vuln --ignore-unfixed --severity HIGH,CRITICAL mattermost/mattermost-operator:test
2022-10-11T18:59:59.011-0700    INFO     Vulnerability scanning is enabled
2022-10-11T19:00:00.123-0700    INFO     Detected OS: debian
2022-10-11T19:00:00.123-0700    INFO     Detecting Debian vulnerabilities...
2022-10-11T19:00:00.126-0700    INFO     Number of language-specific files: 1
2022-10-11T19:00:00.126-0700    INFO     Detecting gobinary vulnerabilities...

mattermost/mattermost-operator:test (debian 11.5)

Total: 0 (HIGH: 0, CRITICAL: 0)


mattermost-operator (gobinary)

Total: 2 (HIGH: 2, CRITICAL: 0)

┌──────────────────┬────────────────┬──────────┬────────────────────────────────────┬───────────────────────────────────┬─────────────────────────────────────────────────────────────┐
│     Library      │ Vulnerability  │ Severity │         Installed Version          │           Fixed Version           │                            Title                            │
├──────────────────┼────────────────┼──────────┼────────────────────────────────────┼───────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│ golang.org/x/net │ CVE-2021-44716 │ HIGH     │ v0.0.0-20210825183410-e898025ed96a │ 0.0.0-20211209124913-491a49abca63 │ golang: net/http: limit growth of header canonicalization   │
│                  │                │          │                                    │                                   │ cache                                                       │
│                  │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2021-44716                  │
│                  ├────────────────┤          │                                    ├───────────────────────────────────┼─────────────────────────────────────────────────────────────┤
│                  │ CVE-2022-27664 │          │                                    │ 0.0.0-20220906165146-f3363e06e74c │ golang: net/http: handle server errors after sending GOAWAY │
│                  │                │          │                                    │                                   │ https://avd.aquasec.com/nvd/cve-2022-27664                  │
└──────────────────┴────────────────┴──────────┴────────────────────────────────────┴───────────────────────────────────┴─────────────────────────────────────────────────────────────┘
```
* This image was built locally and tested against a local `KIND` cluster by following the README instructions.
*  Since we are not enabling Http2, the remaining HIGH CVEs from package `golang.org/x/net` was not addressed in this PR.


#### Ticket Link
NONE

#### Release Note
NONE

```release-note
NONE
```