### PR TITLE
Set MM_SQLSETTINGS_DATASOURCE from database secret for external databases

### DIFF
--- a/pkg/mattermost/database_external.go
+++ b/pkg/mattermost/database_external.go
@@ -52,6 +52,10 @@ func (e *ExternalDBConfig) EnvVars(_ *mmv1beta.Mattermost) []corev1.EnvVar {
 			Name:      "MM_CONFIG",
 			ValueFrom: EnvSourceFromSecret(e.secretName, "DB_CONNECTION_STRING"),
 		},
+		{
+			Name:      "MM_SQLSETTINGS_DATASOURCE",
+			ValueFrom: EnvSourceFromSecret(e.secretName, "DB_CONNECTION_STRING"),
+		},
 	}
 
 	if e.hasReaderEndpoints {

--- a/pkg/mattermost/database_external_test.go
+++ b/pkg/mattermost/database_external_test.go
@@ -36,7 +36,7 @@ func TestNewExternalDBInfo(t *testing.T) {
 		assert.False(t, config.hasReaderEndpoints)
 
 		envs := config.EnvVars(mattermost)
-		assert.Equal(t, 1, len(envs))
+		assert.Equal(t, 2, len(envs))
 
 		initContainers := config.InitContainers(mattermost)
 		assert.Equal(t, 0, len(initContainers))
@@ -54,7 +54,7 @@ func TestNewExternalDBInfo(t *testing.T) {
 		assert.True(t, config.hasReaderEndpoints)
 
 		envs := config.EnvVars(mattermost)
-		assert.Equal(t, 2, len(envs))
+		assert.Equal(t, 3, len(envs))
 
 		initContainers := config.InitContainers(mattermost)
 		assert.Equal(t, 1, len(initContainers))

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -874,6 +874,7 @@ func TestGenerateDeployment_V1Beta(t *testing.T) {
 					if externalDB.dbType == database.MySQLDatabase ||
 						externalDB.dbType == database.PostgreSQLDatabase {
 						expectedInitContainers++
+						assertEnvVarExists(t, "MM_SQLSETTINGS_DATASOURCE", mattermostAppContainer.Env)
 					}
 				}
 			} else {

--- a/test/e2e_local.sh
+++ b/test/e2e_local.sh
@@ -25,7 +25,7 @@ source "${DIR}"/setup_test.sh
 make deploy
 
 echo "Running operator e2e tests..."
-go test ./test/e2e --timeout 45m -v
+go test ./test/e2e -count=1 --timeout 45m -v
 
 echo "Running external DB and File Store e2e..."
-go test ./test/e2e-external --timeout 15m -v
+go test ./test/e2e-external -count=1 --timeout 15m -v


### PR DESCRIPTION
The database secret value the operator uses for the primary database writer connection is `DB_CONNECTION_STRING`. This value gets translated to an `MM_CONFIG` environment variable in the Mattermost deployment.

This change also sets `MM_SQLSETTINGS_DATASOURCE` to that same value which prevents issues where an improper datasource value in the Mattermost configuration table could lead to Mattermost server startup trying to connect with an outdated connection. This ensures that Mattermost uses the same secret value in all cases for database connections.

Fixes https://mattermost.atlassian.net/browse/CLD-9281

```release-note
Set MM_SQLSETTINGS_DATASOURCE from database secret for external databases
```
