### PR TITLE
Add input validation and hardening across CR processing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         run: make build-image
 
       - name: ci/scan-docker-security
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
         continue-on-error: true
         with:
           image-ref: "mattermost/mattermost-operator:test"
@@ -172,7 +172,7 @@ jobs:
 
       - name: ci/scan-docker-security-fips
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@97e0b3872f55f89b95b2f65b3dbab56962816478 # v0.34.2
         continue-on-error: true
         with:
           image-ref: "mattermost/mattermost-operator-fips:test"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 # Build the mattermost operator
+# NOTE: For production builds, pin these images to digests for supply-chain safety.
+# Example: golang:1.24.13@sha256:<digest>
+# See Dockerfile.fips for an example of digest-pinned images.
 ARG BUILD_IMAGE=golang:1.24.13
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,6 +1,7 @@
 # Build the mattermost operator (FIPS version)
 ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.24.13@sha256:4ddb471a06569e7df7ced9c349ea41dd5aeb393a52bbfe1efb7c6bc88fe7e4ff
-# NOTE: Pin BASE_IMAGE to a digest for supply-chain safety, matching BUILD_IMAGE above.
+# TODO: Pin BASE_IMAGE to digest for supply-chain safety (registry requires auth to resolve).
+# Matching BUILD_IMAGE above when digest becomes available.
 ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.1
 
 FROM ${BUILD_IMAGE} as builder

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,5 +1,6 @@
 # Build the mattermost operator (FIPS version)
 ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.24.13@sha256:4ddb471a06569e7df7ced9c349ea41dd5aeb393a52bbfe1efb7c6bc88fe7e4ff
+# NOTE: Pin BASE_IMAGE to a digest for supply-chain safety, matching BUILD_IMAGE above.
 ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.1
 
 FROM ${BUILD_IMAGE} as builder

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -80,16 +80,23 @@ func (mm *Mattermost) SetDefaults() error {
 	return nil
 }
 
-// validateVolumes checks that no dangerous volume types are specified.
-// Only known-safe volume sources are permitted: ConfigMap, Secret, EmptyDir,
-// PersistentVolumeClaim, Projected, DownwardAPI, and CSI.
-// HostPath volumes are explicitly rejected as they allow mounting arbitrary
-// host filesystem paths into pods.
+// validateVolumes enforces an allowlist of volume sources. Only the following
+// types are permitted: ConfigMap, Secret, EmptyDir, PersistentVolumeClaim,
+// Projected, DownwardAPI, and CSI. All other volume types (e.g., HostPath,
+// NFS, ISCSI, Glusterfs) are rejected for security and consistency.
 func validateVolumes(volumes []corev1.Volume) error {
 	for _, vol := range volumes {
-		if vol.VolumeSource.HostPath != nil {
-			return fmt.Errorf("volume %q uses HostPath source which is not allowed: "+
-				"HostPath volumes can expose the host filesystem and are a security risk", vol.Name)
+		src := vol.VolumeSource
+		isAllowed := src.ConfigMap != nil ||
+			src.Secret != nil ||
+			src.EmptyDir != nil ||
+			src.PersistentVolumeClaim != nil ||
+			src.Projected != nil ||
+			src.DownwardAPI != nil ||
+			src.CSI != nil
+		if !isAllowed {
+			return fmt.Errorf("volume %q uses an unsupported volume source; "+
+				"allowed types: ConfigMap, Secret, EmptyDir, PersistentVolumeClaim, Projected, DownwardAPI, CSI", vol.Name)
 		}
 	}
 	return nil

--- a/apis/mattermost/v1beta1/mattermost_utils.go
+++ b/apis/mattermost/v1beta1/mattermost_utils.go
@@ -73,6 +73,25 @@ func (mm *Mattermost) SetDefaults() error {
 	mm.Spec.FileStore.SetDefaults()
 	mm.Spec.Database.SetDefaults()
 
+	if err := validateVolumes(mm.Spec.Volumes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateVolumes checks that no dangerous volume types are specified.
+// Only known-safe volume sources are permitted: ConfigMap, Secret, EmptyDir,
+// PersistentVolumeClaim, Projected, DownwardAPI, and CSI.
+// HostPath volumes are explicitly rejected as they allow mounting arbitrary
+// host filesystem paths into pods.
+func validateVolumes(volumes []corev1.Volume) error {
+	for _, vol := range volumes {
+		if vol.VolumeSource.HostPath != nil {
+			return fmt.Errorf("volume %q uses HostPath source which is not allowed: "+
+				"HostPath volumes can expose the host filesystem and are a security risk", vol.Name)
+		}
+	}
 	return nil
 }
 
@@ -217,6 +236,40 @@ func (mm *Mattermost) GetImageName() string {
 		return fmt.Sprintf("%s@%s", mm.Spec.Image, mm.Spec.Version)
 	}
 	return fmt.Sprintf("%s:%s", mm.Spec.Image, mm.Spec.Version)
+}
+
+// mutableImageTags is the set of well-known mutable tags that should be avoided
+// for reproducible deployments.
+var mutableImageTags = map[string]bool{
+	"latest":  true,
+	"master":  true,
+	"main":    true,
+	"nightly": true,
+	"edge":    true,
+}
+
+// ImageTagWarnings returns a list of warnings about the image reference
+// configuration. It warns when mutable tags are used and recommends
+// digest-pinned references for supply-chain safety.
+// The GetImageName() method already supports digest format (image@sha256:...)
+// which is the recommended approach for production deployments.
+func (mm *Mattermost) ImageTagWarnings() []string {
+	var warnings []string
+
+	version := mm.Spec.Version
+	if version == "" {
+		version = DefaultMattermostVersion
+	}
+
+	// Check for well-known mutable tags
+	if mutableImageTags[strings.ToLower(version)] {
+		warnings = append(warnings, fmt.Sprintf(
+			"image version %q is a mutable tag; consider using a digest reference (image@sha256:...) for reproducible deployments",
+			version,
+		))
+	}
+
+	return warnings
 }
 
 // GetProductionDeploymentName returns the name of the deployment that is

--- a/apis/mattermost/v1beta1/mattermost_utils_test.go
+++ b/apis/mattermost/v1beta1/mattermost_utils_test.go
@@ -6,6 +6,7 @@ import (
 	pkgUtils "github.com/mattermost/mattermost-operator/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestMattermost_SetDefaults(t *testing.T) {
@@ -63,6 +64,121 @@ func TestMattermost_SetDefaults(t *testing.T) {
 		})
 	})
 
+}
+
+func TestValidateVolumes(t *testing.T) {
+	baseSpec := func() MattermostSpec {
+		return MattermostSpec{
+			Ingress: &Ingress{Enabled: false},
+		}
+	}
+
+	t.Run("allow safe volume types", func(t *testing.T) {
+		mm := &Mattermost{Spec: baseSpec()}
+		mm.Spec.Volumes = []v1.Volume{
+			{Name: "config", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-config"}}}},
+			{Name: "secret", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "my-secret"}}},
+			{Name: "tmp", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+			{Name: "data", VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}}},
+		}
+		err := mm.SetDefaults()
+		require.NoError(t, err)
+	})
+
+	t.Run("reject HostPath volume", func(t *testing.T) {
+		mm := &Mattermost{Spec: baseSpec()}
+		mm.Spec.Volumes = []v1.Volume{
+			{Name: "host-mount", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/etc"}}},
+		}
+		err := mm.SetDefaults()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HostPath")
+		assert.Contains(t, err.Error(), "host-mount")
+	})
+
+	t.Run("reject HostPath mixed with safe volumes", func(t *testing.T) {
+		mm := &Mattermost{Spec: baseSpec()}
+		mm.Spec.Volumes = []v1.Volume{
+			{Name: "config", VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: "my-config"}}}},
+			{Name: "bad-vol", VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/var/run/docker.sock"}}},
+		}
+		err := mm.SetDefaults()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bad-vol")
+	})
+
+	t.Run("allow empty volumes list", func(t *testing.T) {
+		mm := &Mattermost{Spec: baseSpec()}
+		err := mm.SetDefaults()
+		require.NoError(t, err)
+	})
+}
+
+func TestMattermost_ImageTagWarnings(t *testing.T) {
+	for _, tc := range []struct {
+		description    string
+		version        string
+		expectWarnings bool
+	}{
+		{
+			description:    "no warning for specific version tag",
+			version:        "10.8.1",
+			expectWarnings: false,
+		},
+		{
+			description:    "no warning for digest reference",
+			version:        "sha256:dd15a51ac7dafd213744d1ef23394e7532f71a90f477c969b94600e46da5a0cf",
+			expectWarnings: false,
+		},
+		{
+			description:    "warn for latest tag",
+			version:        "latest",
+			expectWarnings: true,
+		},
+		{
+			description:    "warn for Latest tag (case insensitive)",
+			version:        "Latest",
+			expectWarnings: true,
+		},
+		{
+			description:    "warn for master tag",
+			version:        "master",
+			expectWarnings: true,
+		},
+		{
+			description:    "warn for main tag",
+			version:        "main",
+			expectWarnings: true,
+		},
+		{
+			description:    "warn for nightly tag",
+			version:        "nightly",
+			expectWarnings: true,
+		},
+		{
+			description:    "warn for edge tag",
+			version:        "edge",
+			expectWarnings: true,
+		},
+		{
+			description:    "no warning for empty version (uses default)",
+			version:        "",
+			expectWarnings: false,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			mm := &Mattermost{Spec: MattermostSpec{
+				Version: tc.version,
+			}}
+			warnings := mm.ImageTagWarnings()
+			if tc.expectWarnings {
+				assert.NotEmpty(t, warnings)
+				assert.Contains(t, warnings[0], "mutable tag")
+			} else {
+				assert.Empty(t, warnings)
+			}
+		})
+	}
 }
 
 func TestMattermost_IngressAccessors(t *testing.T) {

--- a/apis/mattermost/v1beta1/mattermost_utils_test.go
+++ b/apis/mattermost/v1beta1/mattermost_utils_test.go
@@ -80,6 +80,9 @@ func TestValidateVolumes(t *testing.T) {
 			{Name: "secret", VolumeSource: v1.VolumeSource{Secret: &v1.SecretVolumeSource{SecretName: "my-secret"}}},
 			{Name: "tmp", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
 			{Name: "data", VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: "my-pvc"}}},
+			{Name: "projected", VolumeSource: v1.VolumeSource{Projected: &v1.ProjectedVolumeSource{Sources: []v1.VolumeProjection{}}}},
+			{Name: "downward", VolumeSource: v1.VolumeSource{DownwardAPI: &v1.DownwardAPIVolumeSource{Items: []v1.DownwardAPIVolumeFile{}}}},
+			{Name: "csi", VolumeSource: v1.VolumeSource{CSI: &v1.CSIVolumeSource{Driver: "test-driver"}}},
 		}
 		err := mm.SetDefaults()
 		require.NoError(t, err)
