### PR TITLE
[GH-389] Usage of pinned tags fixed

### DIFF
--- a/apis/mattermost/v1alpha1/clusterinstallation_test.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_test.go
@@ -163,6 +163,13 @@ func TestClusterInstallation(t *testing.T) {
 		assert.Contains(t, ci.GetImageName(), ci.Spec.Version)
 		assert.Equal(t, ci.GetImageName(), fmt.Sprintf("%s@%s", ci.Spec.Image, ci.Spec.Version))
 	})
+
+	t.Run("using tag and digest", func(t *testing.T) {
+		ci.Spec.Version = "10.6.1@sha256:dd15a51ac7dafd213744d1ef23394e7532f71a90f477c969b94600e46da5a0cf"
+		assert.Contains(t, ci.GetImageName(), ci.Spec.Image)
+		assert.Contains(t, ci.GetImageName(), ci.Spec.Version)
+		assert.Equal(t, ci.GetImageName(), fmt.Sprintf("%s:%s", ci.Spec.Image, ci.Spec.Version))
+	})
 }
 
 func TestGetDeploymentImageName(t *testing.T) {

--- a/apis/mattermost/v1alpha1/clusterinstallation_utils.go
+++ b/apis/mattermost/v1alpha1/clusterinstallation_utils.go
@@ -189,10 +189,10 @@ func (mattermost *ClusterInstallation) GetMattermostAppContainer(containers []co
 // GetImageName returns the container image name that matches the spec of the
 // ClusterInstallation.
 func (mattermost *ClusterInstallation) GetImageName() string {
-	// if user set the version using the Digest instead of tag like
+	// if user set the version using only the Digest instead of tag or tag@digest like
 	// sha256:dd15a51ac7dafd213744d1ef23394e7532f71a90f477c969b94600e46da5a0cf
 	// we need to set the @ instead of : to split the image name and "tag"
-	if strings.Contains(mattermost.Spec.Version, "sha256:") {
+	if strings.HasPrefix(mattermost.Spec.Version, "sha256:") {
 		return fmt.Sprintf("%s@%s", mattermost.Spec.Image, mattermost.Spec.Version)
 	}
 	return fmt.Sprintf("%s:%s", mattermost.Spec.Image, mattermost.Spec.Version)

--- a/apis/mattermost/v1beta1/mattermost_test.go
+++ b/apis/mattermost/v1beta1/mattermost_test.go
@@ -157,6 +157,13 @@ func TestMattermost(t *testing.T) {
 		assert.Contains(t, mm.GetImageName(), mm.Spec.Version)
 		assert.Equal(t, mm.GetImageName(), fmt.Sprintf("%s@%s", mm.Spec.Image, mm.Spec.Version))
 	})
+
+	t.Run("using tag and digest", func(t *testing.T) {
+		mm.Spec.Version = "10.6.1@sha256:dd15a51ac7dafd213744d1ef23394e7532f71a90f477c969b94600e46da5a0cf"
+		assert.Contains(t, mm.GetImageName(), mm.Spec.Image)
+		assert.Contains(t, mm.GetImageName(), mm.Spec.Version)
+		assert.Equal(t, mm.GetImageName(), fmt.Sprintf("%s:%s", mm.Spec.Image, mm.Spec.Version))
+	})
 }
 
 func TestOtherUtils(t *testing.T) {

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -210,10 +210,10 @@ func getContainerByName(containers []corev1.Container, containerName string) *co
 // GetImageName returns the container image name that matches the spec of the
 // ClusterInstallation.
 func (mm *Mattermost) GetImageName() string {
-	// if user set the version using the Digest instead of tag like
+	// if user set the version using only the Digest instead of tag or tag@digest like
 	// sha256:dd15a51ac7dafd213744d1ef23394e7532f71a90f477c969b94600e46da5a0cf
 	// we need to set the @ instead of : to split the image name and "tag"
-	if strings.Contains(mm.Spec.Version, "sha256:") {
+	if strings.HasPrefix(mm.Spec.Version, "sha256:") {
 		return fmt.Sprintf("%s@%s", mm.Spec.Image, mm.Spec.Version)
 	}
 	return fmt.Sprintf("%s:%s", mm.Spec.Image, mm.Spec.Version)


### PR DESCRIPTION
#### Summary
Deployment was broken when using a pinned tag instead of only a tag or only a digest.

For example when using a "tag" of `1.2.3@sha26:0000000000...`, the operator would incorrectly combine this with the image name to be `...mattermost@1.2.3@sha256:0000...` instead of using the colon. This pattern of using pinned tags is commonly used in conjunction with dependency update tools like renovate or dependabot.

#### Ticket Link
Fixes #389

#### Release Note
```release-note
The operator now supports the usage of tags in the CRD that consist of tag and digest. Previously only tag or digest was supported, not both.
```
