### PR TITLE
Update golang version to 1.25.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build the mattermost operator
 # NOTE: For production builds, pin these images to digests for supply-chain safety.
-# Example: golang:1.24.13@sha256:<digest>
+# Example: golang:1.25.9@sha256:<digest>
 # See Dockerfile.fips for an example of digest-pinned images.
-ARG BUILD_IMAGE=golang:1.24.13
+ARG BUILD_IMAGE=golang:1.25.9
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM ${BUILD_IMAGE} as builder

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,5 +1,5 @@
 # Build the mattermost operator (FIPS version)
-ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.24.13@sha256:4ddb471a06569e7df7ced9c349ea41dd5aeb393a52bbfe1efb7c6bc88fe7e4ff
+ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.25.9@sha256:ca33f3634a8f23ca6b3eaad280617effce698b23da56499731c75cfc9057bb45
 # TODO: Pin BASE_IMAGE to digest for supply-chain safety (registry requires auth to resolve).
 # Matching BUILD_IMAGE above when digest becomes available.
 ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.1

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -2,7 +2,7 @@
 ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.25.9@sha256:ca33f3634a8f23ca6b3eaad280617effce698b23da56499731c75cfc9057bb45
 # TODO: Pin BASE_IMAGE to digest for supply-chain safety (registry requires auth to resolve).
 # Matching BUILD_IMAGE above when digest becomes available.
-ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.1
+ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.2@sha256:ffcaa014791edcc8635785336fe42eb5cdebacfa88221a2af319fcdf3e82ab6d
 
 FROM ${BUILD_IMAGE} as builder
 
@@ -41,4 +41,4 @@ COPY --from=builder /workspace/build/_output/bin/mattermost-operator .
 
 USER 65532
 
-ENTRYPOINT ["/mattermost-operator"] 
+ENTRYPOINT ["/mattermost-operator"]

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BUILD_IMAGE = golang:$(GOLANG_VERSION)
 BASE_IMAGE = gcr.io/distroless/static:nonroot
 
 ## FIPS Docker Build Versions
-BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.24
+BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.25
 BASE_IMAGE_FIPS = cgr.dev/mattermost.com/glibc-openssl-fips:15.1
 
 ################################################################################

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/mattermost/mattermost-operator
 
-go 1.24.13
-
+go 1.25.9
 
 require (
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -11,7 +11,7 @@ run_ct_container() {
     docker run --rm --interactive --detach --network host --name test-cont \
         --volume "$(pwd):/go/src/github.com/mattermost/mattermost-operator" \
         --workdir "/go/src/github.com/mattermost/mattermost-operator" \
-        "golang:1.24" \
+        "golang:1.25" \
         cat
     echo
 }


### PR DESCRIPTION
## Summary

Bumps Go from 1.24.13 to 1.25.9 across the operator.


#### Release Note
```release-note
Updates Golang to 1.25.9
```

Made with [Cursor](https://cursor.com)