### PR TITLE
Update golang version to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build the mattermost operator
 # NOTE: For production builds, pin these images to digests for supply-chain safety.
-# Example: golang:1.25.9@sha256:<digest>
+# Example: golang:1.26.3@sha256:<digest>
 # See Dockerfile.fips for an example of digest-pinned images.
-ARG BUILD_IMAGE=golang:1.25.9
+ARG BUILD_IMAGE=golang:1.26.3
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM ${BUILD_IMAGE} as builder

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,8 +1,6 @@
 # Build the mattermost operator (FIPS version)
 ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.26.3@sha256:90017f556002f392c7eb21a96bf845e1b0675cb32a43ac8c85c25cbb80e848cc
-# TODO: Pin BASE_IMAGE to digest for supply-chain safety (registry requires auth to resolve).
-# Matching BUILD_IMAGE above when digest becomes available.
-ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.2@sha256:ffcaa014791edcc8635785336fe42eb5cdebacfa88221a2af319fcdf3e82ab6d
+ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:16.1.0@sha256:3ffd0b8b652a95f17764ff4cd3abf5a424651ebae407fb98085e01ff40e5de7c
 
 FROM ${BUILD_IMAGE} as builder
 

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,5 +1,5 @@
 # Build the mattermost operator (FIPS version)
-ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.25.9@sha256:ca33f3634a8f23ca6b3eaad280617effce698b23da56499731c75cfc9057bb45
+ARG BUILD_IMAGE=cgr.dev/mattermost.com/go-msft-fips:1.26.3@sha256:90017f556002f392c7eb21a96bf845e1b0675cb32a43ac8c85c25cbb80e848cc
 # TODO: Pin BASE_IMAGE to digest for supply-chain safety (registry requires auth to resolve).
 # Matching BUILD_IMAGE above when digest becomes available.
 ARG BASE_IMAGE=cgr.dev/mattermost.com/glibc-openssl-fips:15.2@sha256:ffcaa014791edcc8635785336fe42eb5cdebacfa88221a2af319fcdf3e82ab6d

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BUILD_IMAGE = golang:$(GOLANG_VERSION)
 BASE_IMAGE = gcr.io/distroless/static:nonroot
 
 ## FIPS Docker Build Versions
-BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.26
+BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.26.3@sha256:90017f556002f392c7eb21a96bf845e1b0675cb32a43ac8c85c25cbb80e848cc
 BASE_IMAGE_FIPS = cgr.dev/mattermost.com/glibc-openssl-fips:15.1
 
 ################################################################################

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BASE_IMAGE = gcr.io/distroless/static:nonroot
 
 ## FIPS Docker Build Versions
 BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.26.3@sha256:90017f556002f392c7eb21a96bf845e1b0675cb32a43ac8c85c25cbb80e848cc
-BASE_IMAGE_FIPS = cgr.dev/mattermost.com/glibc-openssl-fips:15.1
+BASE_IMAGE_FIPS = cgr.dev/mattermost.com/glibc-openssl-fips:16.1.0@sha256:3ffd0b8b652a95f17764ff4cd3abf5a424651ebae407fb98085e01ff40e5de7c
 
 ################################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BUILD_IMAGE = golang:$(GOLANG_VERSION)
 BASE_IMAGE = gcr.io/distroless/static:nonroot
 
 ## FIPS Docker Build Versions
-BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.25
+BUILD_IMAGE_FIPS = cgr.dev/mattermost.com/go-msft-fips:1.26
 BASE_IMAGE_FIPS = cgr.dev/mattermost.com/glibc-openssl-fips:15.1
 
 ################################################################################

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-operator
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -11,7 +11,7 @@ run_ct_container() {
     docker run --rm --interactive --detach --network host --name test-cont \
         --volume "$(pwd):/go/src/github.com/mattermost/mattermost-operator" \
         --workdir "/go/src/github.com/mattermost/mattermost-operator" \
-        "golang:1.25" \
+        "golang:1.26" \
         cat
     echo
 }


### PR DESCRIPTION
## Summary

Bumps Go from 1.25.9 to 1.26.3 across the operator and updates FIPS image references:

- Go toolchain bumped to `1.26.3`
- FIPS runtime image `cgr.dev/mattermost.com/glibc-openssl-fips` bumped to `16.1.0@sha256:3ffd0b8b...` 

#### Release Note
```release-note
Updates Golang to 1.26.3 and bumps FIPS base image (glibc-openssl-fips) to 16.1.0.
```

Made with [Cursor](https://cursor.com)
