### PR TITLE
Ingress deletion by label instead of name

### DIFF
--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -195,7 +195,7 @@ func (r *MattermostReconciler) checkMattermostIngress(mattermost *mmv1beta.Matte
 	}
 
 	if !mattermost.IngressEnabled() && !mattermost.AWSLoadBalancerEnabled() {
-		err := r.Resources.DeleteIngress(types.NamespacedName{Namespace: desired.Namespace, Name: desired.Name}, reqLogger)
+		err := r.Resources.DeleteIngress(desired.Namespace, desired.Labels, reqLogger)
 		if err != nil {
 			return errors.Wrap(err, "failed to delete disabled ingress")
 		}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

The Mattermost operator keeps deleting Ingresses it did not create itself if they have the same name. It makes more sense for the operator to find resources by their labels. That is what Kubernetes labels are for.

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
