### PR TITLE
Migrate from CircleCI to Github Actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,34 @@
+name: cd
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types:
+      - completed
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v3.2.0
+        with:
+          fetch-depth: 0
+
+      - name: cd/build-docker
+        run: make build-image
+
+      - name: ci/push-docker
+        run: |
+          set -e
+          set -u
+          echo $DOCKERHUB_TOKEN | docker login --username $DOCKERHUB_USERNAME --password-stdin
+          docker tag mattermost/mattermost-operator:test mattermost/mattermost-operator:$TAG
+          docker push mattermost/mattermost-operator:$TAG
+        env:
+          TAG: ${GITHUB_REF_NAME}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,110 @@
+name: ci
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: "1.16.3"
+          cache: true
+
+      - name: ci/check-style
+        run: make check-style
+
+      - name: ci/check-modules
+        run: make check-modules
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: "1.16.3"
+
+      - name: Generate Operator Manifests
+        run: |
+          make clean operator-sdk
+          mkdir -p /tmp/apis/mattermost/v1alpha1
+
+          cp -R apis/mattermost/v1alpha1/* /tmp/apis/mattermost/v1alpha1
+          mkdir -p /tmp/apis/mattermost/v1beta1
+          cp -R apis/mattermost/v1beta1/* /tmp/apis/mattermost/v1beta1
+          mkdir -p /tmp/config/crd/bases
+          cp -R config/crd/bases/* /tmp/config/crd/bases
+
+          make generate manifests
+          diff /tmp/apis/mattermost/v1alpha1 apis/mattermost/v1alpha1
+          diff /tmp/apis/mattermost/v1beta1 apis/mattermost/v1beta1
+          diff /tmp/config/crd/bases config/crd/bases
+
+      - name: ci/test
+        run: make unittest goverall
+
+      - name: ci/test-e2e
+        run: ./test/e2e.sh
+        env:
+          K8S_VERSION: v1.17.5
+          IMAGE_NAME: mattermost/mattermost-operator
+          IMAGE_TAG: test
+          KIND_VERSION: v0.8.1
+          SDK_VERSION: v1.0.1
+
+  build:
+    if: ${{ github.event_name == 'pull_request' || github.ref_name  == 'master' }}
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@dc323e67f16fb5f7663d20ff7941f27f5809e9b6 # v3.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Set short SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: ci/build-docker
+        run: make build-image
+
+      - name: ci/scan-docker-security
+        uses: aquasecurity/trivy-action@9ab158e8597f3b310480b9a69402b419bc03dbd5 # v0.8.0
+        with:
+          image-ref: "mattermost/mattermost-operator"
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
+
+      - name: ci/push-docker
+        run: |
+          set -e
+          set -u
+          TAG="${GITHUB_SHA:0:7}"
+          echo $DOCKERHUB_TOKEN | docker login --username $DOCKERHUB_USERNAME --password-stdin
+          docker tag mattermost/mattermost-operator:test mattermost/mattermost-operator:$TAG
+          docker push mattermost/mattermost-operator:$TAG
+        env:
+          TAG: ${GITHUB_SHA:0:7}


### PR DESCRIPTION
#### Summary
We gradually moving away from CirlceCI to Github Actions as we are consolidating the CIs we use. In parallel we are introducing `trivy` in the PR level and we block the PR about the number of critical vulnerabilities.

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/CLD-4711

#### Release Note
```release-note
NONE
```
