### PR TITLE
Use PublishNotReadyAddresses for services

### DIFF
--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -29,9 +29,7 @@ var defaultIngressPathType = networkingv1.PathTypeImplementationSpecific
 
 // GenerateService returns the service for the Mattermost app.
 func GenerateService(mattermost *mattermostv1alpha1.ClusterInstallation, serviceName, selectorName string) *corev1.Service {
-	baseAnnotations := map[string]string{
-		"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-	}
+	baseAnnotations := make(map[string]string)
 
 	if mattermost.Spec.UseServiceLoadBalancer {
 		// Create a LoadBalancer service with additional annotations provided in
@@ -503,7 +501,8 @@ func newService(mattermost *mattermostv1alpha1.ClusterInstallation, serviceName,
 			Annotations: annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: mattermostv1alpha1.ClusterInstallationSelectorLabels(selectorName),
+			Selector:                 mattermostv1alpha1.ClusterInstallationSelectorLabels(selectorName),
+			PublishNotReadyAddresses: true,
 		},
 	}
 }

--- a/pkg/mattermost/mattermost_test.go
+++ b/pkg/mattermost/mattermost_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -67,6 +66,8 @@ func TestGenerateService(t *testing.T) {
 				expectPort(t, service, 8065)
 				expectPort(t, service, 8067)
 			}
+
+			assert.True(t, service.Spec.PublishNotReadyAddresses)
 		})
 	}
 }
@@ -169,8 +170,8 @@ func TestGenerateDeployment(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{"type": "compute"},
 						},
 					},
@@ -184,8 +185,8 @@ func TestGenerateDeployment(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector: map[string]string{"type": "compute", "size": "big", "region": "iceland"},
 						},
 					},
@@ -199,8 +200,8 @@ func TestGenerateDeployment(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
 							NodeSelector: nil,
 						},
 					},
@@ -210,9 +211,9 @@ func TestGenerateDeployment(t *testing.T) {
 		{
 			name: "affinity 1",
 			spec: mattermostv1alpha1.ClusterInstallationSpec{
-				Affinity: &v1.Affinity{
-					PodAffinity: &v1.PodAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+				Affinity: &corev1.Affinity{
+					PodAffinity: &corev1.PodAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 							{
 								LabelSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{"key": "value"},
@@ -224,11 +225,11 @@ func TestGenerateDeployment(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Affinity: &v1.Affinity{
-								PodAffinity: &v1.PodAffinity{
-									RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Affinity: &corev1.Affinity{
+								PodAffinity: &corev1.PodAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 										{
 											LabelSelector: &metav1.LabelSelector{
 												MatchLabels: map[string]string{"key": "value"},
@@ -249,8 +250,8 @@ func TestGenerateDeployment(t *testing.T) {
 			},
 			want: &appsv1.Deployment{
 				Spec: appsv1.DeploymentSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
 							Affinity: nil,
 						},
 					},

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -35,9 +35,7 @@ type FileStoreConfig interface {
 
 // GenerateServiceV1Beta returns the service for the Mattermost app.
 func GenerateServiceV1Beta(mattermost *mmv1beta.Mattermost) *corev1.Service {
-	baseAnnotations := map[string]string{
-		"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
-	}
+	baseAnnotations := make(map[string]string)
 
 	if mattermost.AWSLoadBalancerEnabled() {
 		// Create a NodePort service because the ALB requires it
@@ -515,7 +513,8 @@ func newServiceV1Beta(mattermost *mmv1beta.Mattermost, annotations map[string]st
 			Annotations:     annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: mmv1beta.MattermostSelectorLabels(mattermost.Name),
+			Selector:                 mmv1beta.MattermostSelectorLabels(mattermost.Name),
+			PublishNotReadyAddresses: true,
 		},
 	}
 }

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -102,6 +102,8 @@ func TestGenerateService_V1Beta(t *testing.T) {
 			if mattermost.Spec.ResourceLabels != nil || (mattermost.Spec.PodTemplate != nil && mattermost.Spec.PodTemplate.ExtraLabels != nil) {
 				expectLabels(t, service, mattermost.Spec)
 			}
+
+			assert.True(t, service.Spec.PublishNotReadyAddresses)
 		})
 	}
 }


### PR DESCRIPTION
This change replaces the deprecated annotation
`service.alpha.kubernetes.io/tolerate-unready-endpoints` with the PublishNotReadyAddresses service setting when generating services.

Fixes https://mattermost.atlassian.net/browse/CLD-7415 and https://github.com/mattermost/mattermost-operator/issues/369

```release-note
Use PublishNotReadyAddresses for services
```