@@ -92,7 +95,7 @@ func TestValidateVolumes(t *testing.T) {
 		}
 		err := mm.SetDefaults()
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "HostPath")
+		assert.Contains(t, err.Error(), "unsupported")
 		assert.Contains(t, err.Error(), "host-mount")
 	})
 
@@ -105,6 +108,28 @@ func TestValidateVolumes(t *testing.T) {
 		err := mm.SetDefaults()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "bad-vol")
+		assert.Contains(t, err.Error(), "unsupported")
+	})
+
+	t.Run("reject NFS volume", func(t *testing.T) {
+		mm := &Mattermost{Spec: baseSpec()}
+		mm.Spec.Volumes = []v1.Volume{
+			{Name: "nfs-vol", VolumeSource: v1.VolumeSource{NFS: &v1.NFSVolumeSource{Server: "nfs.example.com", Path: "/export"}}},
+		}
+		err := mm.SetDefaults()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nfs-vol")
+		assert.Contains(t, err.Error(), "unsupported")
+	})
+
+	t.Run("reject ISCSI volume", func(t *testing.T) {
+		mm := &Mattermost{Spec: baseSpec()}
+		mm.Spec.Volumes = []v1.Volume{
+			{Name: "iscsi-vol", VolumeSource: v1.VolumeSource{ISCSI: &v1.ISCSIVolumeSource{TargetPortal: "10.0.0.1", IQN: "iqn.test", Lun: 0}}},
+		}
+		err := mm.SetDefaults()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "iscsi-vol")
 	})
 
 	t.Run("allow empty volumes list", func(t *testing.T) {

--- a/apis/mattermost/v1beta1/patch_apply.go
+++ b/apis/mattermost/v1beta1/patch_apply.go
@@ -45,6 +45,14 @@ var forbiddenDeploymentPatchContains = []string{
 	"/securityContext/capabilities",
 }
 
+// forbiddenServicePatchPrefixes defines path prefixes that are not allowed in
+// JSON patches applied to Services. These paths can alter traffic routing.
+var forbiddenServicePatchPrefixes = []string{
+	"/spec/selector",
+	"/spec/externalIPs",
+	"/spec/externalName",
+}
+
 // patchOperation represents a single JSON Patch operation for validation purposes.
 type patchOperation struct {
 	Op   string `json:"op"`
@@ -70,6 +78,24 @@ func validateDeploymentPatch(rawPatch string) error {
 			}
 		}
 	}
+	return nil
+}
+
+// validateServicePatch checks that no patch operations target forbidden paths.
+func validateServicePatch(rawPatch string) error {
+	var ops []patchOperation
+	if err := json.Unmarshal([]byte(rawPatch), &ops); err != nil {
+		return errors.Wrap(err, "failed to decode patch operations for validation")
+	}
+
+	for _, op := range ops {
+		for _, prefix := range forbiddenServicePatchPrefixes {
+			if op.Path == prefix || strings.HasPrefix(op.Path, prefix+"/") {
+				return fmt.Errorf("patch operation %q on forbidden path %q is not allowed", op.Op, op.Path)
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -123,6 +149,10 @@ func (s *MattermostStatus) ClearDeploymentPatchStatus() {
 func (rp *ResourcePatch) ApplyToService(service *v1.Service) (*v1.Service, bool, error) {
 	if rp == nil || rp.Service == nil || rp.Service.Disable || rp.Service.Patch == "" {
 		return service, false, nil
+	}
+
+	if err := validateServicePatch(rp.Service.Patch); err != nil {
+		return nil, false, errors.Wrap(err, "service patch validation failed")
 	}
 
 	patched := v1.Service{}

--- a/apis/mattermost/v1beta1/patch_apply.go
+++ b/apis/mattermost/v1beta1/patch_apply.go
@@ -5,6 +5,9 @@ package v1beta1
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
@@ -13,9 +16,62 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	k8sjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes/scheme"
 )
+
+// forbiddenDeploymentPatchPrefixes defines path prefixes that are not allowed
+// in JSON patches applied to Deployments. These paths can be used to escalate
+// privileges or break security boundaries.
+var forbiddenDeploymentPatchPrefixes = []string{
+	"/spec/template/spec/hostNetwork",
+	"/spec/template/spec/hostPID",
+	"/spec/template/spec/hostIPC",
+	"/spec/template/spec/volumes",
+	"/spec/template/spec/serviceAccountName",
+	"/spec/template/spec/serviceAccount",
+	"/spec/template/spec/nodeSelector",
+	"/spec/template/spec/nodeName",
+	"/spec/template/spec/initContainers",
+}
+
+// forbiddenDeploymentPatchContains defines path segments that are forbidden
+// anywhere in a Deployment patch path. This catches per-container security
+// settings regardless of the container index.
+var forbiddenDeploymentPatchContains = []string{
+	"/securityContext/privileged",
+	"/securityContext/allowPrivilegeEscalation",
+	"/securityContext/runAsUser",
+	"/securityContext/capabilities",
+}
+
+// patchOperation represents a single JSON Patch operation for validation purposes.
+type patchOperation struct {
+	Op   string `json:"op"`
+	Path string `json:"path"`
+}
+
+// validateDeploymentPatch checks that no patch operations target forbidden paths.
+func validateDeploymentPatch(rawPatch string) error {
+	var ops []patchOperation
+	if err := json.Unmarshal([]byte(rawPatch), &ops); err != nil {
+		return errors.Wrap(err, "failed to decode patch operations for validation")
+	}
+
+	for _, op := range ops {
+		for _, prefix := range forbiddenDeploymentPatchPrefixes {
+			if op.Path == prefix || strings.HasPrefix(op.Path, prefix+"/") {
+				return fmt.Errorf("patch operation %q on forbidden path %q is not allowed", op.Op, op.Path)
+			}
+		}
+		for _, segment := range forbiddenDeploymentPatchContains {
+			if strings.Contains(op.Path, segment) {
+				return fmt.Errorf("patch operation %q on forbidden path %q is not allowed", op.Op, op.Path)
+			}
+		}
+	}
+	return nil
+}
 
 var decoder runtime.Decoder
 var encoder runtime.Encoder
@@ -28,6 +84,10 @@ func (rp *ResourcePatch) IsEmpty() bool {
 func (rp *ResourcePatch) ApplyToDeployment(deployment *appsv1.Deployment) (*appsv1.Deployment, bool, error) {
 	if rp == nil || rp.Deployment == nil || rp.Deployment.Disable || rp.Deployment.Patch == "" {
 		return deployment, false, nil
+	}
+
+	if err := validateDeploymentPatch(rp.Deployment.Patch); err != nil {
+		return nil, false, errors.Wrap(err, "deployment patch validation failed")
 	}
 
 	patched := appsv1.Deployment{}
@@ -207,7 +267,7 @@ func defaultEncoder() (runtime.Encoder, error) {
 		return nil, err
 	}
 
-	jsonSerializer := json.NewSerializerWithOptions(json.DefaultMetaFactory, resourceScheme, resourceScheme, json.SerializerOptions{})
+	jsonSerializer := k8sjson.NewSerializerWithOptions(k8sjson.DefaultMetaFactory, resourceScheme, resourceScheme, k8sjson.SerializerOptions{})
 
 	return jsonSerializer, nil
 }

--- a/apis/mattermost/v1beta1/patch_apply_test.go
+++ b/apis/mattermost/v1beta1/patch_apply_test.go
@@ -516,6 +516,89 @@ func TestValidateDeploymentPatch_ForbiddenPaths(t *testing.T) {
 	}
 }
 
+func TestValidateServicePatch_ForbiddenPaths(t *testing.T) {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"existing": "val"},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "mattermost"},
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: 80},
+			},
+		},
+	}
+
+	forbiddenPatches := []struct {
+		description string
+		patch       string
+	}{
+		{
+			description: "selector",
+			patch:       `[{"op":"replace","path":"/spec/selector","value":{"app":"attacker"}}]`,
+		},
+		{
+			description: "selector subpath",
+			patch:       `[{"op":"add","path":"/spec/selector/app","value":"attacker"}]`,
+		},
+		{
+			description: "externalIPs",
+			patch:       `[{"op":"add","path":"/spec/externalIPs","value":["1.2.3.4"]}]`,
+		},
+		{
+			description: "externalIPs subpath",
+			patch:       `[{"op":"add","path":"/spec/externalIPs/-","value":"1.2.3.4"}]`,
+		},
+		{
+			description: "externalName",
+			patch:       `[{"op":"replace","path":"/spec/externalName","value":"attacker.example.com"}]`,
+		},
+	}
+
+	for _, tc := range forbiddenPatches {
+		t.Run("should block "+tc.description, func(t *testing.T) {
+			resPatch := ResourcePatch{
+				Service: &Patch{Patch: tc.patch},
+			}
+
+			_, applied, err := resPatch.ApplyToService(service)
+			require.Error(t, err)
+			assert.False(t, applied)
+			assert.Contains(t, err.Error(), "forbidden path")
+		})
+	}
+
+	allowedPatches := []struct {
+		description string
+		patch       string
+	}{
+		{
+			description: "metadata labels",
+			patch:       `[{"op":"add","path":"/metadata/labels/new","value":"value"}]`,
+		},
+		{
+			description: "metadata annotations",
+			patch:       `[{"op":"add","path":"/metadata/annotations","value":{"a":"b"}}]`,
+		},
+		{
+			description: "ports",
+			patch:       `[{"op":"add","path":"/spec/ports/-","value":{"name":"metrics","port":9000}}]`,
+		},
+	}
+
+	for _, tc := range allowedPatches {
+		t.Run("should allow "+tc.description, func(t *testing.T) {
+			resPatch := ResourcePatch{
+				Service: &Patch{Patch: tc.patch},
+			}
+
+			_, applied, err := resPatch.ApplyToService(service)
+			require.NoError(t, err)
+			assert.True(t, applied)
+		})
+	}
+}
+
 func loadFile(t *testing.T, path string) string {
 	b, err := os.ReadFile(path)
 	require.NoError(t, err)

--- a/apis/mattermost/v1beta1/patch_apply_test.go
+++ b/apis/mattermost/v1beta1/patch_apply_test.go
@@ -88,7 +88,7 @@ func TestResourcePatch_ApplyToDeployment(t *testing.T) {
 									Image: "my-image-2",
 								},
 							},
