### PR TITLE
feat(filestore): use service account for s3 api calls

### DIFF
--- a/apis/mattermost/v1beta1/mattermost_types.go
+++ b/apis/mattermost/v1beta1/mattermost_types.go
@@ -369,6 +369,9 @@ type ExternalFileStore struct {
 	// Optionally enter the name of already existing secret.
 	// Secret should have two values: "accesskey" and "secretkey".
 	Secret string `json:"secret,omitempty"`
+
+	// Optionally use service account with IAM role to access AWS services, like S3.
+	UseServiceAccount bool `json:"useServiceAccount,omitempty"`
 }
 
 // ExternalVolumeFileStore defines the configuration of an externally managed

--- a/config/crd/bases/installation.mattermost.com_mattermosts.yaml
+++ b/config/crd/bases/installation.mattermost.com_mattermosts.yaml
@@ -250,6 +250,10 @@ spec:
                       url:
                         description: Set to use an external MinIO deployment or S3.
                         type: string
+                      useServiceAccount:
+                        description: Optionally use service account with IAM role
+                          to access AWS services, like S3.
+                        type: boolean
                     type: object
                   externalVolume:
                     description: Defines the configuration of externally managed PVC

--- a/controllers/mattermost/mattermost/file_store.go
+++ b/controllers/mattermost/mattermost/file_store.go
@@ -36,7 +36,7 @@ func (r *MattermostReconciler) checkFileStore(mattermost *mmv1beta.Mattermost, r
 
 func (r *MattermostReconciler) checkExternalFileStore(mattermost *mmv1beta.Mattermost, reqLogger logr.Logger) (mattermostApp.FileStoreConfig, error) {
 	if mattermost.Spec.FileStore.External.UseServiceAccount {
-		return mattermostApp.NewExternalFileStoreInfoWithoutSecret(mattermost)
+		return mattermostApp.NewExternalFileStoreInfo(mattermost, nil)
 	}
 
 	secret := &corev1.Secret{}
@@ -46,7 +46,7 @@ func (r *MattermostReconciler) checkExternalFileStore(mattermost *mmv1beta.Matte
 		return nil, err
 	}
 
-	return mattermostApp.NewExternalFileStoreInfo(mattermost, *secret)
+	return mattermostApp.NewExternalFileStoreInfo(mattermost, secret)
 }
 
 func (r *MattermostReconciler) checkExternalVolumeFileStore(mattermost *mmv1beta.Mattermost, reqLogger logr.Logger) (mattermostApp.FileStoreConfig, error) {

--- a/controllers/mattermost/mattermost/file_store.go
+++ b/controllers/mattermost/mattermost/file_store.go
@@ -35,7 +35,7 @@ func (r *MattermostReconciler) checkFileStore(mattermost *mmv1beta.Mattermost, r
 }
 
 func (r *MattermostReconciler) checkExternalFileStore(mattermost *mmv1beta.Mattermost, reqLogger logr.Logger) (mattermostApp.FileStoreConfig, error) {
-	if mattermost.Spec.FileStore.IsExternal() && mattermost.Spec.FileStore.External.UseServiceAccount {
+	if mattermost.Spec.FileStore.External.UseServiceAccount {
 		return mattermostApp.NewExternalFileStoreInfoWithoutSecret(mattermost)
 	}
 

--- a/controllers/mattermost/mattermost/file_store.go
+++ b/controllers/mattermost/mattermost/file_store.go
@@ -35,6 +35,10 @@ func (r *MattermostReconciler) checkFileStore(mattermost *mmv1beta.Mattermost, r
 }
 
 func (r *MattermostReconciler) checkExternalFileStore(mattermost *mmv1beta.Mattermost, reqLogger logr.Logger) (mattermostApp.FileStoreConfig, error) {
+	if mattermost.Spec.FileStore.IsExternal() && mattermost.Spec.FileStore.External.UseServiceAccount {
+		return mattermostApp.NewExternalFileStoreInfoWithoutSecret(mattermost)
+	}
+
 	secret := &corev1.Secret{}
 	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: mattermost.Spec.FileStore.External.Secret, Namespace: mattermost.Namespace}, secret)
 	if err != nil {

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -129,6 +129,7 @@ func (r *MattermostReconciler) checkMattermostRBAC(mattermost *mmv1beta.Mattermo
 	if err != nil {
 		return errors.Wrap(err, "failed to check mattermost ServiceAccount")
 	}
+
 	err = r.checkMattermostRole(mattermost, reqLogger)
 	if err != nil {
 		return errors.Wrap(err, "failed to check mattermost Role")
@@ -142,23 +143,11 @@ func (r *MattermostReconciler) checkMattermostRBAC(mattermost *mmv1beta.Mattermo
 }
 
 func (r *MattermostReconciler) checkMattermostSA(mattermost *mmv1beta.Mattermost, reqLogger logr.Logger) error {
-	desired := mattermostApp.GenerateServiceAccountV1Beta(mattermost, mattermost.Name)
-
 	if mattermost.Spec.FileStore.External != nil && mattermost.Spec.FileStore.External.UseServiceAccount {
-		current := &corev1.ServiceAccount{}
-		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, current)
-		if err != nil && k8sErrors.IsNotFound(err) {
-			return errors.Wrap(err, "service account needs to be created manually if fileStore.external.useServiceAccount is true")
-		} else if err != nil {
-			return errors.Wrap(err, "failed to check if service account exists")
-		}
-
-		if _, ok := current.Annotations["eks.amazonaws.com/role-arn"]; !ok {
-			return fmt.Errorf(`service account does not have "eks.amazonaws.com/role-arn" annotation, which is required if fileStore.external.useServiceAccount is true`)
-		}
-
 		return nil
 	}
+
+	desired := mattermostApp.GenerateServiceAccountV1Beta(mattermost, mattermost.Name)
 
 	err := r.Resources.CreateServiceAccountIfNotExists(mattermost, desired, reqLogger)
 	if err != nil {

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -144,29 +144,32 @@ func TestCheckMattermost(t *testing.T) {
 		require.NoError(t, err)
 		err = reconciler.checkMattermostSA(mm, logger)
 		assert.NoError(t, err)
-		found2 := &corev1.ServiceAccount{}
-		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found2)
+		found = &corev1.ServiceAccount{}
+		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
 		require.NoError(t, err)
-		require.Equal(t, "asd", found2.Annotations["eks.amazonaws.com/role-arn"])
+		require.Equal(t, "asd", found.Annotations["eks.amazonaws.com/role-arn"])
 		err = reconciler.Client.Delete(context.TODO(), sa)
 		require.NoError(t, err)
 
-		err = reconciler.checkMattermostSA(mm, logger)
-		require.Error(t, err)
-		require.Equal(t, `service account needs to be created manually if fileStore.external.useServiceAccount is true: serviceaccounts "foo" not found`, err.Error())
+		mm.Spec.FileStore.External = nil
 
-		sa2 := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      mmName,
-				Namespace: mmNamespace,
-			},
-		}
-		err = reconciler.Client.Create(context.TODO(), sa2)
+		err = reconciler.checkMattermostSA(mm, logger)
+		assert.NoError(t, err)
+		found = &corev1.ServiceAccount{}
+		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
+		require.NoError(t, err)
+		err = reconciler.Client.Delete(context.TODO(), sa)
 		require.NoError(t, err)
 
+		mm.Spec.FileStore.External = &mmv1beta.ExternalFileStore{
+			UseServiceAccount: false,
+		}
+
 		err = reconciler.checkMattermostSA(mm, logger)
-		require.Error(t, err)
-		require.Equal(t, `service account does not have "eks.amazonaws.com/role-arn" annotation, which is required if fileStore.external.useServiceAccount is true`, err.Error())
+		assert.NoError(t, err)
+		found = &corev1.ServiceAccount{}
+		err = reconciler.Client.Get(context.TODO(), types.NamespacedName{Name: mmName, Namespace: mmNamespace}, found)
+		require.NoError(t, err)
 	})
 
 	t.Run("role", func(t *testing.T) {

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -780,7 +780,7 @@ func TestCheckMattermostExternalDBAndFileStore(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	fileStoreInfo, err := mattermostApp.NewExternalFileStoreInfo(mm, corev1.Secret{
+	fileStoreInfo, err := mattermostApp.NewExternalFileStoreInfo(mm, &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "fileStoreSecret"},
 		Data: map[string][]byte{
 			"accesskey": []byte("my-key"),

--- a/docs/mattermost-operator/mattermost-operator.yaml
+++ b/docs/mattermost-operator/mattermost-operator.yaml
@@ -1824,6 +1824,12 @@ spec:
             properties:
               awsLoadBalancerController:
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations defines annotations passed to the Ingress
+                      associated with Mattermost.
+                    type: object
                   certificateARN:
                     description: Certificate arn for the ALB, required if SSL enabled
                     type: string
@@ -2011,6 +2017,10 @@ spec:
                       url:
                         description: Set to use an external MinIO deployment or S3.
                         type: string
+                      useServiceAccount:
+                        description: Optionally use service account with IAM role
+                          to access AWS services, like S3.
+                        type: boolean
                     type: object
                   externalVolume:
                     description: Defines the configuration of externally managed PVC

--- a/pkg/mattermost/env_var.go
+++ b/pkg/mattermost/env_var.go
@@ -61,18 +61,10 @@ func s3EnvVars(fileStore *FileStoreInfo) []corev1.EnvVar {
 	minioAccessEnv := EnvSourceFromSecret(fileStore.secretName, fileStoreSecretAccessKey)
 	minioSecretEnv := EnvSourceFromSecret(fileStore.secretName, fileStoreSecretSecretKey)
 
-	return []corev1.EnvVar{
+	envs := []corev1.EnvVar{
 		{
 			Name:  "MM_FILESETTINGS_DRIVERNAME",
 			Value: "amazons3",
-		},
-		{
-			Name:      "MM_FILESETTINGS_AMAZONS3ACCESSKEYID",
-			ValueFrom: minioAccessEnv,
-		},
-		{
-			Name:      "MM_FILESETTINGS_AMAZONS3SECRETACCESSKEY",
-			ValueFrom: minioSecretEnv,
 		},
 		{
 			Name:  "MM_FILESETTINGS_AMAZONS3BUCKET",
@@ -87,6 +79,19 @@ func s3EnvVars(fileStore *FileStoreInfo) []corev1.EnvVar {
 			Value: strconv.FormatBool(fileStore.useS3SSL),
 		},
 	}
+
+	if fileStore.secretName != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:      "MM_FILESETTINGS_AMAZONS3ACCESSKEYID",
+			ValueFrom: minioAccessEnv,
+		})
+		envs = append(envs, corev1.EnvVar{
+			Name:      "MM_FILESETTINGS_AMAZONS3SECRETACCESSKEY",
+			ValueFrom: minioSecretEnv,
+		})
+	}
+
+	return envs
 }
 
 func elasticSearchEnvVars(host, user, password string) []corev1.EnvVar {

--- a/pkg/mattermost/env_var.go
+++ b/pkg/mattermost/env_var.go
@@ -58,9 +58,6 @@ func localFileEnvVars(filePath string) []corev1.EnvVar {
 }
 
 func s3EnvVars(fileStore *FileStoreInfo) []corev1.EnvVar {
-	minioAccessEnv := EnvSourceFromSecret(fileStore.secretName, fileStoreSecretAccessKey)
-	minioSecretEnv := EnvSourceFromSecret(fileStore.secretName, fileStoreSecretSecretKey)
-
 	envs := []corev1.EnvVar{
 		{
 			Name:  "MM_FILESETTINGS_DRIVERNAME",
@@ -81,6 +78,9 @@ func s3EnvVars(fileStore *FileStoreInfo) []corev1.EnvVar {
 	}
 
 	if fileStore.secretName != "" {
+		minioAccessEnv := EnvSourceFromSecret(fileStore.secretName, fileStoreSecretAccessKey)
+		minioSecretEnv := EnvSourceFromSecret(fileStore.secretName, fileStoreSecretSecretKey)
+
 		envs = append(envs, corev1.EnvVar{
 			Name:      "MM_FILESETTINGS_AMAZONS3ACCESSKEYID",
 			ValueFrom: minioAccessEnv,

--- a/pkg/mattermost/file_store.go
+++ b/pkg/mattermost/file_store.go
@@ -155,7 +155,7 @@ func (e *OperatorManagedMinioConfig) Volumes(_ *mmv1beta.Mattermost) ([]corev1.V
 	return []corev1.Volume{}, []corev1.VolumeMount{}
 }
 
-func NewExternalFileStoreInfo(mattermost *mmv1beta.Mattermost, secret corev1.Secret) (FileStoreConfig, error) {
+func NewExternalFileStoreInfo(mattermost *mmv1beta.Mattermost, secret *corev1.Secret) (FileStoreConfig, error) {
 	if mattermost.Spec.FileStore.External == nil {
 		return nil, errors.New("external file store configuration not provided")
 	}
@@ -166,6 +166,16 @@ func NewExternalFileStoreInfo(mattermost *mmv1beta.Mattermost, secret corev1.Sec
 	url := mattermost.Spec.FileStore.External.URL
 	if url == "" {
 		return nil, errors.New("external file store URL is empty")
+	}
+
+	if secret == nil {
+		return &ExternalFileStore{
+			fsInfo: FileStoreInfo{
+				bucketName: bucket,
+				url:        url,
+				useS3SSL:   true,
+			},
+		}, nil
 	}
 
 	if _, ok := secret.Data["accesskey"]; !ok {
@@ -178,28 +188,6 @@ func NewExternalFileStoreInfo(mattermost *mmv1beta.Mattermost, secret corev1.Sec
 	return &ExternalFileStore{
 		fsInfo: FileStoreInfo{
 			secretName: secret.Name,
-			bucketName: bucket,
-			url:        url,
-			useS3SSL:   true,
-		},
-	}, nil
-}
-
-func NewExternalFileStoreInfoWithoutSecret(mattermost *mmv1beta.Mattermost) (FileStoreConfig, error) {
-	if mattermost.Spec.FileStore.External == nil {
-		return nil, errors.New("external file store configuration not provided")
-	}
-	bucket := mattermost.Spec.FileStore.External.Bucket
-	if bucket == "" {
-		return nil, errors.New("external file store bucket is empty")
-	}
-	url := mattermost.Spec.FileStore.External.URL
-	if url == "" {
-		return nil, errors.New("external file store URL is empty")
-	}
-
-	return &ExternalFileStore{
-		fsInfo: FileStoreInfo{
 			bucketName: bucket,
 			url:        url,
 			useS3SSL:   true,

--- a/pkg/mattermost/file_store.go
+++ b/pkg/mattermost/file_store.go
@@ -185,6 +185,28 @@ func NewExternalFileStoreInfo(mattermost *mmv1beta.Mattermost, secret corev1.Sec
 	}, nil
 }
 
+func NewExternalFileStoreInfoWithoutSecret(mattermost *mmv1beta.Mattermost) (FileStoreConfig, error) {
+	if mattermost.Spec.FileStore.External == nil {
+		return nil, errors.New("external file store configuration not provided")
+	}
+	bucket := mattermost.Spec.FileStore.External.Bucket
+	if bucket == "" {
+		return nil, errors.New("external file store bucket is empty")
+	}
+	url := mattermost.Spec.FileStore.External.URL
+	if url == "" {
+		return nil, errors.New("external file store URL is empty")
+	}
+
+	return &ExternalFileStore{
+		fsInfo: FileStoreInfo{
+			bucketName: bucket,
+			url:        url,
+			useS3SSL:   true,
+		},
+	}, nil
+}
+
 func NewExternalVolumeFileStoreInfo(mattermost *mmv1beta.Mattermost) (FileStoreConfig, error) {
 	if mattermost.Spec.FileStore.ExternalVolume == nil {
 		return nil, errors.New("external volume file store configuration not provided")

--- a/pkg/mattermost/file_store_test.go
+++ b/pkg/mattermost/file_store_test.go
@@ -47,7 +47,7 @@ func TestFileStore(t *testing.T) {
 			},
 		}
 
-		secret := corev1.Secret{
+		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "external-file-store"},
 			Data: map[string][]byte{
 				"accesskey": []byte("key"),
@@ -75,7 +75,7 @@ func TestFileStore(t *testing.T) {
 			},
 		}
 
-		config, err := NewExternalFileStoreInfoWithoutSecret(mattermost)
+		config, err := NewExternalFileStoreInfo(mattermost, nil)
 		fileStore := config.(*ExternalFileStore)
 		require.NoError(t, err)
 		initContainers := fileStore.InitContainers(mattermost)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Makes using a secret for S3 optional. Instead, gives an option to UseServiceAccount instead.
This feature is quite important to ensure security standards.

#### Ticket Link
Fixes #315 

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Makes using a secret for S3 calls optional, gives an option to UseServiceAccount with IAM role instead.
```
