### PR TITLE
fix(postgres): use -h instead of --dbname when executing pg_isready

### DIFF
--- a/pkg/mattermost/database_external.go
+++ b/pkg/mattermost/database_external.go
@@ -110,7 +110,7 @@ func getDBCheckInitContainer(secretName, dbType string) *corev1.Container {
 			Env:             envVars,
 			Command: []string{
 				"sh", "-c",
-				"until pg_isready --dbname=\"$DB_CONNECTION_CHECK_URL\"; do echo waiting for database; sleep 5; done;",
+				"until pg_isready -h $DB_CONNECTION_CHECK_URL; do echo waiting for database; sleep 5; done;",
 			},
 		}
 	}

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -795,7 +795,7 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 				Name:            "init-check-database",
 				Image:           "postgres:13",
 				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         []string{"sh", "-c", "until pg_isready --dbname=\"$DB_CONNECTION_CHECK_URL\"; do echo waiting for database; sleep 5; done;"},
+				Command:         []string{"sh", "-c", "until pg_isready -h $DB_CONNECTION_CHECK_URL; do echo waiting for database; sleep 5; done;"},
 				Env:             []corev1.EnvVar{{Name: "DB_CONNECTION_CHECK_URL", Value: "", ValueFrom: EnvSourceFromSecret("secret", "DB_CONNECTION_CHECK_URL")}},
 			},
 		}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This replaces the use of --dbname when executing `pg_isready --dbname="$DB_CONNECTION_CHECK_URL"`since it doesn’t work. It should be `pg_isready -h $DB_CONNECTION_CHECK_URL`.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
