### PR TITLE
Fix installation size 25000users

### DIFF
--- a/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_sizes.go
@@ -249,12 +249,12 @@ var size25000 = ClusterInstallationSize{
 		Replicas: 2,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("500Mi"),
+				corev1.ResourceCPU:    resource.MustParse("1000m"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("4000m"),
-				corev1.ResourceMemory: resource.MustParse("8Gi"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
 			},
 		},
 	},
@@ -262,7 +262,7 @@ var size25000 = ClusterInstallationSize{
 		Replicas: 4,
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("200m"),
+				corev1.ResourceCPU:    resource.MustParse("300m"),
 				corev1.ResourceMemory: resource.MustParse("500Mi"),
 			},
 		},
@@ -272,7 +272,7 @@ var size25000 = ClusterInstallationSize{
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("500m"),
-				corev1.ResourceMemory: resource.MustParse("500Mi"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 		},
 	},


### PR DESCRIPTION
This size had the same values as 10000users. This change bumps the resource requests and limits up to better support more users.

Fixes https://mattermost.atlassian.net/browse/CLD-6216

```release-note
Fix installation size 25000users
```
