### PR TITLE
ci: run over release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - "release-.*"
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:


### PR DESCRIPTION
#### Summary

Allow CI workflow to run under `release-` branches as well.

#### Ticket Link

None

#### Release Note
```release-note
none
```
