### PR TITLE
fix: workflow push tag triggers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,7 @@ on:
       - completed
   push:
     tags:
-      - "v.*"
+      - "v**"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
       - master
       - "release-.*"
     tags:
-      - "v.*"
+      - "v**"
   pull_request:
 
 permissions:


### PR DESCRIPTION
#### Summary

According to Github documentation[^1], using `v1.**` triggers any `v1.XXX` tag, which means that the expression is not really a regex. I changed the push triggers to `v**` to ensure that it trigger on any new version tag.

#### Ticket Link

None

#### Release Note

```release-note
none
```

[^1]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-of-specific-tags-occurs