### PR TITLE
fix: run db migration instead of version command

### DIFF
--- a/pkg/resources/update_job.go
+++ b/pkg/resources/update_job.go
@@ -127,7 +127,7 @@ func PrepareMattermostJobTemplate(name, namespace string, baseDeployment *appsv1
 		job.Spec.Template.Spec.Containers[i].ReadinessProbe = nil
 
 		// We don't want the full server to start so we print the version and exit
-		job.Spec.Template.Spec.Containers[i].Args = []string{"version"}
+		job.Spec.Template.Spec.Containers[i].Args = []string{"db", "migrate"}
 	}
 
 	// Override values for job-specific behavior.


### PR DESCRIPTION
#### Summary

This fixes the removal of the store initialialization for the version command of the mattermost server under
https://github.com/mattermost/mattermost-server/pull/19364

#### Ticket Link

None

#### Release Note

```release-note
fix: use `mattermost db migration` for database migrations instead of `mattermost version`
```
