### PR TITLE
feat: allow customizable target arch/platform on make build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM ${BUILD_IMAGE} as builder
 
+ARG TARGETARCH
+ARG TARGETOS
+
 WORKDIR /workspace
 COPY . .
 
@@ -11,7 +14,7 @@ RUN mkdir -p licenses
 COPY LICENSE /workspace/licenses
 
 # Build
-RUN make build
+RUN make build TARGET_OS=$TARGETOS TARGET_ARCH=$TARGETARCH
 
 FROM ${BASE_IMAGE}
 

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ MACHINE = $(shell uname -m)
 GOFLAGS ?= $(GOFLAGS:) -mod=vendor
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M%S)
 BUILD_HASH := $(shell git rev-parse HEAD)
+TARGET_OS ?= linux
+TARGET_ARCH ?= amd64
 
 BUNDLE_IMG ?= controller-bundle:$(VERSION) # Default bundle image tag
 CRD_OPTIONS ?= "crd" # Image URL to use all building/pushing image targets
@@ -119,7 +121,7 @@ goverall: $(GOVERALLS_GEN) ## Runs goveralls
 
 build: ## Build the mattermost-operator
 	@echo Building Mattermost-operator
-	GO111MODULE=on GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO) build $(GOFLAGS) -gcflags all=-trimpath=$(GOPATH) -asmflags all=-trimpath=$(GOPATH) -a -installsuffix cgo -o build/_output/bin/mattermost-operator $(GO_LINKER_FLAGS) ./main.go
+	GO111MODULE=on GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) CGO_ENABLED=0 $(GO) build $(GOFLAGS) -gcflags all=-trimpath=$(GOPATH) -asmflags all=-trimpath=$(GOPATH) -a -installsuffix cgo -o build/_output/bin/mattermost-operator $(GO_LINKER_FLAGS) ./main.go
 
 .PHONE: buildx-image
 buildx-image:  ## Builds and pushes the docker image for mattermost-operator


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR fix arm64 build.

*__Note:__ cf. https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope.*

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://github.com/mattermost/mattermost-operator/issues/359.

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
support arm64 builds/binaries
```
