### PR TITLE
Improve filestore defaults logic

### DIFF
--- a/apis/mattermost/v1beta1/file_store_util.go
+++ b/apis/mattermost/v1beta1/file_store_util.go
@@ -12,7 +12,7 @@ import (
 
 // SetDefaults sets the missing values in FileStore to the default ones.
 func (fs *FileStore) SetDefaults() {
-	if fs.IsExternal() || fs.IsExternalVolume() || fs.IsLocal() {
+	if fs.isAnyExceptOperatorManaged() {
 		return
 	}
 
@@ -36,6 +36,13 @@ func (fs *FileStore) IsLocal() bool {
 	return fs.Local != nil && fs.Local.Enabled
 }
 
+// isAnyExceptOperatorManaged checks if any filestore types are configurated
+// except the operator managed type. This is generally used to see if defaults
+// should be applied.
+func (fs *FileStore) isAnyExceptOperatorManaged() bool {
+	return fs.IsExternal() || fs.IsExternalVolume() || fs.IsLocal()
+}
+
 func (fs *FileStore) ensureDefault() {
 	if fs.OperatorManaged == nil {
 		fs.OperatorManaged = &OperatorManagedMinio{}
@@ -50,7 +57,7 @@ func (omm *OperatorManagedMinio) SetDefaults() {
 }
 
 func (fs *FileStore) SetDefaultReplicasAndResources() {
-	if fs.IsExternal() {
+	if fs.isAnyExceptOperatorManaged() {
 		return
 	}
 	fs.ensureDefault()
@@ -67,7 +74,7 @@ func (omm *OperatorManagedMinio) SetDefaultReplicasAndResources() {
 }
 
 func (fs *FileStore) OverrideReplicasAndResourcesFromSize(size mattermostv1alpha1.ClusterInstallationSize) {
-	if fs.IsExternal() {
+	if fs.isAnyExceptOperatorManaged() {
 		return
 	}
 	fs.ensureDefault()

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -45,7 +45,7 @@ const (
 	MattermostAppContainerName = "mattermost"
 )
 
-// SetDefaults set the missing values in the manifest to the default ones
+// SetDefaults sets the missing values in the manifest to the default ones
 func (mm *Mattermost) SetDefaults() error {
 	if mm.AWSLoadBalancerEnabled() && len(mm.Spec.AWSLoadBalancerController.Hosts) == 0 {
 		return errors.New("awsLoadBalancerController.hosts is required, but not set")


### PR DESCRIPTION
This corrects an issue where some operator managed filestore default settings could be applied when not using an operator managed filestore type. These settings would be ignored when reconciling the Mattermost resources, but could be confusing when reviewing the resource.

```release-note
Improve filestore defaults logic
```
