### PR TITLE
Update Golang to 1.24.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,7 @@
 module github.com/mattermost/mattermost-operator
 
-go 1.24.0
+go 1.24.7
 
-toolchain go1.24.4
 
 require (
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0


### PR DESCRIPTION
Updates golang to 1.24.7

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
