### PR TITLE
Bump operator version to v1.22

### DIFF
--- a/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -15,7 +15,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "9.5.1"
+	DefaultMattermostVersion = "9.7.1"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -15,7 +15,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "9.7.1"
+	DefaultMattermostVersion = "9.7.3"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -19,7 +19,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "9.7.1"
+	DefaultMattermostVersion = "9.7.3"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -19,7 +19,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "9.2.3"
+	DefaultMattermostVersion = "9.7.1"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/test/constants.go
+++ b/test/constants.go
@@ -3,9 +3,9 @@ package test
 const (
 	// LatestStableMattermostVersion is the most recent stable version of
 	// Mattermost.
-	LatestStableMattermostVersion = "9.5.1"
+	LatestStableMattermostVersion = "9.7.1"
 	// PreviousStableMattermostVersion is the latest dot release of Mattermost
 	// that is one minor version lower than the latest release.
 	// i.e. It's a typical release that would need to be upgraded from.
-	PreviousStableMattermostVersion = "9.4.0"
+	PreviousStableMattermostVersion = "9.6.0"
 )

--- a/test/constants.go
+++ b/test/constants.go
@@ -3,7 +3,7 @@ package test
 const (
 	// LatestStableMattermostVersion is the most recent stable version of
 	// Mattermost.
-	LatestStableMattermostVersion = "9.7.1"
+	LatestStableMattermostVersion = "9.7.3"
 	// PreviousStableMattermostVersion is the latest dot release of Mattermost
 	// that is one minor version lower than the latest release.
 	// i.e. It's a typical release that would need to be upgraded from.

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-var version = "1.21.0"
+var version = "1.22.0"
 var buildTime string
 var buildHash string
 


### PR DESCRIPTION
This also updates the default Mattermost version to 9.7.3.

Fixes https://mattermost.atlassian.net/browse/CLD-7571

```release-note
None
```
