### PR TITLE
Introduction of FIPS Release Pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - "v**"
 
+env:
+  ENABLE_FIPS_BUILDS: true # Set to false to disable FIPS builds
+
 permissions:
   contents: read
 
@@ -33,7 +36,8 @@ jobs:
           OPERATOR_IMAGE_TAG: ${{ github.ref_name }}
 
   build-fips:
-    if: ${{ vars.ENABLE_FIPS_BUILDS == 'true' }}
+    if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: cd/checkout-repo

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,21 +36,23 @@ jobs:
           OPERATOR_IMAGE_TAG: ${{ github.ref_name }}
 
   build-fips:
-    if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
     continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - name: cd/checkout-repo
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: cd/setup-buildx
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         with:
           version: v0.7.1
 
       - name: cd/docker-login-chainguard
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: cgr.dev
@@ -58,12 +60,14 @@ jobs:
           password: ${{ secrets.CHAINGUARD_DEV_TOKEN }}
 
       - name: cd/docker-login
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: cd/push-docker-fips
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         run: make buildx-image-fips
         env:
           OPERATOR_IMAGE_TAG_FIPS: ${{ github.ref_name }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -50,8 +50,8 @@ jobs:
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: cgr.dev
-          username: ${{ secrets.CHAINGUARD_USERNAME }}
-          password: ${{ secrets.CHAINGUARD_TOKEN }}
+          username: ${{ secrets.CHAINGUARD_DEV_USERNAME }}
+          password: ${{ secrets.CHAINGUARD_DEV_TOKEN }}
 
       - name: cd/docker-login
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,6 +37,8 @@ jobs:
 
   build-fips:
     continue-on-error: true
+    permissions:
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: cd/checkout-repo
@@ -51,13 +53,11 @@ jobs:
         with:
           version: v0.7.1
 
-      - name: cd/docker-login-chainguard
+      - name: cd/setup-chainctl
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: chainguard-dev/setup-chainctl@v0.3.2
         with:
-          registry: cgr.dev
-          username: ${{ secrets.CHAINGUARD_DEV_USERNAME }}
-          password: ${{ secrets.CHAINGUARD_DEV_TOKEN }}
+          identity: ee399b4c72dd4e58e3d617f78fc47b74733c9557/0439801bd43520ae
 
       - name: cd/docker-login
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,3 +31,35 @@ jobs:
         run: make buildx-image
         env:
           OPERATOR_IMAGE_TAG: ${{ github.ref_name }}
+
+  build-fips:
+    if: ${{ vars.ENABLE_FIPS_BUILDS == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: cd/checkout-repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: cd/setup-buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          version: v0.7.1
+
+      - name: cd/docker-login-chainguard
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: cgr.dev
+          username: ${{ secrets.CHAINGUARD_USERNAME }}
+          password: ${{ secrets.CHAINGUARD_TOKEN }}
+
+      - name: cd/docker-login
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: cd/push-docker-fips
+        run: make buildx-image-fips
+        env:
+          OPERATOR_IMAGE_TAG_FIPS: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
     continue-on-error: true
     permissions:
       security-events: write
+      id-token: write
     runs-on: ubuntu-latest
     needs: [lint, test]
     steps:
@@ -157,13 +158,11 @@ jobs:
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
-      - name: ci/docker-login-chainguard
+      - name: ci/setup-chainctl
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        uses: chainguard-dev/setup-chainctl@v0.3.2
         with:
-          registry: cgr.dev
-          username: ${{ secrets.CHAINGUARD_DEV_USERNAME }}
-          password: ${{ secrets.CHAINGUARD_DEV_TOKEN }}
+          identity: ee399b4c72dd4e58e3d617f78fc47b74733c9557/0439801bd43520ae
 
       - name: ci/build-docker-fips
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,62 @@ jobs:
         env:
           OPERATOR_IMAGE_TAG: ${{ env.SHORT_SHA }}
         run: make buildx-image
+
+  build-fips:
+    if: ${{ (github.event_name == 'pull_request' || github.ref_name  == 'master') && github.actor != 'dependabot[bot]' && vars.ENABLE_FIPS_BUILDS == 'true' }}
+    permissions:
+      security-events: write
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: ci/set-short-SHA
+        run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
+
+      - name: ci/docker-login-chainguard
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: cgr.dev
+          username: ${{ secrets.CHAINGUARD_USERNAME }}
+          password: ${{ secrets.CHAINGUARD_TOKEN }}
+
+      - name: ci/build-docker-fips
+        run: make build-image-fips
+
+      - name: ci/scan-docker-security-fips
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
+        continue-on-error: true
+        with:
+          image-ref: "mattermost/mattermost-operator-fips:test"
+          format: "sarif"
+          limit-severities-for-sarif: true
+          output: "trivy-results-fips.sarif"
+          exit-code: "0"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
+
+      - name: ci/create-trivy-results-report-fips
+        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+        with:
+          sarif_file: "trivy-results-fips.sarif"
+
+      - name: ci/setup-buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          version: v0.7.1
+
+      - name: ci/docker-login
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: ci/docker-push-fips
+        env:
+          OPERATOR_IMAGE_TAG_FIPS: ${{ env.SHORT_SHA }}
+        run: make buildx-image-fips

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         run: make buildx-image
 
   build-fips:
-    if: ${{ (github.event_name == 'pull_request' || github.ref_name  == 'master') && github.actor != 'dependabot[bot]' && env.ENABLE_FIPS_BUILDS == 'true' }}
+    if: ${{ (github.event_name == 'pull_request' || github.ref_name  == 'master') && github.actor != 'dependabot[bot]' }}
     continue-on-error: true
     permissions:
       security-events: write
@@ -148,14 +148,17 @@ jobs:
     needs: [lint, test]
     steps:
       - name: ci/checkout-repo
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: ci/set-short-SHA
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         run: echo "SHORT_SHA=${GITHUB_SHA:0:7}" >> $GITHUB_ENV
 
       - name: ci/docker-login-chainguard
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: cgr.dev
@@ -163,9 +166,11 @@ jobs:
           password: ${{ secrets.CHAINGUARD_DEV_TOKEN }}
 
       - name: ci/build-docker-fips
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         run: make build-image-fips
 
       - name: ci/scan-docker-security-fips
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
         continue-on-error: true
         with:
@@ -179,22 +184,26 @@ jobs:
           severity: "CRITICAL,HIGH"
 
       - name: ci/create-trivy-results-report-fips
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           sarif_file: "trivy-results-fips.sarif"
 
       - name: ci/setup-buildx
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
         with:
           version: v0.7.1
 
       - name: ci/docker-login
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: ci/docker-push-fips
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         env:
           OPERATOR_IMAGE_TAG_FIPS: ${{ env.SHORT_SHA }}
         run: make buildx-image-fips

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - "v**"
   pull_request:
 
+env:
+  ENABLE_FIPS_BUILDS: true # Set to false to disable FIPS builds
+
 permissions:
   contents: read
 
@@ -137,7 +140,8 @@ jobs:
         run: make buildx-image
 
   build-fips:
-    if: ${{ (github.event_name == 'pull_request' || github.ref_name  == 'master') && github.actor != 'dependabot[bot]' && vars.ENABLE_FIPS_BUILDS == 'true' }}
+    if: ${{ (github.event_name == 'pull_request' || github.ref_name  == 'master') && github.actor != 'dependabot[bot]' && env.ENABLE_FIPS_BUILDS == 'true' }}
+    continue-on-error: true
     permissions:
       security-events: write
     runs-on: ubuntu-latest
@@ -155,8 +159,8 @@ jobs:
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: cgr.dev
-          username: ${{ secrets.CHAINGUARD_USERNAME }}
-          password: ${{ secrets.CHAINGUARD_TOKEN }}
+          username: ${{ secrets.CHAINGUARD_DEV_USERNAME }}
+          password: ${{ secrets.CHAINGUARD_DEV_TOKEN }}
 
       - name: ci/build-docker-fips
         run: make build-image-fips

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,6 +1,6 @@
 # Build the mattermost operator (FIPS version)
-ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.24.5.1
-ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.1.0
+ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.24
+ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.1
 
 FROM ${BUILD_IMAGE} as builder
 

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,0 +1,42 @@
+# Build the mattermost operator (FIPS version)
+ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.24.5.1
+ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.1.0
+
+FROM ${BUILD_IMAGE} as builder
+
+ARG TARGETARCH
+ARG TARGETOS
+
+WORKDIR /workspace
+COPY . .
+
+RUN mkdir -p licenses
+COPY LICENSE /workspace/licenses
+
+# Build with FIPS-compliant settings
+ENV CGO_ENABLED=1
+ENV GOFIPS=1
+ENV GOEXPERIMENT=systemcrypto
+RUN make _build-fips-internal TARGET_OS=$TARGETOS TARGET_ARCH=$TARGETARCH
+
+FROM ${BASE_IMAGE}
+
+LABEL name="Mattermost Operator (FIPS)" \
+  maintainer="dev-ops@mattermost.com" \
+  vendor="Mattermost" \
+  distribution-scope="public" \
+  architecture="x86_64" \
+  url="https://mattermost.dev" \
+  io.k8s.description="Mattermost Operator creates, configures and helps manage Mattermost installations on Kubernetes (FIPS-compliant)" \
+  io.k8s.display-name="Mattermost Operator (FIPS)" \
+  io.openshift.tags="mattermost,collaboration,operator,fips" \
+  summary="Quick and easy Mattermost setup (FIPS-compliant)" \
+  description="Mattermost operator deploys and configures Mattermost installations, and assists with maintenance/upgrade operations. This is a FIPS-compliant version."
+
+WORKDIR /
+COPY --from=builder /workspace/licenses .
+COPY --from=builder /workspace/build/_output/bin/mattermost-operator .
+
+USER 65532
+
+ENTRYPOINT ["/mattermost-operator"] 

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ BUILD_IMAGE = golang:$(GOLANG_VERSION)
 BASE_IMAGE = gcr.io/distroless/static:nonroot
 
 ## FIPS Docker Build Versions
-BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.24.5.1
-BASE_IMAGE_FIPS = cgr.dev/mattermost.com/glibc-openssl-fips:15.1.0
+BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.24
+BASE_IMAGE_FIPS = cgr.dev/mattermost.com/glibc-openssl-fips:15.1
 
 ################################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ SDK_VERSION = v1.0.1
 BUILD_IMAGE = golang:$(GOLANG_VERSION)
 BASE_IMAGE = gcr.io/distroless/static:nonroot
 
+## FIPS Docker Build Versions
+BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.24.5.1
+BASE_IMAGE_FIPS = cgr.dev/mattermost.com/glibc-openssl-fips:15.1.0
+
 ################################################################################
 
 GO ?= $(shell command -v go 2> /dev/null)
@@ -24,6 +28,12 @@ TEST_FLAGS ?= -v
 OPERATOR_IMAGE_NAME ?= mattermost/mattermost-operator
 OPERATOR_IMAGE_TAG ?= test
 OPERATOR_IMAGE ?= $(OPERATOR_IMAGE_NAME):$(OPERATOR_IMAGE_TAG)
+
+## FIPS Operator Image
+OPERATOR_IMAGE_NAME_FIPS ?= mattermost/mattermost-operator-fips
+OPERATOR_IMAGE_TAG_FIPS ?= $(OPERATOR_IMAGE_TAG)
+OPERATOR_IMAGE_FIPS ?= $(OPERATOR_IMAGE_NAME_FIPS):$(OPERATOR_IMAGE_TAG_FIPS)
+
 MACHINE = $(shell uname -m)
 GOFLAGS ?= $(GOFLAGS:)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M%S)
@@ -123,12 +133,12 @@ build: ## Build the mattermost-operator
 	@echo Building Mattermost-operator
 	GO111MODULE=on GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) CGO_ENABLED=0 $(GO) build $(GOFLAGS) -gcflags all=-trimpath=$(GOPATH) -asmflags all=-trimpath=$(GOPATH) -a -installsuffix cgo -o build/_output/bin/mattermost-operator $(GO_LINKER_FLAGS) ./main.go
 
-.PHONE: buildx-image
+.PHONY: buildx-image
 buildx-image:  ## Builds and pushes the docker image for mattermost-operator
 	@echo Building Mattermost-operator Docker Image
 	BUILD_IMAGE=$(BUILD_IMAGE) BASE_IMAGE=$(BASE_IMAGE) OPERATOR_IMAGE=$(OPERATOR_IMAGE) ./scripts/build_image.sh buildx
 
-.PHONE: build-image
+.PHONY: build-image
 build-image:  ## Build the docker image for mattermost-operator
 	@echo Building Mattermost-operator Docker Image
 	BUILD_IMAGE=$(BUILD_IMAGE) BASE_IMAGE=$(BASE_IMAGE) OPERATOR_IMAGE=$(OPERATOR_IMAGE) ./scripts/build_image.sh local
@@ -136,6 +146,44 @@ build-image:  ## Build the docker image for mattermost-operator
 .PHONY: push-image
 push-image: ## Push the docker image using base docker (for local development)
 	docker push $(OPERATOR_IMAGE)
+
+## --------------------------------------
+## FIPS Build Targets
+## --------------------------------------
+
+_build-fips-internal: ## Internal FIPS build target (used by Dockerfile.fips and build-fips)
+	@echo "Building Mattermost-operator (FIPS)"
+	@mkdir -p build/_output/bin
+	GO111MODULE=on GOOS=$(TARGET_OS) GOARCH=$(TARGET_ARCH) CGO_ENABLED=1 $(GO) build -tags=requirefips $(GOFLAGS) -gcflags all=-trimpath=$(GOPATH) -asmflags all=-trimpath=$(GOPATH) -a -o build/_output/bin/mattermost-operator $(GO_LINKER_FLAGS) ./main.go
+
+.PHONY: build-fips
+build-fips: ## Build the mattermost-operator with FIPS-compliant settings using containerized build
+	@echo "Building Mattermost-operator (FIPS - containerized)"
+	docker run --rm -v $(shell pwd):/workspace -w /workspace \
+		--entrypoint="" \
+		-e TARGET_OS=$(TARGET_OS) \
+		-e TARGET_ARCH=$(TARGET_ARCH) \
+		-e CGO_ENABLED=1 \
+		-e GOFIPS=1 \
+		-e GOEXPERIMENT=systemcrypto \
+		-e HOST_UID=$(shell id -u) \
+		-e HOST_GID=$(shell id -g) \
+		$(BUILD_IMAGE_FIPS) \
+		sh -c "make _build-fips-internal TARGET_OS=\$$TARGET_OS TARGET_ARCH=\$$TARGET_ARCH && mv build/_output/bin/mattermost-operator build/_output/bin/mattermost-operator-fips && chown \$$HOST_UID:\$$HOST_GID build/_output/bin/mattermost-operator-fips"
+
+.PHONY: buildx-image-fips
+buildx-image-fips:  ## Builds and pushes the FIPS docker image for mattermost-operator
+	@echo Building Mattermost-operator FIPS Docker Image
+	BUILD_IMAGE=$(BUILD_IMAGE_FIPS) BASE_IMAGE=$(BASE_IMAGE_FIPS) OPERATOR_IMAGE=$(OPERATOR_IMAGE_FIPS) ./scripts/build_image.sh buildx fips
+
+.PHONY: build-image-fips
+build-image-fips:  ## Build the FIPS docker image for mattermost-operator
+	@echo Building Mattermost-operator FIPS Docker Image
+	BUILD_IMAGE=$(BUILD_IMAGE_FIPS) BASE_IMAGE=$(BASE_IMAGE_FIPS) OPERATOR_IMAGE=$(OPERATOR_IMAGE_FIPS) ./scripts/build_image.sh local fips
+
+.PHONY: push-image-fips
+push-image-fips: ## Push the FIPS docker image using base docker (for local development)
+	docker push $(OPERATOR_IMAGE_FIPS)
 
 check-style: $(SHADOW_GEN) gofmt vet ## Runs go vet, gofmt
 
@@ -291,4 +339,4 @@ check-modules: $(OUTDATED_GEN) ## Check outdated modules
 
 ## Help documentatin à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' ./Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z-][a-zA-Z_-]+:.*?## .*$$' ./Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -7,6 +7,12 @@ set -o xtrace   # print each command before executing it
 
 DOCKER_COMMAND=("build")
 EXTRA_FLAGS=("--no-cache")
+DOCKERFILE="Dockerfile"
+
+# Check if this is a FIPS build (second parameter)
+if [[ "${2:-}" == "fips" ]]; then
+    DOCKERFILE="Dockerfile.fips"
+fi
 
 # If the image is going to be built using buildx
 if [[ "$1" == "buildx" ]]; then
@@ -22,6 +28,6 @@ fi
 docker "${DOCKER_COMMAND[@]}" \
     --build-arg BUILD_IMAGE="${BUILD_IMAGE}" \
     --build-arg BASE_IMAGE="${BASE_IMAGE}" \
-    . -f Dockerfile \
+    . -f "${DOCKERFILE}" \
     -t "${OPERATOR_IMAGE}" \
     "${EXTRA_FLAGS[@]}"


### PR DESCRIPTION
#### Summary
This change introduces separate build targets in the Makefile and parallel-running GitHub Actions to produce FIPS-compliant Mattermost Operator releases. The changes do not affect the current release pipelines, explicitly including `continue-on-error` and the ability to disable/enable them through an environment variable.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-64292

#### Release Note
```release-note
Introduction of FIPS-compliant Operator Releases
```
