### PR TITLE
Cleanup CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,10 +1,5 @@
 name: cd
 on:
-  workflow_run:
-    workflows: ["ci"]
-    branches-ignore: ["*"]
-    types:
-      - completed
   push:
     tags:
       - "v**"
@@ -16,23 +11,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      - name: cd/checkout-repo
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
-      - name: ci/setup-buildx
+      - name: cd/setup-buildx
         uses: docker/setup-buildx-action@15c905b16b06416d2086efa066dd8e3a35cc7f98 # v2.4.0
         with:
           version: v0.7.1
 
-      - name: ci/docker-login
+      - name: cd/docker-login
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: ci/push-docker
+      - name: cd/push-docker
         run: make buildx-image
         env:
           OPERATOR_IMAGE_TAG: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
       - name: ci/setup-go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
           cache: true
 
       - name: ci/check-style
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
           path: src/github.com/mattermost/mattermost-operator
@@ -44,7 +44,7 @@ jobs:
       - name: ci/setup-go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.21"
+          go-version-file: go.mod
           cache: true
           cache-dependency-path: src/github.com/mattermost/mattermost-operator/go.sum
 
@@ -91,7 +91,7 @@ jobs:
     needs: [lint, test]
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
       - name: ci/setup-go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version-file: go.mod
-          cache: true
+          go-version-file: src/github.com/mattermost/mattermost-operator/go.mod
           cache-dependency-path: src/github.com/mattermost/mattermost-operator/go.sum
+          cache: true
 
       - name: ci/generate-operator-manifests
         run: |


### PR DESCRIPTION
This change does the following:
 - Bumps `actions/checkout` to `v3.6.0`
 - Uses `go.mod` for Go versioning instead of hardcoding value
 - Removes extra `cd` workflow checks

Fixes https://mattermost.atlassian.net/browse/CLD-6451

```release-note
None
```
