### PR TITLE
Specify MinIO MC image version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: make check-modules
 
   test:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/pkg/mattermost/file_store.go
+++ b/pkg/mattermost/file_store.go
@@ -119,7 +119,7 @@ func (e *OperatorManagedMinioConfig) InitContainers(mattermost *mmv1beta.Matterm
 		// Create the init container to create the MinIO bucket
 		{
 			Name:            "create-minio-bucket",
-			Image:           "minio/mc:latest",
+			Image:           "minio/mc:RELEASE.2025-04-16T18-13-26Z",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command: []string{
 				"/bin/sh", "-c",

--- a/pkg/mattermost/mattermost.go
+++ b/pkg/mattermost/mattermost.go
@@ -227,7 +227,7 @@ func GenerateDeployment(mattermost *mattermostv1alpha1.ClusterInstallation, dbIn
 		// Create the init container to create the MinIO bucker
 		initContainers = append(initContainers, corev1.Container{
 			Name:            "create-minio-bucket",
-			Image:           "minio/mc:latest",
+			Image:           "minio/mc:RELEASE.2025-04-16T18-13-26Z",
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command: []string{
 				"/bin/sh", "-c",


### PR DESCRIPTION
This locks the mc image version used for bucket setup to a specific recent release which resolves an issue with a breaking change in the command used. This change also increases the runner size for E2E tests for quicker completion and resolves possible issues with resource contention.

Fixes https://mattermost.atlassian.net/browse/CLD-9267 and https://mattermost.atlassian.net/browse/CLD-9249
```release-note
Specify MinIO MC image version
```
