### PR TITLE
Skip docker push for PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,14 +197,14 @@ jobs:
           version: v0.7.1
 
       - name: ci/docker-login
-        if: env.ENABLE_FIPS_BUILDS == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: ci/docker-push-fips
-        if: env.ENABLE_FIPS_BUILDS == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         env:
           OPERATOR_IMAGE_TAG_FIPS: ${{ env.SHORT_SHA }}
         run: make buildx-image-fips


### PR DESCRIPTION
#### Summary
Forks don't have access to repository secrets, causing the Docker login step to fail. This PR skips the Docker login and push steps for fork PRs while preserving the existing behavior for same-repo PRs and pushes to master.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
