### PR TITLE
Support PVC pending states for external volume filestores

### DIFF
--- a/apis/mattermost/v1beta1/file_store_util.go
+++ b/apis/mattermost/v1beta1/file_store_util.go
@@ -12,7 +12,7 @@ import (
 
 // SetDefaults sets the missing values in FileStore to the default ones.
 func (fs *FileStore) SetDefaults() {
-	if fs.IsExternal() {
+	if fs.IsExternal() || fs.IsExternalVolume() || fs.IsLocal() {
 		return
 	}
 

--- a/controllers/mattermost/mattermost/file_store.go
+++ b/controllers/mattermost/mattermost/file_store.go
@@ -51,7 +51,7 @@ func (r *MattermostReconciler) checkExternalVolumeFileStore(mattermost *mmv1beta
 		return nil, errors.Wrap(err, "failed to create external volume FileStoreConfig")
 	}
 
-	// Ensure that the PVC exists and is bound.
+	// Ensure that the PVC exists and is in a valid state.
 	pvc := &corev1.PersistentVolumeClaim{}
 	err = r.Client.Get(context.TODO(), types.NamespacedName{
 		Name:      mattermost.Spec.FileStore.ExternalVolume.VolumeClaimName,
@@ -61,8 +61,8 @@ func (r *MattermostReconciler) checkExternalVolumeFileStore(mattermost *mmv1beta
 		reqLogger.Error(err, "failed to get specified PVC for external volume storage")
 		return nil, err
 	}
-	if pvc.Status.Phase != corev1.ClaimBound {
-		err := errors.Errorf("specified PVC for external volume storage is not %s (%s)", corev1.ClaimBound, pvc.Status.Phase)
+	if pvc.Status.Phase != corev1.ClaimBound && pvc.Status.Phase != corev1.ClaimPending {
+		err := errors.Errorf("specified PVC for external volume storage is not %s or %s (%s)", corev1.ClaimBound, corev1.ClaimPending, pvc.Status.Phase)
 		reqLogger.Error(err, "failed checking PVC status")
 		return nil, err
 	}


### PR DESCRIPTION
Pending state is valid as well as bound for PVCs that Mattermost can use. This change also corrects some SetDefaults() behavior for filestores.

Fixes https://mattermost.atlassian.net/browse/MM-48932

```release-note
Support PVC pending states for external volume filestores
```
