### PR TITLE
Apply custom service annotations in all cases

### DIFF
--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -35,11 +35,11 @@ type FileStoreConfig interface {
 
 // GenerateServiceV1Beta returns the service for the Mattermost app.
 func GenerateServiceV1Beta(mattermost *mmv1beta.Mattermost) *corev1.Service {
-	baseAnnotations := make(map[string]string)
+	annotations := mergeStringMaps(nil, mattermost.Spec.ServiceAnnotations)
 
 	if mattermost.AWSLoadBalancerEnabled() {
 		// Create a NodePort service because the ALB requires it
-		service := newServiceV1Beta(mattermost, mergeStringMaps(baseAnnotations, mattermost.Spec.ServiceAnnotations))
+		service := newServiceV1Beta(mattermost, annotations)
 		return configureMattermostServiceNodePort(service)
 	}
 
@@ -47,13 +47,13 @@ func GenerateServiceV1Beta(mattermost *mmv1beta.Mattermost) *corev1.Service {
 		// Create a LoadBalancer service with additional annotations provided in
 		// the Mattermost Spec. The LoadBalancer is directly accessible from
 		// outside the cluster thus exposes ports 80 and 443.
-		service := newServiceV1Beta(mattermost, mergeStringMaps(baseAnnotations, mattermost.Spec.ServiceAnnotations))
+		service := newServiceV1Beta(mattermost, annotations)
 		return configureMattermostLoadBalancerService(service)
 	}
 
 	// Create a headless service which is not directly accessible from outside
 	// the cluster and thus exposes a custom port.
-	service := newServiceV1Beta(mattermost, baseAnnotations)
+	service := newServiceV1Beta(mattermost, annotations)
 	return configureMattermostService(service)
 }
 


### PR DESCRIPTION
There was an edge case where extra service annotations were not applied to the service created by the operator. This change ensures that extra annotations are always applied to all service types.

Fixes https://mattermost.atlassian.net/browse/CLD-7557

```release-note
Apply custom service annotations in all cases
```
