### PR TITLE
ci: use scanner actions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: cd/checkout-repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: cd/setup-buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           version: v0.19.3
 
       - name: cd/docker-login
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -43,25 +43,25 @@ jobs:
     steps:
       - name: cd/checkout-repo
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: cd/setup-buildx
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           version: v0.19.3
 
       - name: cd/setup-chainctl
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: chainguard-dev/setup-chainctl@v0.4.0
+        uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
         with:
           identity: ee399b4c72dd4e58e3d617f78fc47b74733c9557/0439801bd43520ae
 
       - name: cd/docker-login
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
     needs: [build, build-fips]
     steps:
       - name: cd/checkout-repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
         with:
           sarif_file: "grype-results.sarif"
+          category: build-grype-scan
 
       - name: ci/docker-login
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
@@ -184,6 +185,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
         with:
           sarif_file: "grype-results-fips.sarif"
+          category: build-grype-scan-fips
 
       - name: ci/setup-buildx
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,23 @@ jobs:
         with:
           version: v0.19.3
 
+      - name: ci/scan-docker-security
+        id: grype-scan
+        uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c # v7.3.2
+        continue-on-error: true
+        with:
+          image: "mattermost/mattermost-operator:test"
+          output-format: sarif
+          output-file: "grype-results.sarif"
+          only-fixed: true
+          fail-build: false
+          severity-cutoff: high
+
+      - name: ci/upload-grype-sarif-results
+        uses: github/codeql-action/upload-sarif@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
+        with:
+          sarif_file: "grype-results.sarif"
+
       - name: ci/docker-login
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -150,6 +167,25 @@ jobs:
       - name: ci/build-docker-fips
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
         run: make build-image-fips
+
+      - name: ci/scan-docker-security-fips
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
+        id: grype-scan-fips
+        uses: anchore/scan-action@7037fa011853d5a11690026fb85feee79f4c946c # v7.3.2
+        continue-on-error: true
+        with:
+          image: "mattermost/mattermost-operator-fips:test"
+          output-format: sarif
+          output-file: "grype-results-fips.sarif"
+          only-fixed: true
+          fail-build: false
+          severity-cutoff: high
+
+      - name: ci/upload-grype-sarif-results-fips
+        if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
+        uses: github/codeql-action/upload-sarif@c6f931105cb2c34c8f901cc885ba1e2e259cf745 # v4.34.0
+        with:
+          sarif_file: "grype-results-fips.sarif"
 
       - name: ci/setup-buildx
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: ci/setup-go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
           cache: true
@@ -39,13 +39,13 @@ jobs:
     runs-on: ubuntu-latest-8-cores
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           path: src/github.com/mattermost/mattermost-operator
 
       - name: ci/setup-go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: src/github.com/mattermost/mattermost-operator/go.mod
           cache-dependency-path: src/github.com/mattermost/mattermost-operator/go.sum
@@ -94,7 +94,7 @@ jobs:
     needs: [lint, test]
     steps:
       - name: ci/checkout-repo
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -105,9 +105,7 @@ jobs:
         run: make build-image
 
       - name: ci/setup-buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-        with:
-          version: v0.19.3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: ci/scan-docker-security
         id: grype-scan
@@ -128,7 +126,7 @@ jobs:
 
       - name: ci/docker-login
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -150,7 +148,7 @@ jobs:
     steps:
       - name: ci/checkout-repo
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -160,7 +158,7 @@ jobs:
 
       - name: ci/setup-chainctl
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: chainguard-dev/setup-chainctl@v0.4.0
+        uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
         with:
           identity: ee399b4c72dd4e58e3d617f78fc47b74733c9557/0439801bd43520ae
 
@@ -189,13 +187,13 @@ jobs:
 
       - name: ci/setup-buildx
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' }}
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           version: v0.19.3
 
       - name: ci/docker-login
         if: ${{ env.ENABLE_FIPS_BUILDS == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -7,7 +7,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - shell: bash
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}


### PR DESCRIPTION
#### Summary
- Start using scan action: follow up https://github.com/mattermost/mattermost-operator/pull/454

#### Release Note
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD action dependencies to newer pinned releases for improved maintenance and stability.
  * Added automated Docker image vulnerability scanning during builds and SARIF upload to Security events to surface high-severity findings (scans allowed to continue on failure).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->