### PR TITLE
Update CI workflow configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           IMAGE_TAG: test
 
   build:
-    if: ${{ github.event_name == 'pull_request' || github.ref_name  == 'master' }}
+    if: ${{ (github.event_name == 'pull_request' || github.ref_name  == 'master') && github.actor != 'dependabot[bot]' }}
     permissions:
       security-events: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Skip build job for dependabot PRs


- Updated the build job condition in CI workflow to exclude dependabot[bot] actor
- Prevents unnecessary Docker builds and security scans on automated dependency updates
- Build job now only runs when the actor is not dependabot and it's either a PR or master branch push

This optimization reduces CI resource usage and build times for dependabot PRs while maintaining full CI coverage for human-authored changes.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9306

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
