### PR TITLE
[MM-49782] Change default revision history limit for Mattermost deployment

### DIFF
--- a/pkg/mattermost/constants.go
+++ b/pkg/mattermost/constants.go
@@ -13,7 +13,7 @@ const (
 	// possible roll-back points.
 	// More details:
 	// https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment
-	defaultRevHistoryLimit = 5
+	defaultRevHistoryLimit = 1
 	// defaultMaxUnavailable is the default max number of unavailable pods out
 	// of specified `Replicas` during rolling update.
 	// More details:


### PR DESCRIPTION
#### Summary

Scaled down the default revision history limit for Mattermost installations deployments from 5 to 1.

This should reconcile all installation's deployments, though no downtime is expected since it would only update the `revisionHistoryLimit` field while the replicaset controller removes old revisions. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49782

#### Release Note

```release-note
Changed default history limit for Mattermost installations to 1
```
