### PR TITLE
allow setting a custom liveness probe timeout

### DIFF
--- a/pkg/mattermost/helpers.go
+++ b/pkg/mattermost/helpers.go
@@ -91,6 +91,10 @@ func setProbes(customLiveness, customReadiness corev1.Probe) (*corev1.Probe, *co
 		liveness.PeriodSeconds = customLiveness.PeriodSeconds
 	}
 
+	if customLiveness.TimeoutSeconds != 0 {
+		liveness.TimeoutSeconds = customLiveness.TimeoutSeconds
+	}
+
 	if customLiveness.FailureThreshold != 0 {
 		liveness.FailureThreshold = customLiveness.FailureThreshold
 	}


### PR DESCRIPTION
Currently you can set some custom values for liveness probes but you can't set the timeout. I ran into an issue and needed to set it.
