### PR TITLE
Remove job scheduling env when using dedicated job server

### DIFF
--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -320,10 +320,6 @@ func GenerateDeploymentV1Beta(mattermost *mmv1beta.Mattermost, db DatabaseConfig
 	// Apply optional job server settings
 	if mattermost.Spec.JobServer != nil && mattermost.Spec.JobServer.DedicatedJobServer {
 		envVarGeneral = append(envVarGeneral, corev1.EnvVar{
-			Name:  "MM_JOBSETTINGS_RUNSCHEDULER",
-			Value: "false",
-		})
-		envVarGeneral = append(envVarGeneral, corev1.EnvVar{
 			Name:  "MM_JOBSETTINGS_RUNJOBS",
 			Value: "false",
 		})

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -791,8 +791,7 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 			},
 			want: &appsv1.Deployment{},
 			requiredEnvVals: map[string]string{
-				"MM_JOBSETTINGS_RUNSCHEDULER": "false",
-				"MM_JOBSETTINGS_RUNJOBS":      "false",
+				"MM_JOBSETTINGS_RUNJOBS": "false",
 			},
 		},
 	}


### PR DESCRIPTION
This env var setting should remain as the default `true` value for the main Mattermost deployment.

Fixes https://mattermost.atlassian.net/browse/CLD-8876

```release-note
Remove job scheduling env when using dedicated job server
```
