### PR TITLE
Bump Operator and Mattermost versions

### DIFF
--- a/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -15,7 +15,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "9.7.3"
+	DefaultMattermostVersion = "10.5.1"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -19,7 +19,7 @@ const (
 	// DefaultMattermostImage is the default Mattermost docker image
 	DefaultMattermostImage = "mattermost/mattermost-enterprise-edition"
 	// DefaultMattermostVersion is the default Mattermost docker tag
-	DefaultMattermostVersion = "9.7.3"
+	DefaultMattermostVersion = "10.5.1"
 	// DefaultMattermostSize is the default number of users
 	DefaultMattermostSize = "5000users"
 	// DefaultMattermostDatabaseType is the default Mattermost database

--- a/docs/mattermost-operator/mattermost-operator.yaml
+++ b/docs/mattermost-operator/mattermost-operator.yaml
@@ -8527,7 +8527,7 @@ spec:
           value: 20s
         - name: MAX_RECONCILE_CONCURRENCY
           value: "10"
-        image: mattermost/mattermost-operator:v1.22.1
+        image: mattermost/mattermost-operator:v1.23.0
         imagePullPolicy: IfNotPresent
         name: mattermost-operator
         ports:

--- a/test/constants.go
+++ b/test/constants.go
@@ -3,9 +3,9 @@ package test
 const (
 	// LatestStableMattermostVersion is the most recent stable version of
 	// Mattermost.
-	LatestStableMattermostVersion = "9.7.3"
+	LatestStableMattermostVersion = "10.5.1"
 	// PreviousStableMattermostVersion is the latest dot release of Mattermost
 	// that is one minor version lower than the latest release.
 	// i.e. It's a typical release that would need to be upgraded from.
-	PreviousStableMattermostVersion = "9.6.0"
+	PreviousStableMattermostVersion = "10.4.0"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-var version = "1.22.1"
+var version = "1.23.0"
 var buildTime string
 var buildHash string
 


### PR DESCRIPTION
Updates the operator to v1.23.0 and the default Mattermost version to v10.5.1.

```release-note
Bump Operator and Mattermost versions
```
