### PR TITLE
Bump default Mattermost server version

### DIFF
--- a/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -15,7 +15,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "7.5.1"
+	DefaultMattermostVersion = "9.2.3"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -19,7 +19,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "7.5.1"
+	DefaultMattermostVersion = "9.2.3"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/test/constants.go
+++ b/test/constants.go
@@ -3,9 +3,9 @@ package test
 const (
 	// LatestStableMattermostVersion is the most recent stable version of
 	// Mattermost.
-	LatestStableMattermostVersion = "7.5.1"
+	LatestStableMattermostVersion = "9.2.3"
 	// PreviousStableMattermostVersion is the latest dot release of Mattermost
 	// that is one minor version lower than the latest release.
 	// i.e. It's a typical release that would need to be upgraded from.
-	PreviousStableMattermostVersion = "7.4.0"
+	PreviousStableMattermostVersion = "9.1.0"
 )


### PR DESCRIPTION
The default has been updated to v9.2.3

Fixes https://mattermost.atlassian.net/browse/CLD-6819

```release-note
Bump default Mattermost server version
```
