### PR TITLE
Hardcode e2e golang image to v1.19.4

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -11,7 +11,7 @@ run_ct_container() {
     docker run --rm --interactive --detach --network host --name test-cont \
         --volume "$(pwd):/go/src/github.com/mattermost/mattermost-operator" \
         --workdir "/go/src/github.com/mattermost/mattermost-operator" \
-        "golang:1.19" \
+        "golang:1.19.4" \
         cat
     echo
 }


### PR DESCRIPTION
This resolves the `detected dubious ownership in repository` issue that popped up with newer golang images. `v1.19.5` and above currently have this issue. We will fix the underlying issue when we migrate to github actions.

```release-note
Hardcode e2e golang image to v1.19.4
```
