### PR TITLE
Bump Operator version number

### DIFF
--- a/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -15,7 +15,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "9.2.3"
+	DefaultMattermostVersion = "9.5.1"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/test/constants.go
+++ b/test/constants.go
@@ -3,9 +3,9 @@ package test
 const (
 	// LatestStableMattermostVersion is the most recent stable version of
 	// Mattermost.
-	LatestStableMattermostVersion = "9.2.3"
+	LatestStableMattermostVersion = "9.5.1"
 	// PreviousStableMattermostVersion is the latest dot release of Mattermost
 	// that is one minor version lower than the latest release.
 	// i.e. It's a typical release that would need to be upgraded from.
-	PreviousStableMattermostVersion = "9.1.0"
+	PreviousStableMattermostVersion = "9.4.0"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-var version = "1.20.0"
+var version = "1.21.0"
 var buildTime string
 var buildHash string
 


### PR DESCRIPTION
This change also updates the default Mattermost version to v9.5.1.

```release-note
Bump Operator and default Mattermost versions
```
