### PR TITLE
Fix panic in determineMaxBodySize on empty proxy-body-size annotation

### DIFF
--- a/pkg/mattermost/helpers.go
+++ b/pkg/mattermost/helpers.go
@@ -49,7 +49,7 @@ func mergeEnvVars(original, new []corev1.EnvVar) []corev1.EnvVar {
 
 func determineMaxBodySize(ingressAnnotations map[string]string, defaultSize string) string {
 	size, ok := ingressAnnotations["nginx.ingress.kubernetes.io/proxy-body-size"]
-	if !ok {
+	if !ok || size == "" {
 		return defaultSize
 	}
 

--- a/pkg/mattermost/helpers_test.go
+++ b/pkg/mattermost/helpers_test.go
@@ -129,6 +129,13 @@ func TestDetermineMaxBodySize(t *testing.T) {
 			expectedSize: defaultSize,
 		},
 		{
+			description: "use default size (no panic) when annotation is empty",
+			ingressAnnotations: map[string]string{
+				"nginx.ingress.kubernetes.io/proxy-body-size": "",
+			},
+			expectedSize: defaultSize,
+		},
+		{
 			description: "use default size when unit not recognized",
 			ingressAnnotations: map[string]string{
 				"nginx.ingress.kubernetes.io/proxy-body-size": "800K",


### PR DESCRIPTION
`determineMaxBodySize` (pkg/mattermost/helpers.go) reads the `nginx.ingress.kubernetes.io/proxy-body-size` ingress annotation and then indexes `size[len(size)-1]` without handling an empty value. Setting that annotation to `""` panics (`index out of range`) during reconcile.

**Fix:** treat an empty annotation value the same as a missing one and return the default size. Adds a regression test case.

```release-note
Fixed a panic in the Mattermost Operator during reconcile when the `nginx.ingress.kubernetes.io/proxy-body-size` ingress annotation is set to an empty value.
```
