### PR TITLE
ci: cancel superseded workflow runs and bump anchore-scan action

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: security/anchore-scan
         id: anchore-operator
-        uses: mattermost/actions/delivery/anchore-scan@003fac68730de6e3e2dc31939e7f2c460f2a8ba0
+        uses: mattermost/actions/delivery/anchore-scan@354df0f666759a18085c7c7135db533f6b1da367
         with:
           image_name: mattermost/mattermost-operator:${{ github.ref_name }}
           dockerfile_path: ./Dockerfile
@@ -115,7 +115,7 @@ jobs:
 
       - name: security/anchore-scan-fips
         id: anchore-operator-fips
-        uses: mattermost/actions/delivery/anchore-scan@003fac68730de6e3e2dc31939e7f2c460f2a8ba0
+        uses: mattermost/actions/delivery/anchore-scan@354df0f666759a18085c7c7135db533f6b1da367
         with:
           image_name: mattermost/mattermost-operator-fips:${{ github.ref_name }}
           dockerfile_path: ./Dockerfile.fips

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   ENABLE_FIPS_BUILDS: true # Set to false to disable FIPS builds

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - "v**"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ENABLE_FIPS_BUILDS: true # Set to false to disable FIPS builds
 


### PR DESCRIPTION
## Summary

- **`.github/workflows/ci.yml`** — add a top-level `concurrency` block (`group: ${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`). On PR #461 we observed three runs (#433/#434/#435) all in progress for the same branch; with this block, new pushes on a PR branch supersede their in-flight predecessors while pushes to `master` and tag refs remain isolated (each gets its own ref-scoped group).
- **`.github/workflows/cd.yml`** — bump `mattermost/actions/delivery/anchore-scan` from `003fac68730de6e3e2dc31939e7f2c460f2a8ba0` to `354df0f666759a18085c7c7135db533f6b1da367` (current `HEAD` of `mattermost/actions`, "Update anchorectl to match instance version (#56)", 2026-05-20). Both `anchore-operator` and `anchore-operator-fips` steps updated to keep the pinned SHA current.

```release-note
NONE
```

Made with [Cursor](https://cursor.com)
