### PR TITLE
Improve external E2E test logic

### DIFF
--- a/resources/postgres.yaml
+++ b/resources/postgres.yaml
@@ -50,7 +50,7 @@ spec:
         tier: postgreSQL
     spec:
       containers:
-        - image: postgres:12-alpine
+        - image: postgres:14-alpine
           name: postgresql
           env:
             - name: POSTGRES_USER

--- a/test/e2e-external/ingress_test.go
+++ b/test/e2e-external/ingress_test.go
@@ -13,9 +13,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TestMattermostIngress Check that setting custom values in the mattermost ingress are set on the k8s
+// mattermostIngressTest checks that setting custom values in the mattermost ingress are set on the k8s
 // ingress and that disabling it and updating the instance removes the k8s ingress from the cluster
-func TestMattermostIngress(t *testing.T) {
+func mattermostIngressTest(t *testing.T) {
 	namespace := "e2e-test-custom-ingress"
 	name := "test-mm"
 

--- a/test/e2e-external/size_test.go
+++ b/test/e2e-external/size_test.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// TestMattermostSize checks defaulting & updating replicas & resources from size.
-func TestMattermostSize(t *testing.T) {
+// mattermostSizeTest checks defaulting & updating replicas & resources from size.
+func mattermostSizeTest(t *testing.T) {
 	namespace := "e2e-test-size"
 	name := "test-mm"
 	mmNamespaceName := types.NamespacedName{Namespace: namespace, Name: name}

--- a/test/e2e/mattermost_test.go
+++ b/test/e2e/mattermost_test.go
@@ -212,7 +212,7 @@ func mattermostUpgradeTest(t *testing.T, k8sClient client.Client, k8sTypedClient
 	require.NoError(t, err)
 }
 
-func mattermostWithMySQLReplicas(t *testing.T, client client.Client, typedClient kubernetes.Interface) {
+func mattermostWithMySQLReplicas(t *testing.T, client client.Client, _ kubernetes.Interface) {
 	testName := "test-mm3"
 
 	exampleMattermost := &operator.Mattermost{


### PR DESCRIPTION
This change does the following:
 - Converts individual external E2E tests to subtests. This now matches the standard E2E test flow and provides better test logging output.
 - Split Mattermost version upgrade test out from base test.
 - Improve reconciliation logging with more status output.
 - Improve reconciliation check with ObservedGeneration validation.
 - Update external E2E postgres container image to version 14.

Fixes https://mattermost.atlassian.net/browse/CLD-7478

```release-note
Improve external E2E test logic
```