-							ServiceAccountName: "newSA",
+							ServiceAccountName: "initialSA",
 						},
 					},
 				},
@@ -366,6 +366,154 @@ func TestPatch(t *testing.T) {
 		assert.Equal(t, obj1.Spec.Type, obj2.Spec.Type)
 		assert.Equal(t, &obj1, &obj2)
 	})
+}
+
+func TestValidateDeploymentPatch_ForbiddenPaths(t *testing.T) {
+	deploy := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "img"},
+					},
+				},
+			},
+		},
+	}
+
+	forbiddenPatches := []struct {
+		description string
+		patch       string
+	}{
+		{
+			description: "hostNetwork",
+			patch:       `[{"op":"add","path":"/spec/template/spec/hostNetwork","value":true}]`,
+		},
+		{
+			description: "hostPID",
+			patch:       `[{"op":"add","path":"/spec/template/spec/hostPID","value":true}]`,
+		},
+		{
+			description: "hostIPC",
+			patch:       `[{"op":"add","path":"/spec/template/spec/hostIPC","value":true}]`,
+		},
+		{
+			description: "privileged securityContext",
+			patch:       `[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/privileged","value":true}]`,
+		},
+		{
+			description: "allowPrivilegeEscalation",
+			patch:       `[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/allowPrivilegeEscalation","value":true}]`,
+		},
+		{
+			description: "capabilities",
+			patch:       `[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/capabilities","value":{"add":["SYS_ADMIN"]}}]`,
+		},
+		{
+			description: "volumes",
+			patch:       `[{"op":"add","path":"/spec/template/spec/volumes","value":[{"name":"host","hostPath":{"path":"/"}}]}]`,
+		},
+		{
+			description: "volumes subpath",
+			patch:       `[{"op":"add","path":"/spec/template/spec/volumes/0","value":{"name":"host","hostPath":{"path":"/"}}}]`,
+		},
+		{
+			description: "serviceAccountName",
+			patch:       `[{"op":"replace","path":"/spec/template/spec/serviceAccountName","value":"cluster-admin"}]`,
+		},
+		{
+			description: "serviceAccount (legacy)",
+			patch:       `[{"op":"replace","path":"/spec/template/spec/serviceAccount","value":"cluster-admin"}]`,
+		},
+		{
+			description: "nodeSelector",
+			patch:       `[{"op":"add","path":"/spec/template/spec/nodeSelector","value":{"target":"master"}}]`,
+		},
+		{
+			description: "nodeName",
+			patch:       `[{"op":"add","path":"/spec/template/spec/nodeName","value":"master-0"}]`,
+		},
+		{
+			description: "initContainers",
+			patch:       `[{"op":"add","path":"/spec/template/spec/initContainers","value":[{"name":"evil","image":"evil"}]}]`,
+		},
+		{
+			description: "runAsUser in securityContext",
+			patch:       `[{"op":"add","path":"/spec/template/spec/containers/0/securityContext/runAsUser","value":0}]`,
+		},
+	}
+
+	for _, tc := range forbiddenPatches {
+		t.Run("should block "+tc.description, func(t *testing.T) {
+			resPatch := ResourcePatch{
+				Deployment: &Patch{Patch: tc.patch},
+			}
+			_, applied, err := resPatch.ApplyToDeployment(deploy)
+			require.Error(t, err)
+			assert.False(t, applied)
+			assert.Contains(t, err.Error(), "forbidden path")
+		})
+	}
+
+	deployWithLabels := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{"existing": "val"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: int32Ptr(1),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "app", Image: "img"},
+					},
+				},
+			},
+		},
+	}
+
+	allowedPatches := []struct {
+		description string
+		patch       string
+		deploy      *appsv1.Deployment
+	}{
+		{
+			description: "labels",
+			patch:       `[{"op":"add","path":"/metadata/labels/foo","value":"bar"}]`,
+			deploy:      deployWithLabels,
+		},
+		{
+			description: "annotations",
+			patch:       `[{"op":"add","path":"/metadata/annotations","value":{"key":"val"}}]`,
+			deploy:      deploy,
+		},
+		{
+			description: "container image",
+			patch:       `[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"new-img"}]`,
+			deploy:      deploy,
+		},
+		{
+			description: "container env",
+			patch:       `[{"op":"add","path":"/spec/template/spec/containers/0/env","value":[{"name":"FOO","value":"bar"}]}]`,
+			deploy:      deploy,
+		},
+		{
+			description: "replicas",
+			patch:       `[{"op":"replace","path":"/spec/replicas","value":3}]`,
+			deploy:      deploy,
+		},
+	}
+
+	for _, tc := range allowedPatches {
+		t.Run("should allow "+tc.description, func(t *testing.T) {
+			resPatch := ResourcePatch{
+				Deployment: &Patch{Patch: tc.patch},
+			}
+			_, applied, err := resPatch.ApplyToDeployment(tc.deploy)
+			require.NoError(t, err)
+			assert.True(t, applied)
+		})
+	}
 }
 
 func loadFile(t *testing.T, path string) string {

--- a/apis/mattermost/v1beta1/testdata/deploy_patch.json
+++ b/apis/mattermost/v1beta1/testdata/deploy_patch.json
@@ -1,7 +1,6 @@
 [
     {"op":"add","path":"/metadata/labels/addedKey","value":"newVal"},
     {"op":"remove","path":"/metadata/labels/oldKey"},
-    {"op":"replace","path":"/spec/template/spec/serviceAccountName","value":"newSA"},
     {"op":"replace","path":"/spec/template/metadata/labels/podKey1","value":"podModifiedVal"},
     {
         "op":"replace",

--- a/controllers/mattermost/mattermost/controller.go
+++ b/controllers/mattermost/mattermost/controller.go
@@ -136,6 +136,11 @@ func (r *MattermostReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 		return reconcile.Result{}, err
 	}
 
+	// Log warnings for mutable image tags (e.g. "latest")
+	for _, w := range mattermost.ImageTagWarnings() {
+		reqLogger.Info(fmt.Sprintf("WARNING: %s", w))
+	}
+
 	softError := mattermost.SetReplicasAndResourcesFromSize()
 	if softError != nil {
 		reqLogger.Error(softError, "Error setting replicas and resources from size. Using default values")

--- a/controllers/mattermost/mattermost/mattermost.go
+++ b/controllers/mattermost/mattermost/mattermost.go
@@ -188,10 +188,10 @@ func (r *MattermostReconciler) checkMattermostRoleBinding(mattermost *mmv1beta.M
 }
 
 func (r *MattermostReconciler) checkMattermostIngress(mattermost *mmv1beta.Mattermost, reqLogger logr.Logger) error {
-	desired := mattermostApp.GenerateIngressV1Beta(mattermost)
+	desired := mattermostApp.GenerateIngressV1Beta(mattermost, reqLogger)
 
 	if mattermost.AWSLoadBalancerEnabled() {
-		desired = mattermostApp.GenerateALBIngressV1Beta(mattermost)
+		desired = mattermostApp.GenerateALBIngressV1Beta(mattermost, reqLogger)
 	}
 
 	if !mattermost.IngressEnabled() && !mattermost.AWSLoadBalancerEnabled() {
@@ -323,7 +323,6 @@ func (r *MattermostReconciler) checkMattermostDeployment(
 	if err != nil {
 		reqLogger.Error(err, "Failed to patch deployment")
 		status.SetDeploymentPatchStatus(false, errors.Wrap(err, "failed to apply patch to Deployment"))
-		fmt.Println(mattermost.Status.ResourcePatch)
 	} else if applied {
 		reqLogger.Info("Applied patch to deployment")
 		desired = patchedObj

--- a/controllers/mattermost/mattermost/mattermost_test.go
+++ b/controllers/mattermost/mattermost/mattermost_test.go
@@ -1321,6 +1321,13 @@ const (
 		"value": {"name": "calls", "port": 8443, "protocol": "UDP"}
 	}
 ]`
+	forbiddenServicePatch = `[
+	{
+		"op":"replace",
+		"path":"/spec/selector",
+		"value":{"app":"attacker"}
+	}
+]`
 )
 
 func Test_Patches(t *testing.T) {
@@ -1463,6 +1470,22 @@ func Test_Patches(t *testing.T) {
 					assert.Equal(t, 2, len(svc.Spec.Ports))
 
 					assert.NotEmpty(t, mmStatus.ResourcePatch.ServicePatch.Error)
+					assert.False(t, mmStatus.ResourcePatch.ServicePatch.Applied)
+				},
+			},
+			{
+				description: "continue without patch on forbidden path",
+				patch: &mmv1beta.ResourcePatch{
+					Service: &mmv1beta.Patch{
+						Patch: forbiddenServicePatch,
+					},
+				},
+				assertFn: func(t *testing.T, svc *corev1.Service, mmStatus mmv1beta.MattermostStatus) {
+					assert.Equal(t, 2, len(svc.Spec.Ports))
+
+					require.NotNil(t, mmStatus.ResourcePatch)
+					require.NotNil(t, mmStatus.ResourcePatch.ServicePatch)
+					assert.Contains(t, mmStatus.ResourcePatch.ServicePatch.Error, "forbidden path")
 					assert.False(t, mmStatus.ResourcePatch.ServicePatch.Applied)
 				},
 			},

--- a/pkg/mattermost/database_external.go
+++ b/pkg/mattermost/database_external.go
@@ -2,6 +2,10 @@ package mattermost
 
 import (
 	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/mattermost/mattermost-operator/pkg/database"
@@ -40,7 +44,10 @@ func NewExternalDBConfig(mattermost *mmv1beta.Mattermost, secret corev1.Secret) 
 	if _, ok := secret.Data["MM_SQLSETTINGS_DATASOURCEREPLICAS"]; ok {
 		externalDB.hasReaderEndpoints = true
 	}
-	if _, ok := secret.Data["DB_CONNECTION_CHECK_URL"]; ok {
+	if checkURL, ok := secret.Data["DB_CONNECTION_CHECK_URL"]; ok {
+		if err := validateDBCheckURL(string(checkURL)); err != nil {
+			return nil, fmt.Errorf("invalid DB_CONNECTION_CHECK_URL: %w", err)
+		}
 		externalDB.hasDBCheckURL = true
 	}
 	if _, ok := secret.Data["MM_SQLSETTINGS_DATASOURCE"]; ok {
@@ -115,7 +122,7 @@ func getDBCheckInitContainer(secretName, dbType string) *corev1.Container {
 			Env:             envVars,
 			Command: []string{
 				"sh", "-c",
-				"until curl --max-time 5 $DB_CONNECTION_CHECK_URL; do echo waiting for database; sleep 5; done;",
+				`until curl --max-time 5 "$DB_CONNECTION_CHECK_URL"; do echo waiting for database; sleep 5; done;`,
 			},
 		}
 	case database.PostgreSQLDatabase:
@@ -126,8 +133,65 @@ func getDBCheckInitContainer(secretName, dbType string) *corev1.Container {
 			Env:             envVars,
 			Command: []string{
 				"sh", "-c",
-				"until pg_isready --dbname=\"$DB_CONNECTION_CHECK_URL\"; do echo waiting for database; sleep 5; done;",
+				`until pg_isready --dbname="$DB_CONNECTION_CHECK_URL"; do echo waiting for database; sleep 5; done;`,
 			},
+		}
+	}
+
+	return nil
+}
+
+// allowedDBCheckSchemes defines the URL schemes permitted for database connection check URLs.
+var allowedDBCheckSchemes = map[string]bool{
+	"http":     true,
+	"https":    true,
+	"mysql":    true,
+	"postgres": true,
+}
+
+// metadataIPBlocks contains IP ranges commonly used for cloud metadata services.
+var metadataIPBlocks []*net.IPNet
+
+func init() {
+	for _, cidr := range []string{
+		"169.254.169.254/32", // AWS, GCP, Azure metadata
+		"100.100.100.200/32", // Alibaba metadata
+		"fd00:ec2::254/128",  // AWS IPv6 metadata
+	} {
+		_, block, _ := net.ParseCIDR(cidr)
+		metadataIPBlocks = append(metadataIPBlocks, block)
+	}
+}
+
+// validateDBCheckURL validates that a DB connection check URL uses an allowed
+// scheme and does not target cloud metadata endpoints.
+func validateDBCheckURL(rawURL string) error {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return errors.New("URL is empty")
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if !allowedDBCheckSchemes[scheme] {
+		return fmt.Errorf("scheme %q is not allowed; permitted schemes: http, https, mysql, postgres", scheme)
+	}
+
+	hostname := parsed.Hostname()
+	if hostname == "" {
+		return errors.New("URL must contain a hostname")
+	}
+
+	// Check if the hostname resolves to a metadata IP.
+	if ip := net.ParseIP(hostname); ip != nil {
+		for _, block := range metadataIPBlocks {
+			if block.Contains(ip) {
+				return fmt.Errorf("URL targets a blocked metadata IP range: %s", hostname)
+			}
 		}
 	}
 

--- a/pkg/mattermost/database_external.go
+++ b/pkg/mattermost/database_external.go
@@ -197,7 +197,7 @@ func validateDBCheckURL(rawURL, dbType string) error {
 		return errors.New("URL must contain a hostname")
 	}
 
-	ips, err := resolveHostnameIPs(hostname)
+	ips, err := hostnameResolver(hostname)
 	if err != nil {
 		return fmt.Errorf("failed to resolve hostname %q: %w", hostname, err)
 	}
@@ -212,9 +212,14 @@ func validateDBCheckURL(rawURL, dbType string) error {
 	return nil
 }
 
-// resolveHostnameIPs returns IPs for a hostname. If hostname is a literal IP,
+// hostnameResolver is the function used to resolve hostnames to IPs.
+// It defaults to defaultResolveHostnameIPs but can be replaced in tests
+// to avoid real DNS lookups.
+var hostnameResolver = defaultResolveHostnameIPs
+
+// defaultResolveHostnameIPs returns IPs for a hostname. If hostname is a literal IP,
 // returns it; otherwise performs DNS lookup with timeout.
-func resolveHostnameIPs(hostname string) ([]net.IP, error) {
+func defaultResolveHostnameIPs(hostname string) ([]net.IP, error) {
 	if ip := net.ParseIP(hostname); ip != nil {
 		return []net.IP{ip}, nil
 	}

--- a/pkg/mattermost/database_external.go
+++ b/pkg/mattermost/database_external.go
@@ -1,11 +1,13 @@
 package mattermost
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/mattermost/mattermost-operator/pkg/database"
@@ -45,7 +47,7 @@ func NewExternalDBConfig(mattermost *mmv1beta.Mattermost, secret corev1.Secret) 
 		externalDB.hasReaderEndpoints = true
 	}
 	if checkURL, ok := secret.Data["DB_CONNECTION_CHECK_URL"]; ok {
-		if err := validateDBCheckURL(string(checkURL)); err != nil {
+		if err := validateDBCheckURL(string(checkURL), externalDB.dbType); err != nil {
 			return nil, fmt.Errorf("invalid DB_CONNECTION_CHECK_URL: %w", err)
 		}
 		externalDB.hasDBCheckURL = true
@@ -141,12 +143,20 @@ func getDBCheckInitContainer(secretName, dbType string) *corev1.Container {
 	return nil
 }
 
-// allowedDBCheckSchemes defines the URL schemes permitted for database connection check URLs.
-var allowedDBCheckSchemes = map[string]bool{
-	"http":     true,
-	"https":    true,
-	"mysql":    true,
-	"postgres": true,
+// allowedDBCheckSchemesByType defines URL schemes permitted per database type.
+// MySQL uses curl for readiness checks (http/https only); PostgreSQL uses pg_isready (postgres URI).
+var allowedDBCheckSchemesByType = map[string]map[string]bool{
+	database.MySQLDatabase:      {"http": true, "https": true},
+	database.PostgreSQLDatabase: {"http": true, "https": true, "postgres": true},
+	"unknown":                   {"http": true, "https": true, "mysql": true, "postgres": true},
+}
+
+func isAllowedDBCheckScheme(dbType, scheme string) bool {
+	schemes, ok := allowedDBCheckSchemesByType[dbType]
+	if !ok {
+		schemes = allowedDBCheckSchemesByType["unknown"]
+	}
+	return schemes[scheme]
 }
 
 // metadataIPBlocks contains IP ranges commonly used for cloud metadata services.
@@ -164,8 +174,9 @@ func init() {
 }
 
 // validateDBCheckURL validates that a DB connection check URL uses an allowed
-// scheme and does not target cloud metadata endpoints.
-func validateDBCheckURL(rawURL string) error {
+// scheme for the given database type and does not target cloud metadata endpoints.
+// For hostnames, it resolves DNS and blocks any IP in metadata ranges.
+func validateDBCheckURL(rawURL, dbType string) error {
 	rawURL = strings.TrimSpace(rawURL)
 	if rawURL == "" {
 		return errors.New("URL is empty")
@@ -177,8 +188,8 @@ func validateDBCheckURL(rawURL string) error {
 	}
 
 	scheme := strings.ToLower(parsed.Scheme)
-	if !allowedDBCheckSchemes[scheme] {
-		return fmt.Errorf("scheme %q is not allowed; permitted schemes: http, https, mysql, postgres", scheme)
+	if !isAllowedDBCheckScheme(dbType, scheme) {
+		return fmt.Errorf("scheme %q is not allowed for database type %q", scheme, dbType)
 	}
 
 	hostname := parsed.Hostname()
@@ -186,8 +197,11 @@ func validateDBCheckURL(rawURL string) error {
 		return errors.New("URL must contain a hostname")
 	}
 
-	// Check if the hostname resolves to a metadata IP.
-	if ip := net.ParseIP(hostname); ip != nil {
+	ips, err := resolveHostnameIPs(hostname)
+	if err != nil {
+		return fmt.Errorf("failed to resolve hostname %q: %w", hostname, err)
+	}
+	for _, ip := range ips {
 		for _, block := range metadataIPBlocks {
 			if block.Contains(ip) {
 				return fmt.Errorf("URL targets a blocked metadata IP range: %s", hostname)
@@ -196,4 +210,23 @@ func validateDBCheckURL(rawURL string) error {
 	}
 
 	return nil
+}
+
+// resolveHostnameIPs returns IPs for a hostname. If hostname is a literal IP,
+// returns it; otherwise performs DNS lookup with timeout.
+func resolveHostnameIPs(hostname string) ([]net.IP, error) {
+	if ip := net.ParseIP(hostname); ip != nil {
+		return []net.IP{ip}, nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, hostname)
+	if err != nil {
+		return nil, err
+	}
+	ips := make([]net.IP, 0, len(addrs))
+	for _, a := range addrs {
+		ips = append(ips, a.IP)
+	}
+	return ips, nil
 }

--- a/pkg/mattermost/database_external_test.go
+++ b/pkg/mattermost/database_external_test.go
@@ -1,6 +1,7 @@
 package mattermost
 
 import (
+	"net"
 	"strings"
 	"testing"
 
@@ -12,7 +13,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func stubResolver(t *testing.T) {
+	t.Helper()
+
+	original := hostnameResolver
+	hostnameResolver = func(hostname string) ([]net.IP, error) {
+		if ip := net.ParseIP(hostname); ip != nil {
+			return []net.IP{ip}, nil
+		}
+
+		return []net.IP{net.ParseIP("10.0.0.99")}, nil
+	}
+
+	t.Cleanup(func() {
+		hostnameResolver = original
+	})
+}
+
 func TestNewExternalDBInfo(t *testing.T) {
+	stubResolver(t)
+
 	mattermost := &mmv1beta.Mattermost{
 		ObjectMeta: metav1.ObjectMeta{Name: "mm-test"},
 		Spec: mmv1beta.MattermostSpec{
@@ -86,6 +106,8 @@ func TestNewExternalDBInfo(t *testing.T) {
 }
 
 func TestExternalDBConfig_SeparateDatasourceKey(t *testing.T) {
+	stubResolver(t)
+
 	mattermost := &mmv1beta.Mattermost{
 		ObjectMeta: metav1.ObjectMeta{Name: "mm-test"},
 		Spec: mmv1beta.MattermostSpec{
@@ -190,6 +212,8 @@ func TestExternalDBConfig_SeparateDatasourceKey(t *testing.T) {
 }
 
 func TestValidateDBCheckURL(t *testing.T) {
+	stubResolver(t)
+
 	t.Run("valid URLs for MySQL", func(t *testing.T) {
 		validURLs := []string{
 			"http://my-db:3306",
@@ -247,6 +271,12 @@ func TestValidateDBCheckURL(t *testing.T) {
 	})
 
 	t.Run("blocked hostname resolving to metadata IP", func(t *testing.T) {
+		original := hostnameResolver
+		hostnameResolver = defaultResolveHostnameIPs
+		t.Cleanup(func() {
+			hostnameResolver = original
+		})
+
 		// 169.254.169.254.nip.io resolves to AWS metadata IP (requires network)
 		err := validateDBCheckURL("http://169.254.169.254.nip.io/metadata", database.MySQLDatabase)
 		require.Error(t, err)
@@ -263,6 +293,8 @@ func TestValidateDBCheckURL(t *testing.T) {
 }
 
 func TestNewExternalDBConfig_InvalidCheckURL(t *testing.T) {
+	stubResolver(t)
+
 	mattermost := &mmv1beta.Mattermost{
 		ObjectMeta: metav1.ObjectMeta{Name: "mm-test"},
 		Spec: mmv1beta.MattermostSpec{

--- a/pkg/mattermost/database_external_test.go
+++ b/pkg/mattermost/database_external_test.go
@@ -1,9 +1,11 @@
 package mattermost
 
 import (
+	"strings"
 	"testing"
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
+	"github.com/mattermost/mattermost-operator/pkg/database"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -188,17 +190,34 @@ func TestExternalDBConfig_SeparateDatasourceKey(t *testing.T) {
 }
 
 func TestValidateDBCheckURL(t *testing.T) {
-	t.Run("valid URLs", func(t *testing.T) {
+	t.Run("valid URLs for MySQL", func(t *testing.T) {
 		validURLs := []string{
 			"http://my-db:3306",
 			"https://my-db:3306",
-			"mysql://my-db:3306/mydb",
-			"postgres://my-db:5432/mydb",
 			"http://10.0.0.1:3306",
 		}
 		for _, u := range validURLs {
-			assert.NoError(t, validateDBCheckURL(u), "expected valid: %s", u)
+			assert.NoError(t, validateDBCheckURL(u, database.MySQLDatabase), "expected valid: %s", u)
 		}
+	})
+
+	t.Run("valid URLs for PostgreSQL", func(t *testing.T) {
+		validURLs := []string{
+			"http://my-db:5432",
+			"https://my-db:5432",
+			"postgres://my-db:5432/mydb",
+			"http://10.0.0.1:5432",
+		}
+		for _, u := range validURLs {
+			assert.NoError(t, validateDBCheckURL(u, database.PostgreSQLDatabase), "expected valid: %s", u)
+		}
+	})
+
+	t.Run("MySQL rejects mysql scheme", func(t *testing.T) {
+		err := validateDBCheckURL("mysql://my-db:3306/mydb", database.MySQLDatabase)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not allowed")
+		assert.Contains(t, err.Error(), "mysql")
 	})
 
 	t.Run("blocked schemes", func(t *testing.T) {
@@ -209,7 +228,7 @@ func TestValidateDBCheckURL(t *testing.T) {
 			"javascript:alert(1)",
 		}
 		for _, u := range blockedURLs {
-			err := validateDBCheckURL(u)
+			err := validateDBCheckURL(u, database.MySQLDatabase)
 			assert.Error(t, err, "expected blocked: %s", u)
 			assert.Contains(t, err.Error(), "not allowed")
 		}
@@ -221,15 +240,25 @@ func TestValidateDBCheckURL(t *testing.T) {
 			"http://100.100.100.200/metadata",
 		}
 		for _, u := range metadataURLs {
-			err := validateDBCheckURL(u)
+			err := validateDBCheckURL(u, database.MySQLDatabase)
 			assert.Error(t, err, "expected blocked: %s", u)
 			assert.Contains(t, err.Error(), "blocked metadata")
 		}
 	})
 
+	t.Run("blocked hostname resolving to metadata IP", func(t *testing.T) {
+		// 169.254.169.254.nip.io resolves to AWS metadata IP (requires network)
+		err := validateDBCheckURL("http://169.254.169.254.nip.io/metadata", database.MySQLDatabase)
+		require.Error(t, err)
+		if strings.Contains(err.Error(), "failed to resolve") {
+			t.Skip("DNS unavailable in test environment; skipping hostname resolution test")
+		}
+		assert.Contains(t, err.Error(), "blocked metadata")
+	})
+
 	t.Run("empty and invalid", func(t *testing.T) {
-		assert.Error(t, validateDBCheckURL(""))
-		assert.Error(t, validateDBCheckURL("://no-scheme"))
+		assert.Error(t, validateDBCheckURL("", database.MySQLDatabase))
+		assert.Error(t, validateDBCheckURL("://no-scheme", database.MySQLDatabase))
 	})
 }
 
@@ -267,6 +296,20 @@ func TestNewExternalDBConfig_InvalidCheckURL(t *testing.T) {
 		_, err := NewExternalDBConfig(mattermost, secret)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid DB_CONNECTION_CHECK_URL")
+	})
+
+	t.Run("rejects mysql scheme for MySQL db type", func(t *testing.T) {
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+			Data: map[string][]byte{
+				"DB_CONNECTION_STRING":    []byte("mysql://user:pass@tcp(host:3306)/db"),
+				"DB_CONNECTION_CHECK_URL": []byte("mysql://host:3306/db"),
+			},
+		}
+		_, err := NewExternalDBConfig(mattermost, secret)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid DB_CONNECTION_CHECK_URL")
+		assert.Contains(t, err.Error(), "not allowed")
 	})
 }
 

--- a/pkg/mattermost/database_external_test.go
+++ b/pkg/mattermost/database_external_test.go
@@ -187,6 +187,104 @@ func TestExternalDBConfig_SeparateDatasourceKey(t *testing.T) {
 	})
 }
 
+func TestValidateDBCheckURL(t *testing.T) {
+	t.Run("valid URLs", func(t *testing.T) {
+		validURLs := []string{
+			"http://my-db:3306",
+			"https://my-db:3306",
+			"mysql://my-db:3306/mydb",
+			"postgres://my-db:5432/mydb",
+			"http://10.0.0.1:3306",
+		}
+		for _, u := range validURLs {
+			assert.NoError(t, validateDBCheckURL(u), "expected valid: %s", u)
+		}
+	})
+
+	t.Run("blocked schemes", func(t *testing.T) {
+		blockedURLs := []string{
+			"file:///etc/passwd",
+			"gopher://evil.com",
+			"ftp://my-db:21/file",
+			"javascript:alert(1)",
+		}
+		for _, u := range blockedURLs {
+			err := validateDBCheckURL(u)
+			assert.Error(t, err, "expected blocked: %s", u)
+			assert.Contains(t, err.Error(), "not allowed")
+		}
+	})
+
+	t.Run("blocked metadata IPs", func(t *testing.T) {
+		metadataURLs := []string{
+			"http://169.254.169.254/latest/meta-data",
+			"http://100.100.100.200/metadata",
+		}
+		for _, u := range metadataURLs {
+			err := validateDBCheckURL(u)
+			assert.Error(t, err, "expected blocked: %s", u)
+			assert.Contains(t, err.Error(), "blocked metadata")
+		}
+	})
+
+	t.Run("empty and invalid", func(t *testing.T) {
+		assert.Error(t, validateDBCheckURL(""))
+		assert.Error(t, validateDBCheckURL("://no-scheme"))
+	})
+}
+
+func TestNewExternalDBConfig_InvalidCheckURL(t *testing.T) {
+	mattermost := &mmv1beta.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{Name: "mm-test"},
+		Spec: mmv1beta.MattermostSpec{
+			Database: mmv1beta.Database{
+				External: &mmv1beta.ExternalDatabase{Secret: "secret"},
+			},
+		},
+	}
+
+	t.Run("rejects metadata URL", func(t *testing.T) {
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+			Data: map[string][]byte{
+				"DB_CONNECTION_STRING":    []byte("postgres://my-postgres"),
+				"DB_CONNECTION_CHECK_URL": []byte("http://169.254.169.254/latest/meta-data"),
+			},
+		}
+		_, err := NewExternalDBConfig(mattermost, secret)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid DB_CONNECTION_CHECK_URL")
+	})
+
+	t.Run("rejects disallowed scheme", func(t *testing.T) {
+		secret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "secret"},
+			Data: map[string][]byte{
+				"DB_CONNECTION_STRING":    []byte("postgres://my-postgres"),
+				"DB_CONNECTION_CHECK_URL": []byte("file:///etc/passwd"),
+			},
+		}
+		_, err := NewExternalDBConfig(mattermost, secret)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid DB_CONNECTION_CHECK_URL")
+	})
+}
+
+func TestGetDBCheckInitContainer_QuotedURL(t *testing.T) {
+	t.Run("mysql container quotes URL variable", func(t *testing.T) {
+		container := getDBCheckInitContainer("secret", "mysql")
+		require.NotNil(t, container)
+		// Verify the command uses double-quoted variable to prevent shell injection
+		assert.Contains(t, container.Command[2], `"$DB_CONNECTION_CHECK_URL"`)
+	})
+
+	t.Run("postgres container quotes URL variable", func(t *testing.T) {
+		container := getDBCheckInitContainer("secret", "postgres")
+		require.NotNil(t, container)
+		assert.Contains(t, container.Command[2], `"$DB_CONNECTION_CHECK_URL"`)
+	})
+}
+
 // Helper function to find an environment variable by name
 func findEnvVar(envs []corev1.EnvVar, name string) *corev1.EnvVar {
 	for i := range envs {

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-logr/logr"
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	pkgUtils "github.com/mattermost/mattermost-operator/pkg/utils"
 
@@ -26,7 +27,8 @@ const (
 
 // sanitizeIngressAnnotations filters out annotations that could allow arbitrary
 // nginx/ingress controller config injection via snippet directives.
-func sanitizeIngressAnnotations(annotations map[string]string) map[string]string {
+// Dropped keys are logged via logger when provided.
+func sanitizeIngressAnnotations(annotations map[string]string, logger logr.Logger) map[string]string {
 	if annotations == nil {
 		return nil
 	}
@@ -34,9 +36,11 @@ func sanitizeIngressAnnotations(annotations map[string]string) map[string]string
 	for k, v := range annotations {
 		lower := strings.ToLower(k)
 		if strings.Contains(lower, "snippet") {
+			logger.Info("dropped unsafe ingress annotation", "key", k, "reason", "contains snippet")
 			continue
 		}
 		if strings.ContainsAny(v, "\r\n") {
+			logger.Info("dropped unsafe ingress annotation", "key", k, "reason", "value contains newline")
 			continue
 		}
 		safe[k] = v
@@ -134,7 +138,7 @@ func configureMattermostServicePorts(service *corev1.Service) *corev1.Service {
 }
 
 // GenerateIngressV1Beta returns the ingress for the Mattermost app.
-func GenerateIngressV1Beta(mattermost *mmv1beta.Mattermost) *networkingv1.Ingress {
+func GenerateIngressV1Beta(mattermost *mmv1beta.Mattermost, logger logr.Logger) *networkingv1.Ingress {
 	ingressAnnotations := map[string]string{
 		"nginx.ingress.kubernetes.io/proxy-body-size": "1000M",
 	}
@@ -149,7 +153,7 @@ func GenerateIngressV1Beta(mattermost *mmv1beta.Mattermost) *networkingv1.Ingres
 		ingressAnnotations[ingressClassAnnotation] = "nginx"
 	}
 
-	for k, v := range sanitizeIngressAnnotations(mattermost.GetIngresAnnotations()) {
+	for k, v := range sanitizeIngressAnnotations(mattermost.GetIngresAnnotations(), logger) {
 		ingressAnnotations[k] = v
 	}
 
@@ -200,7 +204,7 @@ func GenerateALBIngressClassV1Beta(mattermost *mmv1beta.Mattermost) *networkingv
 }
 
 // GenerateIngressALBIngressV1Beta returns the AWS ALB ingress for the Mattermost app.
-func GenerateALBIngressV1Beta(mattermost *mmv1beta.Mattermost) *networkingv1.Ingress {
+func GenerateALBIngressV1Beta(mattermost *mmv1beta.Mattermost, logger logr.Logger) *networkingv1.Ingress {
 	ingressAnnotations := map[string]string{}
 
 	if mattermost.Spec.AWSLoadBalancerController.InternetFacing {
@@ -217,7 +221,7 @@ func GenerateALBIngressV1Beta(mattermost *mmv1beta.Mattermost) *networkingv1.Ing
 		ingressAnnotations["alb.ingress.kubernetes.io/listen-ports"] = `[{"HTTP": 8065}]`
 	}
 
-	for k, v := range sanitizeIngressAnnotations(mattermost.GetAWSLoadBalancerIngressAnnotations()) {
+	for k, v := range sanitizeIngressAnnotations(mattermost.GetAWSLoadBalancerIngressAnnotations(), logger) {
 		ingressAnnotations[k] = v
 	}
 

--- a/pkg/mattermost/mattermost_v1beta.go
+++ b/pkg/mattermost/mattermost_v1beta.go
@@ -3,6 +3,7 @@ package mattermost
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	pkgUtils "github.com/mattermost/mattermost-operator/pkg/utils"
@@ -22,6 +23,26 @@ import (
 const (
 	ingressClassAnnotation = "kubernetes.io/ingress.class"
 )
+
+// sanitizeIngressAnnotations filters out annotations that could allow arbitrary
+// nginx/ingress controller config injection via snippet directives.
+func sanitizeIngressAnnotations(annotations map[string]string) map[string]string {
+	if annotations == nil {
+		return nil
+	}
+	safe := make(map[string]string, len(annotations))
+	for k, v := range annotations {
+		lower := strings.ToLower(k)
+		if strings.Contains(lower, "snippet") {
+			continue
+		}
+		if strings.ContainsAny(v, "\r\n") {
+			continue
+		}
+		safe[k] = v
+	}
+	return safe
+}
 
 type DatabaseConfig interface {
 	EnvVars(mattermost *mmv1beta.Mattermost) []corev1.EnvVar
@@ -128,7 +149,7 @@ func GenerateIngressV1Beta(mattermost *mmv1beta.Mattermost) *networkingv1.Ingres
 		ingressAnnotations[ingressClassAnnotation] = "nginx"
 	}
 
-	for k, v := range mattermost.GetIngresAnnotations() {
+	for k, v := range sanitizeIngressAnnotations(mattermost.GetIngresAnnotations()) {
 		ingressAnnotations[k] = v
 	}
 
@@ -196,7 +217,7 @@ func GenerateALBIngressV1Beta(mattermost *mmv1beta.Mattermost) *networkingv1.Ing
 		ingressAnnotations["alb.ingress.kubernetes.io/listen-ports"] = `[{"HTTP": 8065}]`
 	}
 
-	for k, v := range mattermost.GetAWSLoadBalancerIngressAnnotations() {
+	for k, v := range sanitizeIngressAnnotations(mattermost.GetAWSLoadBalancerIngressAnnotations()) {
 		ingressAnnotations[k] = v
 	}
 

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-logr/logr"
 	mmv1beta "github.com/mattermost/mattermost-operator/apis/mattermost/v1beta1"
 	"github.com/mattermost/mattermost-operator/pkg/database"
 	"github.com/mattermost/mattermost-operator/pkg/utils"
@@ -335,7 +336,7 @@ func TestGenerateIngress_V1Beta(t *testing.T) {
 				Spec:       tt.spec,
 			}
 
-			ingress := GenerateIngressV1Beta(mattermost)
+			ingress := GenerateIngressV1Beta(mattermost, logr.Discard())
 			require.NotNil(t, ingress)
 			assert.Equal(t, tt.expectedIngress, ingress)
 			assert.Equal(t, networkingv1.PathTypeImplementationSpecific, *ingress.Spec.Rules[0].HTTP.Paths[0].PathType)
@@ -1233,7 +1234,7 @@ func TestSanitizeIngressAnnotations(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := sanitizeIngressAnnotations(tt.input)
+			result := sanitizeIngressAnnotations(tt.input, logr.Discard())
 			assert.Equal(t, tt.expected, result)
 		})
 	}
@@ -1255,7 +1256,31 @@ func TestGenerateIngress_V1Beta_SnippetAnnotationsFiltered(t *testing.T) {
 		},
 	}
 
-	ingress := GenerateIngressV1Beta(mattermost)
+	ingress := GenerateIngressV1Beta(mattermost, logr.Discard())
+	require.NotNil(t, ingress)
+
+	assert.Equal(t, "500M", ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"])
+	assert.NotContains(t, ingress.Annotations, "nginx.ingress.kubernetes.io/configuration-snippet")
+	assert.NotContains(t, ingress.Annotations, "nginx.ingress.kubernetes.io/server-snippet")
+}
+
+func TestGenerateALBIngress_V1Beta_SnippetAnnotationsFiltered(t *testing.T) {
+	mattermost := &mmv1beta.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mm"},
+		Spec: mmv1beta.MattermostSpec{
+			AWSLoadBalancerController: &mmv1beta.AWSLoadBalancerController{
+				Enabled: true,
+				Hosts:   []mmv1beta.IngressHost{{HostName: "test"}},
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/proxy-body-size":       "500M",
+					"nginx.ingress.kubernetes.io/configuration-snippet": "more_set_headers 'X-Injected: true';",
+					"nginx.ingress.kubernetes.io/server-snippet":        "lua_shared_dict my_cache 10m;",
+				},
+			},
+		},
+	}
+
+	ingress := GenerateALBIngressV1Beta(mattermost, logr.Discard())
 	require.NotNil(t, ingress)
 
 	assert.Equal(t, "500M", ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"])

--- a/pkg/mattermost/mattermost_v1beta_test.go
+++ b/pkg/mattermost/mattermost_v1beta_test.go
@@ -1158,3 +1158,107 @@ func assertEnvVarEqual(t *testing.T, name, val string, env []corev1.EnvVar) {
 
 	assert.Fail(t, fmt.Sprintf("failed to find env var %s", name))
 }
+
+func TestSanitizeIngressAnnotations(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "nil annotations",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "safe annotations pass through",
+			input:    map[string]string{"nginx.ingress.kubernetes.io/proxy-body-size": "1000M", "custom-annotation": "value"},
+			expected: map[string]string{"nginx.ingress.kubernetes.io/proxy-body-size": "1000M", "custom-annotation": "value"},
+		},
+		{
+			name:     "server-snippet blocked",
+			input:    map[string]string{"nginx.ingress.kubernetes.io/server-snippet": "lua_code_here"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "configuration-snippet blocked",
+			input:    map[string]string{"nginx.ingress.kubernetes.io/configuration-snippet": "more_set_headers"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "auth-snippet blocked",
+			input:    map[string]string{"nginx.ingress.kubernetes.io/auth-snippet": "proxy_set_header"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "stream-snippet blocked",
+			input:    map[string]string{"nginx.ingress.kubernetes.io/stream-snippet": "content"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "case insensitive snippet detection",
+			input:    map[string]string{"nginx.ingress.kubernetes.io/Server-Snippet": "content"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "custom snippet annotation blocked",
+			input:    map[string]string{"example.com/my-snippet": "content"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "newline in value blocked",
+			input:    map[string]string{"safe-key": "line1\nline2"},
+			expected: map[string]string{},
+		},
+		{
+			name:     "carriage return in value blocked",
+			input:    map[string]string{"safe-key": "line1\rline2"},
+			expected: map[string]string{},
+		},
+		{
+			name: "mixed safe and dangerous annotations",
+			input: map[string]string{
+				"nginx.ingress.kubernetes.io/proxy-body-size":         "1000M",
+				"nginx.ingress.kubernetes.io/configuration-snippet":   "dangerous",
+				"nginx.ingress.kubernetes.io/ssl-redirect":            "true",
+				"nginx.ingress.kubernetes.io/server-snippet":          "also-dangerous",
+				"safe-key-with-newline":                               "value\ninjected",
+			},
+			expected: map[string]string{
+				"nginx.ingress.kubernetes.io/proxy-body-size": "1000M",
+				"nginx.ingress.kubernetes.io/ssl-redirect":    "true",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeIngressAnnotations(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateIngress_V1Beta_SnippetAnnotationsFiltered(t *testing.T) {
+	mattermost := &mmv1beta.Mattermost{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-mm"},
+		Spec: mmv1beta.MattermostSpec{
+			Ingress: &mmv1beta.Ingress{
+				Enabled: true,
+				Host:    "test",
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/proxy-body-size":       "500M",
+					"nginx.ingress.kubernetes.io/configuration-snippet": "more_set_headers 'X-Injected: true';",
+					"nginx.ingress.kubernetes.io/server-snippet":        "lua_shared_dict my_cache 10m;",
+				},
+			},
+		},
+	}
+
+	ingress := GenerateIngressV1Beta(mattermost)
+	require.NotNil(t, ingress)
+
+	assert.Equal(t, "500M", ingress.Annotations["nginx.ingress.kubernetes.io/proxy-body-size"])
+	assert.NotContains(t, ingress.Annotations, "nginx.ingress.kubernetes.io/configuration-snippet")
+	assert.NotContains(t, ingress.Annotations, "nginx.ingress.kubernetes.io/server-snippet")
+}


### PR DESCRIPTION
#### Summary

Adds input validation and defensive hardening across several CR processing paths:

- **Init container commands**: Properly quote shell variables in database connection check init containers to handle URLs with special characters correctly
- **URL validation**: Validate external database connection check URLs to ensure they use expected schemes and point to valid hosts
- **Volume validation**: Validate volume sources in Mattermost CR specs, rejecting unsupported volume types (e.g., HostPath) that could cause unexpected behavior
- **Ingress annotation filtering**: Filter ingress annotations to prevent passthrough of controller-specific directives (e.g., snippet annotations) that could interfere with ingress controller configuration
- **Resource patch validation**: Add path-based validation for JSON patch operations on Deployments to prevent modifications to sensitive pod spec fields
- **Image tag warnings**: Log warnings when mutable image tags are used and document digest-pinned image references as the recommended approach

#### Ticket Link

NONE

#### Release Note

```release-note
Added input validation for Mattermost CR fields including volume sources, ingress annotations, resource patches, and external database connection check URLs. Added warnings for mutable image tags.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warnings for deployments using mutable image tags; suggests digest references.
  * Validation to restrict unsafe volume types and sanitize ingress annotations.
  * Validation of deployment and service patch operations and DB connection check URLs.

* **Tests**
  * Expanded tests covering volume validation, image-tag warnings, patch validation, ingress sanitization, and DB URL handling.

* **Chores**
  * Added Dockerfile comments documenting supply-chain safety and digest-pinning guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->